### PR TITLE
Batch 8 audit bundle: 11 plans (upload hardening, schema guard, import batching, iOS picker + inbox tests, konsist/CI/docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -124,7 +124,7 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -242,7 +242,7 @@ jobs:
         run: brew install openjdk@21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -325,7 +325,7 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -364,7 +364,7 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -408,7 +408,7 @@ jobs:
         run: brew install openjdk@21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,8 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      - name: Check formatting (Spotless)
-        run: ./gradlew spotlessCheck --no-daemon
-
-      - name: Run static analysis (Detekt)
-        run: ./gradlew detekt --no-daemon
+      - name: Lint (Spotless + Detekt)
+        run: ./gradlew spotlessCheck detekt --no-daemon
 
       # SwiftLint runs on Linux against .swift source (no Xcode needed) via the official
       # container, pinned (0.63.3 — keep CLAUDE.md's local-commands row in sync when bumping).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,43 @@ jobs:
           path: build/reports/detekt/
           retention-days: 7
 
+  # ── Supply chain ─────────────────────────────────────────────────────────────
+  dependency-graph:
+    name: Submit dependency graph
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      # Overrides the workflow-level `contents: read` — the dependency-graph
+      # submission API writes the resolved graph back to the repository.
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Review new dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
   # ── Test ─────────────────────────────────────────────────────────────────────
   test-jvm:
     name: Test (JVM)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Decode keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ${{ runner.temp }}/release.keystore
@@ -182,7 +182,7 @@ jobs:
         run: brew install openjdk@21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Cache Konan
         uses: actions/cache@v6
@@ -271,7 +271,7 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Cache Konan (Kotlin/Native)
         uses: actions/cache@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,12 @@ CI is organized into three stages — **Lint / Test / Build** — across a Linux
 
 `./gradlew verifyLocal --no-daemon` runs the Linux-lane `Lint` + `Test (JVM)` gates above in a single invocation (the native and iOS lanes stay separate).
 
+> **Never pipe a gate command.** `./gradlew … | tee build.log` (or `| tail`, `| grep`)
+> makes the shell report the pipe's last stage, not Gradle — a failing gate exits 0 and
+> looks green. Run gates bare and read the final `BUILD SUCCESSFUL` / `BUILD FAILED`
+> line. If you must capture output, use `set -o pipefail` first (zsh/bash) or check
+> `$pipestatus[1]` / `${PIPESTATUS[0]}` afterwards.
+
 **†iOS** = requires a Mac with Xcode 26. On an iOS-capable machine, run these before pushing. **On a non-iOS dev machine (e.g. Linux), the iOS gates can't run locally — push and rely on remote CI to run them** (the `Test (iOS)` / `Build (iOS)` / Swift-lint jobs gate the PR regardless).
 
 > **iOS local gate:** `Build (iOS)` (`xcodebuild build`) does **not** compile `ListenUpTests`. Before pushing iOS changes from a Mac, also run `xcodebuild build-for-testing` (or the full `Test (iOS)` command) so test-target drift can't slip to CI.
@@ -306,7 +312,7 @@ client/
 │       └── desktopMain/        # Desktop-specific UI
 ├── contract/                   # Client↔server contract: @Rpc service interfaces,
 │                               #   @Serializable DTOs, the error hierarchy
-├── server/                     # Ktor JVM server
+├── server/                     # Ktor server (KMP: JVM + linuxX64 native)
 ├── androidApp/                 # Android entry point (thin wrapper)
 ├── desktopApp/                 # Desktop entry point (thin wrapper)
 ├── build-logic/                # Gradle convention plugins + detekt-rules

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ For contributors who want to build the apps and server locally.
 - **JDK 21** (the build pins `jvmToolchain(21)`; Gradle auto-provisions a matching JDK via the Foojay toolchain resolver if you don't have one)
 - **Android SDK** with API 33+ (for Android builds) — Android Studio Otter or later recommended
 - **Xcode 26** (for iOS builds, macOS only)
+- **Native link headers** (only for the server's Linux-native lane, `./gradlew :server:linuxX64Test`): Debian/Ubuntu `libargon2-dev libsqlite3-dev libcurl4-openssl-dev`; Arch `argon2 sqlite curl`. Not needed for the JVM server or the Android app.
 
 ### Build & Run
 
@@ -119,9 +120,6 @@ cd ListenUp
 
 # Server
 ./gradlew :server:runJvm
-
-# Desktop (JVM, in progress)
-./gradlew :desktopApp:run
 ```
 
 For iOS, open `iosApp/ListenUp.xcodeproj` in Xcode and run the `ListenUp` scheme against a simulator or device.

--- a/iosApp/ListenUp/DesignSystem/Components/NamedEntityPickerSheet.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/NamedEntityPickerSheet.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+/// A native value row for `NamedEntityPickerSheet`. Never a Swift-Export-bridged Kotlin object
+/// (iosApp rule 8) — each wrapper maps its observer rows into this at the boundary.
+struct PickerRow: Identifiable, Equatable {
+    let id: String
+    let name: String
+    /// Trailing membership checkmark (the book-detail shelf sheet); `false` everywhere else.
+    var isChecked: Bool = false
+}
+
+/// How the picker renders when there are no rows.
+enum PickerEmptyState {
+    /// Just an empty list — the create affordance is the only content (shelves).
+    case silent
+    /// A footnote hint row above the create affordance (bulk collection).
+    case hint(String)
+    /// A full `ContentUnavailableView` replacing the list (book-detail collection).
+    case unavailable(String, systemImage: String)
+}
+
+/// The inline "New …" create affordance. `nil` hides the create section entirely
+/// (e.g. a non-admin viewing collections).
+struct InlineCreate {
+    let label: String
+    let nameHint: String
+    let onCreate: (String) -> Void
+}
+
+/// One sheet for the whole "pick a named entity, or make a new one and add to it" interaction —
+/// the shape the bulk/detail collection and shelf picker sheets all shared. Callers pass their
+/// localized strings and bind the entity-specific observer calls into the closures; nothing here
+/// knows whether it's showing collections or shelves.
+struct NamedEntityPickerSheet: View {
+    let title: String
+    let rows: [PickerRow]
+    var headerText: String?
+    var emptyState: PickerEmptyState = .silent
+    var errorText: String?
+    var frosted: Bool = false
+    let isBusy: Bool
+    var create: InlineCreate?
+    let onSelect: (String) -> Void
+    let onClose: () -> Void
+
+    @State private var isCreating = false
+    @State private var newName = ""
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if let headerText {
+                    Section {
+                        Text(headerText)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                rowsSection
+
+                if let create {
+                    createSection(create)
+                }
+
+                if let errorText {
+                    Section {
+                        Text(errorText)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .scrollContentBackground(frosted ? .hidden : .automatic)
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(String(localized: "common.done"), action: onClose)
+                }
+                if isBusy {
+                    ToolbarItem(placement: .topBarLeading) {
+                        ProgressView()
+                    }
+                }
+            }
+            .presentationDetents([.medium, .large])
+        }
+        .presentationBackgroundFrosted(frosted)
+    }
+
+    // MARK: - Rows
+
+    @ViewBuilder
+    private var rowsSection: some View {
+        switch emptyState {
+        case .unavailable(let text, let icon) where rows.isEmpty:
+            ContentUnavailableView(text, systemImage: icon)
+        case .hint(let text) where rows.isEmpty:
+            Section {
+                Text(text)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        default:
+            Section {
+                ForEach(rows) { row in
+                    rowButton(row)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rowButton(_ row: PickerRow) -> some View {
+        Button { onSelect(row.id) } label: {
+            HStack {
+                Text(row.name)
+                    .foregroundStyle(.primary)
+                if row.isChecked {
+                    Spacer()
+                    Image(systemName: "checkmark")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.listenUpOrange)
+                }
+            }
+        }
+        .disabled(isBusy)
+        .accessibilityLabel(Text(row.name))
+        .accessibilityValue(row.isChecked ? Text(String(localized: "common.selected")) : Text(""))
+    }
+
+    // MARK: - Create
+
+    @ViewBuilder
+    private func createSection(_ create: InlineCreate) -> some View {
+        Section {
+            if isCreating {
+                TextField(create.nameHint, text: $newName)
+                    .submitLabel(.done)
+                    .onSubmit { submit(create) }
+
+                HStack {
+                    Button(String(localized: "common.cancel")) {
+                        isCreating = false
+                        newName = ""
+                    }
+                    .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Button(String(localized: "common.create")) { submit(create) }
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color.listenUpOrange)
+                        .disabled(trimmedName.isEmpty || isBusy)
+                }
+                // .borderless gives each button its own hit target — without it a tap
+                // anywhere in the row fires Cancel then Create, a silent create failure.
+                .buttonStyle(.borderless)
+            } else {
+                Button { isCreating = true } label: {
+                    Label(create.label, systemImage: "plus")
+                        .foregroundStyle(Color.listenUpOrange)
+                }
+            }
+        }
+    }
+
+    private var trimmedName: String {
+        newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func submit(_ create: InlineCreate) {
+        let name = trimmedName
+        guard !name.isEmpty else { return }
+        create.onCreate(name)
+        newName = ""
+        isCreating = false
+    }
+}
+
+private extension View {
+    /// The bulk sheets float on a `.thickMaterial` sheet background; the detail sheets use the
+    /// default. Applied conditionally so the two treatments stay identical to the originals.
+    @ViewBuilder
+    func presentationBackgroundFrosted(_ frosted: Bool) -> some View {
+        if frosted {
+            presentationBackground(.thickMaterial)
+        } else {
+            self
+        }
+    }
+}

--- a/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxObserver.swift
+++ b/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxObserver.swift
@@ -40,23 +40,29 @@ final class AdminInboxObserver {
     // MARK: - State mapping
 
     private func apply(_ state: AdminInboxUiState) {
+        phase = Self.phase(from: state)
+    }
+
+    /// Pure: project the sealed `AdminInboxUiState` onto the flattened phase.
+    /// `nonisolated` so tests can exercise it off the main actor (mirrors the backup observers).
+    nonisolated static func phase(from state: AdminInboxUiState) -> AdminInboxPhase {
         switch onEnum(of: state) {
         case .loading:
-            phase = .loading
+            return .loading
         case .ready(let ready):
-            phase = .ready(AdminInboxReadyModel(from: ready))
+            return .ready(AdminInboxReadyModel(from: ready))
         case .error(let error):
-            phase = .error(error.message)
+            return .error(error.message)
         case .unknown:
             Log.error("Unexpected AdminInboxUiState case")
-            phase = .error(String(localized: "common.something_went_wrong"))
+            return .error(String(localized: "common.something_went_wrong"))
         }
     }
 }
 
 // MARK: - Phase
 
-enum AdminInboxPhase {
+enum AdminInboxPhase: Equatable {
     case loading
     case ready(AdminInboxReadyModel)
     case error(String)
@@ -64,7 +70,7 @@ enum AdminInboxPhase {
 
 // MARK: - Ready model
 
-struct AdminInboxReadyModel {
+struct AdminInboxReadyModel: Equatable {
     let books: [InboxBookRowModel]
     let selectedBookIds: Set<String>
     let isReleasing: Bool
@@ -92,7 +98,7 @@ struct AdminInboxReadyModel {
 
 // MARK: - Row model
 
-struct InboxBookRowModel: Identifiable {
+struct InboxBookRowModel: Identifiable, Equatable {
     let id: String
     let title: String
     let author: String?

--- a/iosApp/ListenUp/Features/BookDetail/Components/CollectionPickerSheet.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/CollectionPickerSheet.swift
@@ -1,129 +1,38 @@
 import SwiftUI
 
-/// Sheet body for filing the current book into one of the admin's collections.
+/// Binds `BookDetailObserver`'s collections into `NamedEntityPickerSheet` for the single-book "file
+/// this book into a collection" flow: a `ContentUnavailableView` empty state, an admin-gated create
+/// affordance, and an inline collection-error section. No frost and no count header (detail style).
 ///
-/// Lists `observer.allCollections` as a simple tappable list; selecting one calls
-/// `addToCollection(collectionId:)`. Admins may also create a new collection inline
-/// via a "New Collection…" affordance that reveals a text field and creates a
-/// collection containing the book in one step. Collection errors surface inline; an
-/// in-flight add shows a progress indicator and disables the rows.
-///
-/// The assembly screen presents this via `.sheet`, owning the presentation
-/// binding (`observer.showCollectionPicker`) and driving `closeCollectionPicker()` /
-/// `clearCollectionError()` on dismiss. Bound directly to `BookDetailObserver`.
+/// The assembly screen presents this via `.sheet`, owning the presentation binding
+/// (`observer.showCollectionPicker`) and driving `closeCollectionPicker()` / `clearCollectionError()`
+/// on dismiss.
 struct CollectionPickerSheet: View {
     let observer: BookDetailObserver
     /// Invoked by the Done button; the assembly screen flips the sheet binding.
     let onClose: () -> Void
 
-    @State private var isCreatingCollection = false
-    @State private var newCollectionName = ""
-
     var body: some View {
-        NavigationStack {
-            List {
-                collectionsSection
-                // Collections are admin-managed: the create affordance is admin-only
-                // (belt-and-suspenders — the whole picker is already admin-gated).
-                if observer.isAdmin {
-                    newCollectionSection
-                }
-                if let collectionError = observer.collectionError {
-                    Section {
-                        Text(collectionError)
-                            .font(.footnote)
-                            .foregroundStyle(.red)
-                    }
-                }
-            }
-            .navigationTitle(String(localized: "book.detail_collection_picker_title"))
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(String(localized: "common.done"), action: onClose)
-                }
-                if observer.isAddingToCollection {
-                    ToolbarItem(placement: .topBarLeading) {
-                        ProgressView()
-                    }
-                }
-            }
-            .presentationDetents([.medium, .large])
-        }
-    }
-
-    // MARK: - Collections
-
-    @ViewBuilder
-    private var collectionsSection: some View {
-        if observer.allCollections.isEmpty {
-            ContentUnavailableView(
+        NamedEntityPickerSheet(
+            title: String(localized: "book.detail_collection_picker_title"),
+            rows: observer.allCollections.map { PickerRow(id: $0.id, name: $0.name) },
+            emptyState: .unavailable(
                 String(localized: "book.detail_no_collections"),
                 systemImage: "rectangle.stack"
-            )
-        } else {
-            Section {
-                ForEach(observer.allCollections) { collection in
-                    Button { observer.addToCollection(collectionId: collection.id) } label: {
-                        Text(collection.name)
-                            .foregroundStyle(.primary)
-                    }
-                    .disabled(observer.isAddingToCollection)
-                    .accessibilityLabel(Text(collection.name))
-                }
-            }
-        }
-    }
-
-    // MARK: - New collection
-
-    @ViewBuilder
-    private var newCollectionSection: some View {
-        Section {
-            if isCreatingCollection {
-                TextField(String(localized: "common.collection_name_hint"), text: $newCollectionName)
-                    .submitLabel(.done)
-                    .onSubmit(createCollection)
-
-                HStack {
-                    Button(String(localized: "common.cancel")) {
-                        isCreatingCollection = false
-                        newCollectionName = ""
-                    }
-                    .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    Button(String(localized: "common.create"), action: createCollection)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(Color.listenUpOrange)
-                        .disabled(trimmedName.isEmpty || observer.isAddingToCollection)
-                }
-                // Give each button its own hit target. Without .borderless, two default
-                // buttons in a List row make the whole row tappable for BOTH: a tap anywhere
-                // outside the tiny "Create" text fires Cancel (clearing the name) then Create,
-                // which no-ops on the empty-name guard — a silent create failure.
-                .buttonStyle(.borderless)
-            } else {
-                Button { isCreatingCollection = true } label: {
-                    Label(String(localized: "book.detail_new_collection"), systemImage: "plus")
-                        .foregroundStyle(Color.listenUpOrange)
-                }
-            }
-        }
-    }
-
-    // MARK: - Actions
-
-    private var trimmedName: String {
-        newCollectionName.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func createCollection() {
-        let name = trimmedName
-        guard !name.isEmpty else { return }
-        observer.createCollectionAndAdd(name: name)
-        newCollectionName = ""
-        isCreatingCollection = false
+            ),
+            errorText: observer.collectionError,
+            isBusy: observer.isAddingToCollection,
+            // Collections are admin-managed: the create affordance is admin-only (belt-and-suspenders
+            // — the whole picker is already admin-gated).
+            create: observer.isAdmin
+                ? InlineCreate(
+                    label: String(localized: "book.detail_new_collection"),
+                    nameHint: String(localized: "common.collection_name_hint"),
+                    onCreate: { observer.createCollectionAndAdd(name: $0) }
+                  )
+                : nil,
+            onSelect: { observer.addToCollection(collectionId: $0) },
+            onClose: onClose
+        )
     }
 }

--- a/iosApp/ListenUp/Features/BookDetail/Components/ShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/ShelfPickerSheet.swift
@@ -1,127 +1,29 @@
 import SwiftUI
 
-/// Sheet body for adding the current book to one of the user's shelves.
+/// Binds `BookDetailObserver`'s shelves into `NamedEntityPickerSheet` for the single-book "add this
+/// book to a shelf" flow: a trailing membership checkmark per shelf (`containsBook`), an always-present
+/// create affordance, and an inline shelf-error section. No frost and no count header (detail style).
 ///
-/// Lists `observer.myShelves`, marking membership with a trailing checkmark, and
-/// offers an inline "New Shelf…" affordance that reveals a text field and creates
-/// a shelf containing the book in one step. Shelf errors surface inline; an
-/// in-flight add shows a progress indicator.
-///
-/// The assembly screen presents this via `.sheet`, owning the presentation
-/// binding (`observer.showShelfPicker`) and driving `closeShelfPicker()` /
-/// `clearShelfError()` on dismiss. Bound directly to `BookDetailObserver`.
+/// The assembly screen presents this via `.sheet`, owning the presentation binding
+/// (`observer.showShelfPicker`) and driving `closeShelfPicker()` / `clearShelfError()` on dismiss.
 struct ShelfPickerSheet: View {
     let observer: BookDetailObserver
     /// Invoked by the Done button; the assembly screen flips the sheet binding.
     let onClose: () -> Void
 
-    @State private var isCreatingShelf = false
-    @State private var newShelfName = ""
-
     var body: some View {
-        NavigationStack {
-            List {
-                shelvesSection
-                newShelfSection
-                if let shelfError = observer.shelfError {
-                    Section {
-                        Text(shelfError)
-                            .font(.footnote)
-                            .foregroundStyle(.red)
-                    }
-                }
-            }
-            .navigationTitle(String(localized: "book.detail_add_to_shelf"))
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(String(localized: "common.done"), action: onClose)
-                }
-                if observer.isAddingToShelf {
-                    ToolbarItem(placement: .topBarLeading) {
-                        ProgressView()
-                    }
-                }
-            }
-            .presentationDetents([.medium, .large])
-        }
-    }
-
-    // MARK: - Existing shelves
-
-    private var shelvesSection: some View {
-        Section {
-            ForEach(observer.myShelves) { shelf in
-                Button { observer.addToShelf(shelfId: shelf.id) } label: {
-                    HStack {
-                        Text(shelf.name)
-                            .foregroundStyle(.primary)
-                        Spacer()
-                        if shelf.containsBook {
-                            Image(systemName: "checkmark")
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(Color.listenUpOrange)
-                        }
-                    }
-                }
-                .disabled(observer.isAddingToShelf)
-                .accessibilityLabel(Text(shelf.name))
-                .accessibilityValue(shelf.containsBook
-                    ? Text(String(localized: "common.selected"))
-                    : Text(""))
-            }
-        }
-    }
-
-    // MARK: - New shelf
-
-    @ViewBuilder
-    private var newShelfSection: some View {
-        Section {
-            if isCreatingShelf {
-                TextField(String(localized: "common.shelf_name_hint"), text: $newShelfName)
-                    .submitLabel(.done)
-                    .onSubmit(createShelf)
-
-                HStack {
-                    Button(String(localized: "common.cancel")) {
-                        isCreatingShelf = false
-                        newShelfName = ""
-                    }
-                    .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    Button(String(localized: "common.create"), action: createShelf)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(Color.listenUpOrange)
-                        .disabled(trimmedName.isEmpty || observer.isAddingToShelf)
-                }
-                // Give each button its own hit target. Without .borderless, two default
-                // buttons in a List row make the whole row tappable for BOTH: a tap anywhere
-                // outside the tiny "Create" text fires Cancel (clearing the name) then Create,
-                // which no-ops on the empty-name guard — a silent create failure.
-                .buttonStyle(.borderless)
-            } else {
-                Button { isCreatingShelf = true } label: {
-                    Label(String(localized: "book.detail_new_shelf"), systemImage: "plus")
-                        .foregroundStyle(Color.listenUpOrange)
-                }
-            }
-        }
-    }
-
-    // MARK: - Actions
-
-    private var trimmedName: String {
-        newShelfName.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func createShelf() {
-        let name = trimmedName
-        guard !name.isEmpty else { return }
-        observer.createShelfAndAdd(name: name)
-        newShelfName = ""
-        isCreatingShelf = false
+        NamedEntityPickerSheet(
+            title: String(localized: "book.detail_add_to_shelf"),
+            rows: observer.myShelves.map { PickerRow(id: $0.id, name: $0.name, isChecked: $0.containsBook) },
+            errorText: observer.shelfError,
+            isBusy: observer.isAddingToShelf,
+            create: InlineCreate(
+                label: String(localized: "book.detail_new_shelf"),
+                nameHint: String(localized: "common.shelf_name_hint"),
+                onCreate: { observer.createShelfAndAdd(name: $0) }
+            ),
+            onSelect: { observer.addToShelf(shelfId: $0) },
+            onClose: onClose
+        )
     }
 }

--- a/iosApp/ListenUp/Features/Selection/BulkCollectionPickerSheet.swift
+++ b/iosApp/ListenUp/Features/Selection/BulkCollectionPickerSheet.swift
@@ -1,15 +1,10 @@
 import SwiftUI
 
-/// Sheet body for filing the multi-selected books into one of the admin's collections.
-///
-/// Mirrors `BulkShelfPickerSheet` but is bound to `BookSelectionObserver` and operates on the whole
-/// selection: a leading count line states how many books will be added, each collection is a plain
-/// tappable row, and an inline "New Collection…" affordance creates a collection and files every
-/// selected book into it in one step. The create affordance is always present — an admin with zero
-/// collections still needs a way to make the first one — so the empty state is a hint row above it,
-/// not a full-screen `ContentUnavailableView`. Admin-gated (the whole sheet is only presented for
-/// admins). Failures surface on the global `ErrorBus`; on success the VM clears the selection and
-/// emits an event the observer reacts to by dismissing this sheet.
+/// Binds `BookSelectionObserver`'s collections into `NamedEntityPickerSheet` for the bulk-selection
+/// "file every selected book into a collection" flow: a count header, frost, an always-present
+/// create affordance, and a hint-row empty state (an admin with zero collections still needs to make
+/// the first one). Failures surface on the global `ErrorBus`; on success the VM clears the selection
+/// and the observer dismisses this sheet.
 struct BulkCollectionPickerSheet: View {
     let observer: BookSelectionObserver
     /// Number of books currently selected — shown in the count line.
@@ -17,111 +12,21 @@ struct BulkCollectionPickerSheet: View {
     /// Invoked by the Done button; the assembly screen flips the sheet binding.
     let onClose: () -> Void
 
-    @State private var isCreatingCollection = false
-    @State private var newCollectionName = ""
-
     var body: some View {
-        NavigationStack {
-            List {
-                Section {
-                    Text(String(format: String(localized: "selection.add_n_to_collection"), count))
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-                collectionsSection
-                newCollectionSection
-            }
-            .scrollContentBackground(.hidden)
-            .navigationTitle(String(localized: "book.detail_collection_picker_title"))
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(String(localized: "common.done"), action: onClose)
-                }
-                if observer.isAddingToCollection {
-                    ToolbarItem(placement: .topBarLeading) {
-                        ProgressView()
-                    }
-                }
-            }
-            .presentationDetents([.medium, .large])
-            .presentationBackground(.thickMaterial)
-        }
-    }
-
-    // MARK: - Existing collections
-
-    @ViewBuilder
-    private var collectionsSection: some View {
-        if observer.allCollections.isEmpty {
-            Section {
-                Text(String(localized: "book.detail_no_collections"))
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-        } else {
-            Section {
-                ForEach(observer.allCollections) { collection in
-                    Button { observer.addToCollection(collectionId: collection.id) } label: {
-                        Text(collection.name)
-                            .foregroundStyle(.primary)
-                    }
-                    .disabled(observer.isAddingToCollection)
-                    .accessibilityLabel(Text(collection.name))
-                }
-            }
-        }
-    }
-
-    // MARK: - New collection
-
-    @ViewBuilder
-    private var newCollectionSection: some View {
-        Section {
-            if isCreatingCollection {
-                TextField(String(localized: "common.collection_name_hint"), text: $newCollectionName)
-                    .submitLabel(.done)
-                    .onSubmit(createCollection)
-
-                HStack {
-                    Button(String(localized: "common.cancel")) {
-                        isCreatingCollection = false
-                        newCollectionName = ""
-                    }
-                    .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    Button(String(localized: "common.create"), action: createCollection)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(Color.listenUpOrange)
-                        .disabled(trimmedName.isEmpty || observer.isAddingToCollection)
-                }
-                // Give each button its own hit target. Without .borderless, two default
-                // buttons in a List row make the whole row tappable for BOTH: a tap anywhere
-                // outside the tiny "Create" text fires Cancel (clearing the name) then Create,
-                // which no-ops on the empty-name guard — a silent create failure.
-                .buttonStyle(.borderless)
-            } else {
-                Button { isCreatingCollection = true } label: {
-                    Label(String(localized: "book.detail_new_collection"), systemImage: "plus")
-                        .foregroundStyle(Color.listenUpOrange)
-                }
-            }
-        }
-    }
-
-    // MARK: - Actions
-
-    private var trimmedName: String {
-        newCollectionName.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func createCollection() {
-        let name = trimmedName
-        guard !name.isEmpty else { return }
-        observer.createCollectionAndAdd(name: name)
-        newCollectionName = ""
-        isCreatingCollection = false
+        NamedEntityPickerSheet(
+            title: String(localized: "book.detail_collection_picker_title"),
+            rows: observer.allCollections.map { PickerRow(id: $0.id, name: $0.name) },
+            headerText: String(format: String(localized: "selection.add_n_to_collection"), count),
+            emptyState: .hint(String(localized: "book.detail_no_collections")),
+            frosted: true,
+            isBusy: observer.isAddingToCollection,
+            create: InlineCreate(
+                label: String(localized: "book.detail_new_collection"),
+                nameHint: String(localized: "common.collection_name_hint"),
+                onCreate: { observer.createCollectionAndAdd(name: $0) }
+            ),
+            onSelect: { observer.addToCollection(collectionId: $0) },
+            onClose: onClose
+        )
     }
 }

--- a/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
@@ -1,13 +1,9 @@
 import SwiftUI
 
-/// Sheet body for adding the multi-selected books to one of the user's shelves.
-///
-/// Mirrors `ShelfPickerSheet` but is bound to `BookSelectionObserver` and operates on the whole
-/// selection: a leading count line states how many books will be added, each shelf is a plain
-/// tappable row (no per-shelf membership checkmark — many books, no single membership), and an
-/// inline "New Shelf…" affordance creates a shelf and files every selected book into it in one
-/// step. Failures surface on the global `ErrorBus`; on success the VM clears the selection and
-/// emits an event the observer reacts to by dismissing this sheet.
+/// Binds `BookSelectionObserver`'s shelves into `NamedEntityPickerSheet` for the bulk-selection "add
+/// every selected book to a shelf" flow: a count header, frost, an always-present create affordance,
+/// and a silent empty state (shelves are always creatable, so no zero-state hint). No per-row
+/// checkmark — many books, no single membership. Failures surface on the global `ErrorBus`.
 struct BulkShelfPickerSheet: View {
     let observer: BookSelectionObserver
     /// Number of books currently selected — shown in the count line.
@@ -15,102 +11,20 @@ struct BulkShelfPickerSheet: View {
     /// Invoked by the Done button; the assembly screen flips the sheet binding.
     let onClose: () -> Void
 
-    @State private var isCreatingShelf = false
-    @State private var newShelfName = ""
-
     var body: some View {
-        NavigationStack {
-            List {
-                Section {
-                    Text(String(format: String(localized: "selection.add_n_to_shelf"), count))
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-                shelvesSection
-                newShelfSection
-            }
-            .scrollContentBackground(.hidden)
-            .navigationTitle(String(localized: "book.detail_add_to_shelf"))
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(String(localized: "common.done"), action: onClose)
-                }
-                if observer.isAddingToShelf {
-                    ToolbarItem(placement: .topBarLeading) {
-                        ProgressView()
-                    }
-                }
-            }
-            .presentationDetents([.medium, .large])
-            .presentationBackground(.thickMaterial)
-        }
-    }
-
-    // MARK: - Existing shelves
-
-    private var shelvesSection: some View {
-        Section {
-            ForEach(observer.myShelves) { shelf in
-                Button { observer.addToShelf(shelfId: shelf.id) } label: {
-                    Text(shelf.name)
-                        .foregroundStyle(.primary)
-                }
-                .disabled(observer.isAddingToShelf)
-                .accessibilityLabel(Text(shelf.name))
-            }
-        }
-    }
-
-    // MARK: - New shelf
-
-    @ViewBuilder
-    private var newShelfSection: some View {
-        Section {
-            if isCreatingShelf {
-                TextField(String(localized: "common.shelf_name_hint"), text: $newShelfName)
-                    .submitLabel(.done)
-                    .onSubmit(createShelf)
-
-                HStack {
-                    Button(String(localized: "common.cancel")) {
-                        isCreatingShelf = false
-                        newShelfName = ""
-                    }
-                    .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    Button(String(localized: "common.create"), action: createShelf)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(Color.listenUpOrange)
-                        .disabled(trimmedName.isEmpty || observer.isAddingToShelf)
-                }
-                // Give each button its own hit target. Without .borderless, two default
-                // buttons in a List row make the whole row tappable for BOTH: a tap anywhere
-                // outside the tiny "Create" text fires Cancel (clearing the name) then Create,
-                // which no-ops on the empty-name guard — a silent create failure.
-                .buttonStyle(.borderless)
-            } else {
-                Button { isCreatingShelf = true } label: {
-                    Label(String(localized: "book.detail_new_shelf"), systemImage: "plus")
-                        .foregroundStyle(Color.listenUpOrange)
-                }
-            }
-        }
-    }
-
-    // MARK: - Actions
-
-    private var trimmedName: String {
-        newShelfName.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func createShelf() {
-        let name = trimmedName
-        guard !name.isEmpty else { return }
-        observer.createShelfAndAdd(name: name)
-        newShelfName = ""
-        isCreatingShelf = false
+        NamedEntityPickerSheet(
+            title: String(localized: "book.detail_add_to_shelf"),
+            rows: observer.myShelves.map { PickerRow(id: $0.id, name: $0.name) },
+            headerText: String(format: String(localized: "selection.add_n_to_shelf"), count),
+            frosted: true,
+            isBusy: observer.isAddingToShelf,
+            create: InlineCreate(
+                label: String(localized: "book.detail_new_shelf"),
+                nameHint: String(localized: "common.shelf_name_hint"),
+                onCreate: { observer.createShelfAndAdd(name: $0) }
+            ),
+            onSelect: { observer.addToShelf(shelfId: $0) },
+            onClose: onClose
+        )
     }
 }

--- a/iosApp/ListenUpTests/Admin/AdminInboxObserverTests.swift
+++ b/iosApp/ListenUpTests/Admin/AdminInboxObserverTests.swift
@@ -1,0 +1,149 @@
+import Testing
+import Foundation
+import Shared
+@testable import ListenUp
+
+/// The value-type mapping `AdminInboxObserver` performs at its boundary — the sealed
+/// `AdminInboxUiState` → `AdminInboxPhase` projection and the native `InboxBookRowModel`.
+/// Mirrors `AdminBackupObserversTests`; the shared `AdminInboxViewModel` logic is covered by
+/// `AdminInboxViewModelTest` in sharedLogic. Guards against a UiState case routed to the wrong
+/// phase and against a bridged Kotlin `InboxBookItem` leaking past the observer boundary
+/// (iosApp rule 8 — map to a native value type before the view).
+
+// MARK: - Phase mapping
+
+@Suite("Admin inbox phase mapping")
+struct AdminInboxPhaseTests {
+    @Test func loadingMapsToLoading() {
+        #expect(AdminInboxObserver.phase(from: AdminInboxUiStateLoading.shared) == .loading)
+    }
+
+    @Test func errorCarriesMessage() {
+        #expect(AdminInboxObserver.phase(from: AdminInboxUiStateError(message: "inbox boom")) == .error("inbox boom"))
+    }
+
+    @Test func readyCarriesBooksSelectionAndFlags() {
+        let state = AdminInboxUiStateReady(
+            bookIds: ["b1", "b2"],
+            books: [inboxItem(id: "b1"), inboxItem(id: "b2")],
+            selectedBookIds: ["b1"],
+            isReleasing: true,
+            lastReleasedCount: 3,
+            error: "partial"
+        )
+        guard case .ready(let model) = AdminInboxObserver.phase(from: state) else {
+            Issue.record("expected .ready")
+            return
+        }
+        #expect(model.books.count == 2)
+        #expect(model.bookCount == 2)
+        #expect(model.selectedBookIds == ["b1"])
+        #expect(model.isReleasing == true)
+        #expect(model.lastReleasedCount == 3)
+        #expect(model.error == "partial")
+        #expect(model.hasBooks == true)
+        #expect(model.hasSelection == true)
+        #expect(model.selectedCount == 1)
+        #expect(model.allSelected == false)
+    }
+
+    @Test func emptyReadyHasNoBooksOrSelection() {
+        let state = AdminInboxUiStateReady(
+            bookIds: [],
+            books: [],
+            selectedBookIds: [],
+            isReleasing: false,
+            lastReleasedCount: nil,
+            error: nil
+        )
+        guard case .ready(let model) = AdminInboxObserver.phase(from: state) else {
+            Issue.record("expected .ready")
+            return
+        }
+        #expect(model.books.isEmpty)
+        #expect(model.bookCount == 0)
+        #expect(model.hasBooks == false)
+        #expect(model.hasSelection == false)
+        #expect(model.selectedCount == 0)
+        #expect(model.allSelected == false)
+        #expect(model.lastReleasedCount == nil)
+        #expect(model.error == nil)
+    }
+
+    @Test func allSelectedWhenSelectionCoversEveryBook() {
+        let state = AdminInboxUiStateReady(
+            bookIds: ["b1", "b2"],
+            books: [inboxItem(id: "b1"), inboxItem(id: "b2")],
+            selectedBookIds: ["b1", "b2"],
+            isReleasing: false,
+            lastReleasedCount: nil,
+            error: nil
+        )
+        guard case .ready(let model) = AdminInboxObserver.phase(from: state) else {
+            Issue.record("expected .ready")
+            return
+        }
+        #expect(model.allSelected == true)
+    }
+}
+
+// MARK: - Row mapping
+
+@Suite("Admin inbox row mapping")
+struct AdminInboxRowModelTests {
+    @Test func mapsEveryField() {
+        let item = InboxBookItem(
+            id: "b7",
+            title: "The Way of Kings",
+            author: "Brandon Sanderson",
+            coverPath: "/covers/b7.jpg",
+            durationMs: 3_600_000,
+            coverHash: "abc123"
+        )
+        let model = InboxBookRowModel(from: item)
+
+        #expect(model.id == "b7")
+        #expect(model.title == "The Way of Kings")
+        #expect(model.author == "Brandon Sanderson")
+        #expect(model.coverPath == "/covers/b7.jpg")
+        #expect(model.coverHash == "abc123")
+        #expect(model.durationMs == 3_600_000)
+    }
+
+    @Test func nilOptionalsSurvive() {
+        let model = InboxBookRowModel(from: inboxItem(id: "b1", author: nil, coverPath: nil, coverHash: nil))
+
+        #expect(model.author == nil)
+        #expect(model.coverPath == nil)
+        #expect(model.coverHash == nil)
+    }
+
+    @Test func formattedDurationPassesThroughForZeroAndOverAnHour() {
+        // Passthrough assertion (not a hard-coded string) so the test pins the wiring, not the
+        // formatter's locale-sensitive output — mirrors the backup suite's `sizeFormatted` check.
+        let zero = InboxBookRowModel(from: inboxItem(id: "z", durationMs: 0))
+        #expect(zero.formattedDuration == DurationFormatting.hoursMinutes(ms: 0))
+
+        let overAnHour = InboxBookRowModel(from: inboxItem(id: "h", durationMs: 3_660_000)) // 1h 01m
+        #expect(overAnHour.formattedDuration == DurationFormatting.hoursMinutes(ms: 3_660_000))
+    }
+}
+
+// MARK: - Fixtures
+
+private func inboxItem(
+    id: String,
+    author: String? = "Author",
+    coverPath: String? = nil,
+    coverHash: String? = nil,
+    durationMs: Int64 = 60_000
+) -> InboxBookItem {
+    InboxBookItem(
+        id: id,
+        title: "Title \(id)",
+        author: author,
+        coverPath: coverPath,
+        durationMs: durationMs,
+        coverHash: coverHash
+    )
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
@@ -12,6 +12,8 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ImportId
 import com.calypsan.listenup.server.io.canonicalize
 import com.calypsan.listenup.server.io.fileIoDispatcher
+import com.calypsan.listenup.server.services.ImportListeningEventWrite
+import com.calypsan.listenup.server.services.ImportPositionWrite
 import com.calypsan.listenup.server.services.ListeningEventRepository
 import com.calypsan.listenup.server.services.PlaybackPositionRepository
 import com.calypsan.listenup.server.services.StatsCascadeDeferred
@@ -219,12 +221,18 @@ class ImportApplier internal constructor(
     }
 
     /**
-     * Records every resolvable progress row, counting imports per user, and adds each imported user
-     * to [affectedUsers] so their stats are backfilled (a finished position refreshes `booksFinished`
-     * even when the user has no imported sessions). Returns the per-user written-position counts.
+     * Records every resolvable progress row through the batched
+     * [PlaybackPositionRepository.recordAllForImport] write, counting imports per user and adding each
+     * imported user to [affectedUsers] so their stats are backfilled (a finished position refreshes
+     * `booksFinished` even when the user has no imported sessions). Returns the per-user
+     * written-position counts.
      *
      * [earliestSessionStartMs] (keyed on raw `(ABS user, ABS item)`) dates each imported
      * `STARTED_BOOK` activity strictly before that book's earliest imported session.
+     *
+     * Progress frames are throttled: one every [APPLY_EVENT_INTERVAL] rows during the resolve scan,
+     * plus an always-emitted final frame reporting `done == total`. A full history import used to emit
+     * one SSE frame per row (including skipped rows); the batched write makes that frequency pointless.
      */
     private suspend fun recordAll(
         progress: List<AbsProgress>,
@@ -236,32 +244,55 @@ class ImportApplier internal constructor(
     ): Map<UserId, Int> {
         val total = progress.size
         val perUser = mutableMapOf<UserId, Int>()
+        val writes = mutableListOf<ImportPositionWrite>()
+        var lastItem: String? = null
 
         progress.forEachIndexed { index, row ->
             val targetUser = userMappings[AbsUserId(row.userId)]
             val targetBook = effectiveBooks[AbsItemId(row.itemId)]
+            lastItem = targetBook?.value ?: row.itemId
             if (targetUser != null && targetBook != null) {
-                recordPosition(targetUser, targetBook, row, earliestSessionStartMs)
+                writes +=
+                    ImportPositionWrite(
+                        userId = targetUser.value,
+                        bookId = targetBook.value,
+                        positionMs = (row.currentTimeSeconds * MILLIS_PER_SECOND).toLong(),
+                        lastPlayedAt = row.lastUpdateMs,
+                        finished = row.isFinished || row.progress >= FINISHED_THRESHOLD,
+                        playbackSpeed = DEFAULT_PLAYBACK_SPEED,
+                        currentChapterId = null,
+                        // Date the imported start strictly before this book's earliest session, and never
+                        // later than the un-fixed value. Null when the book has no imported sessions →
+                        // live behavior (lastPlayedAt).
+                        startedBookOccurredAt =
+                            earliestSessionStartMs[row.userId to row.itemId]
+                                ?.let { minOf(row.lastUpdateMs, it - 1) },
+                    )
                 perUser[targetUser] = (perUser[targetUser] ?: 0) + 1
                 affectedUsers += targetUser.value
             }
-            onEvent(
-                ImportEvent.Applying(
-                    done = index + 1,
-                    total = total,
-                    currentItem = targetBook?.value ?: row.itemId,
-                ),
-            )
+            if ((index + 1) % APPLY_EVENT_INTERVAL == 0) {
+                onEvent(ImportEvent.Applying(done = index + 1, total = total, currentItem = lastItem ?: row.itemId))
+            }
         }
 
+        playbackPositionRepository.recordAllForImport(writes)
+
+        if (total > 0) {
+            onEvent(ImportEvent.Applying(done = total, total = total, currentItem = lastItem ?: ""))
+        }
         return perUser
     }
 
     /**
-     * Imports every resolvable playback session as a listening event (stable `abs:<id>`) and adds
-     * each imported user to [affectedUsers]. The per-event stats hook fires idempotently inside
-     * [ListeningEventRepository.upsert]; the final per-user backfill is the authority. Returns the
-     * number of sessions written.
+     * Imports every resolvable playback session as a listening event (stable `abs:<id>`) through the
+     * batched [ListeningEventRepository.upsertAllForImport] write, and adds each imported user to
+     * [affectedUsers]. The per-event `ListeningSessionClosed` stats hook fires idempotently on first
+     * insert; the final per-user backfill is the authority. Returns the number of sessions written.
+     *
+     * Progress frames are throttled like [recordAll]: one every [APPLY_EVENT_INTERVAL] rows during the
+     * resolve scan, plus an always-emitted final frame reporting `done == total` and the cumulative
+     * `sessionsWritten` tally.
      */
     private suspend fun recordSessions(
         sessions: List<AbsSession>,
@@ -271,54 +302,47 @@ class ImportApplier internal constructor(
         onEvent: (ImportEvent) -> Unit,
     ): Int {
         val total = sessions.size
-        var imported = 0
+        val writes = mutableListOf<ImportListeningEventWrite>()
+        var lastItem: String? = null
 
         sessions.forEachIndexed { index, session ->
             val targetUser = userMappings[AbsUserId(session.userId)]
             val targetBook = effectiveBooks[AbsItemId(session.itemId)]
+            lastItem = targetBook?.value ?: session.itemId
             if (targetUser != null && targetBook != null) {
-                listeningEventRepository.upsert(
-                    value = sessionConverter.toEvent(session, targetBook.value),
-                    clientOpId = null,
-                    userId = targetUser.value,
-                )
-                imported++
+                writes +=
+                    ImportListeningEventWrite(
+                        userId = targetUser.value,
+                        event = sessionConverter.toEvent(session, targetBook.value),
+                    )
                 affectedUsers += targetUser.value
             }
+            if ((index + 1) % APPLY_EVENT_INTERVAL == 0) {
+                onEvent(
+                    ImportEvent.Applying(
+                        done = index + 1,
+                        total = total,
+                        currentItem = lastItem ?: session.itemId,
+                        sessionsWritten = writes.size,
+                    ),
+                )
+            }
+        }
+
+        listeningEventRepository.upsertAllForImport(writes)
+
+        val imported = writes.size
+        if (total > 0) {
             onEvent(
                 ImportEvent.Applying(
-                    done = index + 1,
+                    done = total,
                     total = total,
-                    currentItem = targetBook?.value ?: session.itemId,
+                    currentItem = lastItem ?: "",
                     sessionsWritten = imported,
                 ),
             )
         }
-
         return imported
-    }
-
-    private suspend fun recordPosition(
-        targetUser: UserId,
-        targetBook: BookId,
-        row: AbsProgress,
-        earliestSessionStartMs: Map<Pair<String, String>, Long>,
-    ) {
-        playbackPositionRepository.recordPosition(
-            userId = targetUser.value,
-            bookId = targetBook.value,
-            positionMs = (row.currentTimeSeconds * MILLIS_PER_SECOND).toLong(),
-            lastPlayedAt = row.lastUpdateMs,
-            finished = row.isFinished || row.progress >= FINISHED_THRESHOLD,
-            playbackSpeed = DEFAULT_PLAYBACK_SPEED,
-            currentChapterId = null,
-            // Date the imported start strictly before this book's earliest session, and never
-            // later than the un-fixed value (so progress that already predates the sessions is
-            // unchanged). Null when the book has no imported sessions → live behavior (lastPlayedAt).
-            startedBookOccurredAt =
-                earliestSessionStartMs[row.userId to row.itemId]
-                    ?.let { minOf(row.lastUpdateMs, it - 1) },
-        )
     }
 
     private companion object {
@@ -326,5 +350,8 @@ class ImportApplier internal constructor(
         const val FINISHED_THRESHOLD = 0.99
         const val MILLIS_PER_SECOND = 1_000.0
         const val DEFAULT_PLAYBACK_SPEED = 1.0f
+
+        /** Emit one [ImportEvent.Applying] progress frame per this many resolved rows, plus a final frame. */
+        const val APPLY_EVENT_INTERVAL = 50
     }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/ContributorRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/ContributorRoutes.kt
@@ -29,6 +29,7 @@ import io.ktor.server.resources.put
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 /**
  * REST surface for [ContributorService]. Seven endpoints:
@@ -111,8 +112,16 @@ fun Route.contributorRoutes(
                             .scoped(contributorService)
                             .updateContributor(ContributorId(res.id), ContributorUpdate(imagePath = outcome.relPath))
                 ) {
-                    is AppResult.Success -> call.respond(HttpStatusCode.NoContent)
-                    is AppResult.Failure -> call.respondBareAppError(result.error)
+                    is AppResult.Success -> {
+                        call.respond(HttpStatusCode.NoContent)
+                    }
+
+                    is AppResult.Failure -> {
+                        // The scoped update rejected (no canEdit / unknown id) — remove the file this
+                        // request just wrote so rejected uploads can't accumulate on disk.
+                        SystemFileSystem.delete(Path(imageHome.toString(), outcome.relPath), mustExist = false)
+                        call.respondBareAppError(result.error)
+                    }
                 }
             }
         }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/MetadataImageUpload.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/MetadataImageUpload.kt
@@ -1,18 +1,15 @@
 package com.calypsan.listenup.server.routes
 
+import com.calypsan.listenup.server.io.MultipartPartTooLargeException
 import com.calypsan.listenup.server.io.hashBytesSha256
+import com.calypsan.listenup.server.io.receiveFirstFilePartBytes
 import com.calypsan.listenup.server.metadata.ImageStorage
-import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.PartData
-import io.ktor.http.content.forEachPart
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.request.receiveMultipart
-import io.ktor.utils.io.toByteArray
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-/** Maximum accepted image size for the pre-buffer Content-Length check (10 MiB). Mirrors the book cover cap. */
+/** Maximum accepted image size, enforced during the multipart read (10 MiB). Mirrors the book cover cap. */
 private const val IMAGE_MAX_BYTES = 10L * 1024 * 1024
 
 /**
@@ -35,13 +32,14 @@ internal sealed interface ImageUploadOutcome {
 }
 
 /**
- * Reads the first file part of a multipart upload, enforces the [IMAGE_MAX_BYTES] cap BEFORE buffering
- * (via the declared `Content-Length`), validates the bytes carry a recognised image magic number, and
+ * Reads the first file part of a multipart upload, enforces the [IMAGE_MAX_BYTES] cap DURING the read
+ * (the streaming primitive aborts before an oversize part fully lands in memory — regardless of whether
+ * the part declares a `Content-Length`), validates the bytes carry a recognised image magic number, and
  * writes them content-addressed to `<imageHome>/<subdir>/<sha256>.jpg` via [imageStorage].
  *
  * Content-addressing is deliberate: a replacement image yields a new relative path, which is exactly
- * what clients key their image cache on (the path is the version). Returns 413 for an oversize declared
- * part, 400 when no file part is present, 422 when the bytes fail the image magic-number check, and
+ * what clients key their image cache on (the path is the version). Returns 413 for an oversize part,
+ * 400 when no file part is present, 422 when the bytes fail the image magic-number check, and
  * [ImageUploadOutcome.Stored] with the relative path on success.
  *
  * The caller persists the path through the principal-scoped service so its internal `requireCanEdit`
@@ -52,29 +50,12 @@ internal suspend fun ApplicationCall.storeMultipartImage(
     imageHome: Path,
     imageStorage: ImageStorage,
 ): ImageUploadOutcome {
-    var bytes: ByteArray? = null
-    var oversized = false
-    receiveMultipart().forEachPart { part ->
-        if (part is PartData.FileItem && bytes == null) {
-            val declaredLength = part.headers[HttpHeaders.ContentLength]?.toLongOrNull()
-            if (declaredLength != null && declaredLength > IMAGE_MAX_BYTES) {
-                part.release()
-                oversized = true
-                return@forEachPart
-            }
-            bytes = part.provider().toByteArray()
-        }
-        part.release()
-    }
-
-    if (oversized) return ImageUploadOutcome.Rejected(HttpStatusCode.PayloadTooLarge, "file too large")
-    val data = bytes ?: return ImageUploadOutcome.Rejected(HttpStatusCode.BadRequest, "missing file part")
-    // A part without a declared Content-Length still can't exceed the cap once buffered.
-    if (data.size >
-        IMAGE_MAX_BYTES
-    ) {
-        return ImageUploadOutcome.Rejected(HttpStatusCode.PayloadTooLarge, "file too large")
-    }
+    val data =
+        try {
+            receiveFirstFilePartBytes(IMAGE_MAX_BYTES)
+        } catch (e: MultipartPartTooLargeException) {
+            return ImageUploadOutcome.Rejected(HttpStatusCode.PayloadTooLarge, "file exceeds ${e.limit} bytes")
+        } ?: return ImageUploadOutcome.Rejected(HttpStatusCode.BadRequest, "missing file part")
     if (!isRecognisedImage(data)) {
         return ImageUploadOutcome.Rejected(HttpStatusCode.UnprocessableEntity, "invalid image")
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/SeriesRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/SeriesRoutes.kt
@@ -28,6 +28,7 @@ import io.ktor.server.resources.put
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 /**
  * REST surface for [SeriesService]. Five endpoints:
@@ -106,8 +107,16 @@ fun Route.seriesRoutes(
                             .scoped(seriesService)
                             .updateSeries(SeriesId(res.id), SeriesUpdate(coverPath = outcome.relPath))
                 ) {
-                    is AppResult.Success -> call.respond(HttpStatusCode.NoContent)
-                    is AppResult.Failure -> call.respondBareAppError(result.error)
+                    is AppResult.Success -> {
+                        call.respond(HttpStatusCode.NoContent)
+                    }
+
+                    is AppResult.Failure -> {
+                        // The scoped update rejected (no canEdit / unknown id) — remove the file this
+                        // request just wrote so rejected uploads can't accumulate on disk.
+                        SystemFileSystem.delete(Path(imageHome.toString(), outcome.relPath), mustExist = false)
+                        call.respondBareAppError(result.error)
+                    }
                 }
             }
         }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ListeningEventRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ListeningEventRepository.kt
@@ -8,12 +8,26 @@ import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.Listening_events
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.FirehoseSuppressed
 import com.calypsan.listenup.server.sync.IdRev
 import com.calypsan.listenup.server.sync.SqlSyncableRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.sync.SyncableSubstrateQueries
 import com.calypsan.listenup.server.util.KeyedMutex
 import kotlin.time.Clock
+import kotlinx.coroutines.currentCoroutineContext
+
+/**
+ * One resolved playback session an ABS import intends to persist as a listening event — the batch
+ * counterpart to a single [ListeningEventRepository.upsert] call. [event] carries the stable
+ * `abs:<sessionId>` id, so a re-applied import re-upserts idempotently (append-only). The importer
+ * collects these and hands the whole list to [ListeningEventRepository.upsertAllForImport] so the
+ * writes commit in chunked transactions instead of an existence-read + write commit pair per row.
+ */
+data class ImportListeningEventWrite(
+    val userId: String,
+    val event: ListeningEventSyncPayload,
+)
 
 /**
  * SQLDelight syncable repository for per-user listening events (Playback P2).
@@ -101,6 +115,74 @@ class ListeningEventRepository(
             statsRecorder?.record(StatsEvent.ListeningSessionClosed(userId = userId, span = value))
         }
         return result
+    }
+
+    /**
+     * Batch-upsert [events] for an ABS import — the chunked-transaction counterpart to [upsert]. A
+     * per-session [upsert] loop costs two commits per row (an existence-read transaction plus the
+     * write transaction); a full history import runs tens of thousands. This collapses the burst the
+     * same way [BookRepository.resolveOrInsertAll] does — prepare, then chunked writes — while
+     * preserving [upsert]'s idempotency and first-insert stats-hook semantics exactly:
+     *
+     *  1. **PREPARE (per user, under [firstInsertLock]).** Batch-read which of that user's event ids
+     *     already exist (chunked `IN (…)`), then decide the first-insert flag per row in memory. A
+     *     running seen-set folds intra-batch duplicate ids so the second occurrence is treated as
+     *     already-inserted — matching the single-row loop's read-your-writes.
+     *  2. **WRITE (chunked synchronous transactions).** Process the rows in chunks of
+     *     [PERSIST_CHUNK_SIZE]; each chunk is ONE [suspendTransaction] whose body calls
+     *     [upsertInOpenTransaction] per row — O(chunks) write transactions, not O(rows). [suppressed]
+     *     is read ONCE in the suspend context and threaded in, exactly as the batched book path does.
+     *  3. **HOOKS (post-commit, outside the lock).** Fire `StatsEvent.ListeningSessionClosed` for each
+     *     id that did NOT previously exist — the same choke-point [upsert] fires on first insert.
+     *
+     * **Idempotency / lock choice.** The existence-read and the write for a user's whole batch are
+     * held together under [firstInsertLock] for that user. The import job is single-threaded, but an
+     * imported event uses a stable `abs:<id>` that a *concurrent live sync* could theoretically also
+     * deliver; widening the single-row lock to cover the batch window preserves the exact property
+     * [upsert] guarantees — two deliverers of the same id can never both observe "not yet inserted"
+     * and both fire the stats hook. The lock is released BEFORE the hooks run ([KeyedMutex] is not
+     * reentrant and [StatsRecorder] serializes itself). A no-op on an empty [events].
+     */
+    suspend fun upsertAllForImport(events: List<ImportListeningEventWrite>) {
+        if (events.isEmpty()) return
+        val suppressed = currentCoroutineContext()[FirehoseSuppressed.Key] != null
+
+        events.groupBy { it.userId }.forEach { (userId, userEvents) ->
+            val newlyInserted =
+                firstInsertLock.withLock(userId) {
+                    val existingIds = existingIds(userEvents.map { it.event.id })
+                    val seen = HashSet<String>(userEvents.size)
+                    val firstInserts = ArrayList<ListeningEventSyncPayload>()
+                    for (write in userEvents) {
+                        val existedBefore = write.event.id in existingIds || write.event.id in seen
+                        seen += write.event.id
+                        if (!existedBefore) firstInserts += write.event
+                    }
+                    for (chunk in userEvents.chunked(PERSIST_CHUNK_SIZE)) {
+                        suspendTransaction<Unit>(db) {
+                            chunk.forEach {
+                                upsertInOpenTransaction(it.event, suppressed, clientOpId = null, userId = userId)
+                            }
+                        }
+                    }
+                    firstInserts
+                }
+            newlyInserted.forEach {
+                statsRecorder?.record(StatsEvent.ListeningSessionClosed(userId = userId, span = it))
+            }
+        }
+    }
+
+    /** The subset of [ids] whose listening-event row already exists, read in chunked `IN (…)` batches. */
+    private suspend fun existingIds(ids: List<String>): Set<String> {
+        if (ids.isEmpty()) return emptySet()
+        return suspendTransaction(db) {
+            ids
+                .chunked(SQLITE_IN_CHUNK)
+                .flatMap { chunk -> db.listeningEventsQueries.selectByIds(chunk).executeAsList() }
+                .map { it.id }
+                .toSet()
+        }
     }
 
     override fun idAsString(id: ListeningEventId): String = id.value
@@ -248,5 +330,8 @@ class ListeningEventRepository(
          * `SQLITE_MAX_VARIABLE_NUMBER` (999) with headroom for any fixed bind params.
          */
         const val SQLITE_IN_CHUNK = 900
+
+        /** Import rows per write transaction — one [suspendTransaction] commits a whole chunk. */
+        const val PERSIST_CHUNK_SIZE = 200
     }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.Playback_positions
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.FirehoseSuppressed
 import com.calypsan.listenup.server.sync.IdRev
 import com.calypsan.listenup.server.sync.SqlSyncableRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
@@ -17,6 +18,25 @@ import com.calypsan.listenup.server.sync.SyncableSubstrateQueries
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.currentCoroutineContext
+
+/**
+ * One resolved progress row an ABS import intends to persist as a playback position — the batch
+ * counterpart to a single [PlaybackPositionRepository.recordPosition] call's arguments. The importer
+ * resolves every ABS `(user, item)` pair to one of these, then hands the whole list to
+ * [PlaybackPositionRepository.recordAllForImport] so the writes commit in chunked transactions
+ * instead of one read+write commit pair per row.
+ */
+data class ImportPositionWrite(
+    val userId: String,
+    val bookId: String,
+    val positionMs: Long,
+    val lastPlayedAt: Long,
+    val finished: Boolean,
+    val playbackSpeed: Float,
+    val currentChapterId: String?,
+    val startedBookOccurredAt: Long? = null,
+)
 
 /**
  * SQLDelight syncable repository for per-user playback positions (Playback P1).
@@ -269,6 +289,126 @@ class PlaybackPositionRepository(
     }
 
     /**
+     * Batch-persist [rows] for an ABS import — the chunked-transaction counterpart to
+     * [recordPosition]. A per-row [recordPosition] loop costs two commits per row (a `getPosition`
+     * read transaction plus the [upsert] write transaction); a full history import runs tens of
+     * thousands of those. This collapses the burst the same way [BookRepository.resolveOrInsertAll]
+     * does — prepare, then chunked writes — while preserving [recordPosition]'s semantics exactly:
+     *
+     *  1. **PREPARE (no write transaction).** Batch-read the existing positions for every affected
+     *     `(userId, bookId)` (one `IN (…)` read per user via [findByBookIds]), then apply the
+     *     `lastPlayedAt`-wins guard and surrogate-id reuse in memory. A running per-key view folds
+     *     each row onto the one before it, so two import rows for the same `(user, book)` resolve
+     *     exactly as the single-row loop's read-your-writes would (a stale row is dropped, no write).
+     *  2. **WRITE (chunked synchronous transactions).** Process the prepared rows in chunks of
+     *     [PERSIST_CHUNK_SIZE]; each chunk is ONE [suspendTransaction] whose synchronous body calls
+     *     [upsertInOpenTransaction] per row — O(chunks) write transactions, not O(rows). [suppressed]
+     *     is read ONCE in the suspend context and threaded in, exactly as the batched book path does.
+     *  3. **HOOKS (post-commit, sequential).** After the rows commit, fire the SAME per-row
+     *     completion/start cascade [recordPosition] fires after its single upsert — `BookCompleted`
+     *     on a false→true finish, `BookRestarted` (fresh start / re-read) with `startedBookOccurredAt`
+     *     — in prepared order, unreordered within a row. During an import these run under
+     *     [StatsCascadeDeferred], so they are cheap; the authoritative per-user recompute follows.
+     *
+     * Idempotent by inheritance: the `lastPlayedAt`-wins guard drops a re-applied (older-or-equal)
+     * row before it writes or fires a hook, so re-running an import converges without duplicating a
+     * position or a `book_reads` finish. A no-op on an empty [rows].
+     */
+    suspend fun recordAllForImport(rows: List<ImportPositionWrite>) {
+        if (rows.isEmpty()) return
+
+        // PREPARE — batch-read existing positions per user, then resolve the wins-guard + id-reuse
+        // in memory. The running view (seeded from the DB read, updated per prepared write) makes an
+        // intra-batch second row for the same (user, book) see the first, matching read-your-writes.
+        val existingByKey = HashMap<Pair<String, String>, PlaybackPositionSyncPayload?>()
+        rows.groupBy { it.userId }.forEach { (userId, userRows) ->
+            findByBookIds(UserId(userId), userRows.map { BookId(it.bookId) }.distinct())
+                .forEach { existing -> existingByKey[userId to existing.bookId] = existing }
+        }
+
+        val prepared = ArrayList<PreparedPositionWrite>(rows.size)
+        for (row in rows) {
+            val key = row.userId to row.bookId
+            val existing = existingByKey[key]
+            // lastPlayedAt-wins: a stale write is a no-op, exactly as recordPosition returns early.
+            if (existing != null && existing.lastPlayedAt >= row.lastPlayedAt) continue
+
+            val payload =
+                PlaybackPositionSyncPayload(
+                    id = existing?.id ?: Uuid.random().toString(),
+                    bookId = row.bookId,
+                    positionMs = row.positionMs,
+                    lastPlayedAt = row.lastPlayedAt,
+                    finished = row.finished,
+                    playbackSpeed = row.playbackSpeed,
+                    currentChapterId = row.currentChapterId,
+                    revision = 0L,
+                    updatedAt = 0L,
+                    createdAt = 0L,
+                    deletedAt = null,
+                )
+            prepared +=
+                PreparedPositionWrite(
+                    userId = row.userId,
+                    payload = payload,
+                    priorFinished = existing?.finished ?: false,
+                    existedBefore = existing != null,
+                    startedBookOccurredAt = row.startedBookOccurredAt,
+                )
+            existingByKey[key] = payload
+        }
+
+        // WRITE — one suspendTransaction per chunk; upsertInOpenTransaction per row inside it. The
+        // suspend-only FirehoseSuppressed marker is read once here and threaded into every write.
+        val suppressed = currentCoroutineContext()[FirehoseSuppressed.Key] != null
+        for (chunk in prepared.chunked(PERSIST_CHUNK_SIZE)) {
+            suspendTransaction<Unit>(db) {
+                chunk.forEach { row ->
+                    upsertInOpenTransaction(row.payload, suppressed, clientOpId = null, userId = row.userId)
+                }
+            }
+        }
+
+        // HOOKS — the same de-nested, post-commit cascade recordPosition fires, per row, in order.
+        for (row in prepared) {
+            val finished = row.payload.finished
+            val lastPlayedAt = row.payload.lastPlayedAt
+            val bookId = row.payload.bookId
+            if (finished && !row.priorFinished) {
+                activeSessionRepo?.deleteForUserBook(row.userId, bookId)
+                statsRecorder?.record(
+                    StatsEvent.BookCompleted(
+                        userId = row.userId,
+                        bookId = bookId,
+                        occurredAt = Instant.fromEpochMilliseconds(lastPlayedAt),
+                    ),
+                )
+            } else if (!finished) {
+                activeSessionRepo?.startOrRefresh(row.userId, bookId)
+                if (!row.existedBefore) {
+                    statsRecorder?.record(
+                        StatsEvent.BookRestarted(
+                            userId = row.userId,
+                            bookId = bookId,
+                            occurredAt = Instant.fromEpochMilliseconds(row.startedBookOccurredAt ?: lastPlayedAt),
+                            isReread = false,
+                        ),
+                    )
+                } else if (row.priorFinished) {
+                    statsRecorder?.record(
+                        StatsEvent.BookRestarted(
+                            userId = row.userId,
+                            bookId = bookId,
+                            occurredAt = Instant.fromEpochMilliseconds(row.startedBookOccurredAt ?: lastPlayedAt),
+                            isReread = true,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    /**
      * Returns the current position for `(userId, bookId)`, or `null` if the user
      * has never played this book.
      */
@@ -376,12 +516,29 @@ class PlaybackPositionRepository(
             deletedAt = deleted_at,
         )
 
+    /**
+     * A prepared import position write: the resolved [payload] plus the pre-write view the
+     * post-commit hooks decide on ([priorFinished], [existedBefore]) and the imported start date
+     * override. Captured in the PREPARE phase so the WRITE phase stays purely synchronous and the
+     * HOOKS phase fires the exact cascade [recordPosition] would.
+     */
+    private data class PreparedPositionWrite(
+        val userId: String,
+        val payload: PlaybackPositionSyncPayload,
+        val priorFinished: Boolean,
+        val existedBefore: Boolean,
+        val startedBookOccurredAt: Long?,
+    )
+
     private companion object {
         /**
          * Chunk size for `IN (…)` batch reads. Kept under SQLite's default
          * `SQLITE_MAX_VARIABLE_NUMBER` (999) with headroom for any fixed bind params.
          */
         const val SQLITE_IN_CHUNK = 900
+
+        /** Import rows per write transaction — one [suspendTransaction] commits a whole chunk. */
+        const val PERSIST_CHUNK_SIZE = 200
 
         /** SQLite stores booleans as INTEGER 0/1; map at the write boundary. */
         private fun Boolean.toDbLong(): Long = if (this) 1L else 0L

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsDerivation.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsDerivation.kt
@@ -117,8 +117,12 @@ suspend fun deriveUserStats(
     // 5. Streak day-set: union the listening_events days with the days the user advanced progress
     //    (playback_positions.last_played_at) or finished a book (book_reads.finished_at). ABS imports
     //    write mediaProgress → positions + completions but keep session rows (→ listening_events)
-    //    sparsely, so events alone leave false gaps that collapse the streak. Both engines (this and
-    //    the client's StatsRepositoryImpl) union the same primitives so their streaks agree.
+    //    sparsely, so events alone leave false gaps that collapse the streak. The client's
+    //    StatsRepositoryImpl unions the primitives it has locally (positions' last-played + latest
+    //    finishedAt); this derivation additionally counts every historical `book_reads` finish day, so
+    //    the two streaks match except for re-read finish days the client's last-write-wins position
+    //    cannot see. That divergence is accepted: Home shows the locally-derived streak, leaderboards
+    //    show this one (pinned by UserStatsDerivationStreakDivergenceTest).
     val streakDays = ArrayList(listeningDays)
     suspendTransaction(sql) {
         sql.playbackPositionsQueries.selectLastPlayedAtForUser(userId).executeAsList().forEach { ms ->

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
@@ -316,7 +316,7 @@ class ImportApplierTest :
             }
         }
 
-        test("Applying events carry currentItem and a growing sessionsWritten tally") {
+        test("Applying events throttle to a final frame per pass carrying currentItem and the sessionsWritten tally") {
             withSqlDatabase {
                 val dbs = this
                 runTest {
@@ -329,16 +329,19 @@ class ImportApplierTest :
 
                     val applyingEvents =
                         events.filterIsInstance<com.calypsan.listenup.api.dto.imports.ImportEvent.Applying>()
-                    // The fixture has 2 progress rows + 4 book sessions (podcast excluded) = 6 Applying events total.
-                    applyingEvents.size shouldBe 6
+                    // Throttled to N=50: the fixture's 2 progress rows and 4 book sessions (podcast
+                    // excluded) each emit only their final frame — one per pass.
+                    applyingEvents.size shouldBe 2
 
-                    // Every Applying event must carry a non-null currentItem.
-                    applyingEvents.forEach { it.currentItem.shouldNotBeNull() }
+                    // Every emitted frame is a final frame: done == total for its pass, currentItem non-null.
+                    applyingEvents.forEach {
+                        it.currentItem.shouldNotBeNull()
+                        it.done shouldBe it.total
+                    }
 
-                    // The final Applying event emitted during the sessions pass reflects the
-                    // cumulative sessionsWritten count (3 resolvable sessions in the fixture).
-                    val lastApplying = applyingEvents.last()
-                    lastApplying.sessionsWritten shouldBe 3
+                    // The final Applying event of the sessions pass reflects the cumulative
+                    // sessionsWritten count (3 resolvable sessions in the fixture).
+                    applyingEvents.last().sessionsWritten shouldBe 3
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/MetadataImageUploadRouteTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/MetadataImageUploadRouteTest.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.api.dto.auth.RegisterRequest
 import com.calypsan.listenup.api.dto.auth.RegisterResult
 import com.calypsan.listenup.api.dto.auth.UserPermissions
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.io.hashBytesSha256
 import com.calypsan.listenup.server.module
 import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.SeriesRepository
@@ -20,6 +21,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.forms.ChannelProvider
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
 import io.ktor.client.request.get
@@ -35,6 +37,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.testApplication
+import io.ktor.utils.io.ByteReadChannel
 import java.nio.file.Files
 import org.koin.ktor.ext.inject
 
@@ -232,6 +235,113 @@ class MetadataImageUploadRouteTest :
                             )
                         }
                     response.status shouldBe HttpStatusCode.PayloadTooLarge
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+                homeDir.toFile().deleteRecursively()
+            }
+        }
+
+        test("PUT /api/v1/series/{id}/cover oversize part without a declared Content-Length → 413") {
+            val libraryRoot = Files.createTempDirectory("listenup-img-upload-413-nolen-")
+            val homeDir = Files.createTempDirectory("listenup-img-upload-413-nolen-home-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString(), homeDir = homeDir.toString())
+                    application { module() }
+                    val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+                    val token = client.mintRootToken()
+
+                    val seriesRepo by application.inject<SeriesRepository>()
+                    val id = seriesRepo.resolveOrCreate("Oversize Streaming Series")
+
+                    // ChannelProvider with a null size emits the part with NO per-part Content-Length
+                    // header, so the cap must fire during the streaming read, not via the declared length.
+                    val oversize = ByteArray((IMAGE_MAX_BYTES_TEST + 1).toInt()) { 0 }
+                    val response =
+                        client.put("/api/v1/series/${id.value}/cover") {
+                            bearerAuth(token)
+                            setBody(
+                                MultiPartFormDataContent(
+                                    formData {
+                                        append(
+                                            "file",
+                                            ChannelProvider(size = null) { ByteReadChannel(oversize) },
+                                            Headers.build {
+                                                append(HttpHeaders.ContentType, "image/jpeg")
+                                                append(HttpHeaders.ContentDisposition, "filename=\"big.jpg\"")
+                                            },
+                                        )
+                                    },
+                                ),
+                            )
+                        }
+                    response.status shouldBe HttpStatusCode.PayloadTooLarge
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+                homeDir.toFile().deleteRecursively()
+            }
+        }
+
+        test("PUT /api/v1/contributors/{id}/image rejected for a MEMBER → the stored file is cleaned up") {
+            val libraryRoot = Files.createTempDirectory("listenup-img-upload-orphan-contrib-")
+            val homeDir = Files.createTempDirectory("listenup-img-upload-orphan-contrib-home-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString(), homeDir = homeDir.toString())
+                    application { module() }
+                    val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+                    val rootToken = client.mintRootToken()
+                    val (memberToken, memberId) = client.registerMember("orphan-member@x")
+                    client.patch("/api/v1/admin/users/$memberId") {
+                        bearerAuth(rootToken)
+                        contentType(ContentType.Application.Json)
+                        setBody(AdminUserPatch(permissions = UserPermissions(canEdit = false, canShare = true)))
+                    }
+
+                    val contributorRepo by application.inject<ContributorRepository>()
+                    val id = contributorRepo.resolveOrCreate("Orphan Author", sortName = null)
+
+                    val response =
+                        client.put("/api/v1/contributors/${id.value}/image") {
+                            bearerAuth(memberToken)
+                            setBody(jpegPart())
+                        }
+                    response.status shouldBe HttpStatusCode.Forbidden
+
+                    // The upload stores content-addressed BEFORE the canEdit gate rejects; on rejection the
+                    // helper must delete the file so distinct rejected payloads can't accumulate on disk.
+                    val orphan = homeDir.resolve("contributors/${hashBytesSha256(jpeg)}.jpg")
+                    Files.exists(orphan) shouldBe false
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+                homeDir.toFile().deleteRecursively()
+            }
+        }
+
+        test("PUT /api/v1/series/{id}/cover for an unknown series → the stored file is cleaned up") {
+            val libraryRoot = Files.createTempDirectory("listenup-img-upload-orphan-series-")
+            val homeDir = Files.createTempDirectory("listenup-img-upload-orphan-series-home-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString(), homeDir = homeDir.toString())
+                    application { module() }
+                    val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+                    val token = client.mintRootToken()
+
+                    val response =
+                        client.put("/api/v1/series/nonexistent-series-id/cover") {
+                            bearerAuth(token)
+                            setBody(jpegPart())
+                        }
+                    response.status shouldNotBe HttpStatusCode.NoContent
+
+                    // The unknown-id update returns Failure after the file is stored; the helper must
+                    // delete the file rather than leave it orphaned.
+                    val orphan = homeDir.resolve("series/${hashBytesSha256(jpeg)}.jpg")
+                    Files.exists(orphan) shouldBe false
                 }
             } finally {
                 libraryRoot.toFile().deleteRecursively()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/ListeningEventImportBatchTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/ListeningEventImportBatchTest.kt
@@ -1,0 +1,132 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.sync.ListeningEventSyncPayload
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Equivalence characterization for [ListeningEventRepository.upsertAllForImport]: the batched import
+ * write must leave the database in EXACTLY the state a per-row [ListeningEventRepository.upsert] loop
+ * would (the "bulk == N×single" pattern PR #994 used for reindex batching). Both paths run against
+ * separate in-memory databases seeded identically, under a [FixedClock] so timestamps are
+ * deterministic and every read-back field — id, domain fields, and the sync-discipline revision —
+ * compares value-for-value.
+ *
+ * The fixture mixes every branch the append-only upsert + first-insert bookkeeping must preserve: a
+ * fresh insert, a re-upsert of a pre-existing id (revision advances, domain fields frozen), an
+ * intra-batch duplicate id (second occurrence advances sync columns only), and rows for a second
+ * user. The batch groups its writes by user, so the fixture is grouped (all `uA`, then all `uB`) to
+ * keep the revision sequence identical to the ungrouped single loop.
+ */
+class ListeningEventImportBatchTest :
+    FunSpec({
+
+        test("upsertAllForImport leaves the same event rows as an N×single upsert loop") {
+            withSqlDatabase {
+                val singleDbs = this
+                withSqlDatabase {
+                    val batchDbs = this
+                    runTest {
+                        val clock = FixedClock(Instant.fromEpochMilliseconds(1_000_000L))
+                        val single =
+                            ListeningEventRepository(
+                                db = singleDbs.sql,
+                                bus = ChangeBus(),
+                                registry = SyncRegistry(),
+                                clock = clock,
+                            )
+                        val batch =
+                            ListeningEventRepository(
+                                db = batchDbs.sql,
+                                bus = ChangeBus(),
+                                registry = SyncRegistry(),
+                                clock = clock,
+                            )
+
+                        // Identical pre-existing event in both DBs — a re-applied import re-upserts it.
+                        listOf(single to "uA", batch to "uA").forEach { (repo, user) ->
+                            repo.upsert(eventPayload("evt-seed", "book-seed"), clientOpId = null, userId = user)
+                        }
+
+                        val fixture =
+                            listOf(
+                                ImportListeningEventWrite("uA", eventPayload("evt-1", "book-1")),
+                                ImportListeningEventWrite("uA", eventPayload("evt-2", "book-2")),
+                                // Re-upsert of the seeded id — append-only, domain fields must not change.
+                                ImportListeningEventWrite("uA", eventPayload("evt-seed", "book-seed", startPositionMs = 9_999L)),
+                                ImportListeningEventWrite("uA", eventPayload("evt-3", "book-3")),
+                                // Intra-batch duplicate id — the second occurrence is not a first insert.
+                                ImportListeningEventWrite("uA", eventPayload("evt-3", "book-3", startPositionMs = 7_777L)),
+                                ImportListeningEventWrite("uB", eventPayload("evt-4", "book-4")),
+                                ImportListeningEventWrite("uB", eventPayload("evt-5", "book-5")),
+                            )
+
+                        fixture.forEach { write ->
+                            single.upsert(write.event, clientOpId = null, userId = write.userId)
+                        }
+                        batch.upsertAllForImport(fixture)
+
+                        listOf("uA", "uB").forEach { user ->
+                            eventSnapshot(singleDbs.sql, user) shouldBe eventSnapshot(batchDbs.sql, user)
+                        }
+                    }
+                }
+            }
+        }
+    })
+
+/** A user's live listening events projected to a stable, comparable per-row string, sorted by id. */
+private fun eventSnapshot(
+    sql: ListenUpDatabase,
+    userId: String,
+): List<String> =
+    sql.listeningEventsQueries
+        .selectForUserOrderedByEndedAt(userId)
+        .executeAsList()
+        .map {
+            listOf(
+                it.id,
+                it.book_id,
+                it.start_position_ms,
+                it.end_position_ms,
+                it.started_at,
+                it.ended_at,
+                it.playback_speed,
+                it.tz,
+                it.device_label,
+                it.revision,
+                it.created_at,
+                it.updated_at,
+                it.deleted_at,
+            ).joinToString("|")
+        }.sorted()
+
+private fun eventPayload(
+    id: String,
+    bookId: String,
+    startPositionMs: Long = 0L,
+): ListeningEventSyncPayload =
+    ListeningEventSyncPayload(
+        id = id,
+        bookId = bookId,
+        startPositionMs = startPositionMs,
+        endPositionMs = startPositionMs + 60_000L,
+        startedAt = 1_730_000_000_000L,
+        endedAt = 1_730_000_060_000L,
+        playbackSpeed = 1.0f,
+        tz = "Europe/London",
+        deviceLabel = null,
+        revision = 0L,
+        updatedAt = 0L,
+        createdAt = 0L,
+        deletedAt = null,
+    )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/PlaybackPositionImportBatchTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/PlaybackPositionImportBatchTest.kt
@@ -1,0 +1,130 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Equivalence characterization for [PlaybackPositionRepository.recordAllForImport]: the batched
+ * import write must leave the database in EXACTLY the state a per-row [recordPosition] loop would
+ * (the "bulk == N×single" pattern PR #994 used for reindex batching). Both paths run against
+ * separate in-memory databases seeded identically, under a [FixedClock] so timestamps are
+ * deterministic and the read-back rows are comparable (the surrogate `id` is random per row, so it
+ * is the one field excluded from the comparison).
+ *
+ * The fixture mixes every branch the wins-guard + id-reuse must preserve: a fresh insert, a
+ * stale-older row (dropped against a fresher baseline), an intra-batch finished-flip (a second row
+ * for the same book reusing the first's surrogate id), an intra-batch stale duplicate, and rows for
+ * a second user.
+ */
+class PlaybackPositionImportBatchTest :
+    FunSpec({
+
+        test("recordAllForImport leaves the same position rows as an N×single recordPosition loop") {
+            withSqlDatabase {
+                val singleDbs = this
+                withSqlDatabase {
+                    val batchDbs = this
+                    runTest {
+                        val clock = FixedClock(Instant.fromEpochMilliseconds(1_000_000L))
+                        val single =
+                            PlaybackPositionRepository(
+                                db = singleDbs.sql,
+                                bus = ChangeBus(),
+                                registry = SyncRegistry(),
+                                clock = clock,
+                            )
+                        val batch =
+                            PlaybackPositionRepository(
+                                db = batchDbs.sql,
+                                bus = ChangeBus(),
+                                registry = SyncRegistry(),
+                                clock = clock,
+                            )
+
+                        // Identical pre-existing baseline in both DBs — the wins-guard needs a row that
+                        // is already fresher (lastPlayedAt 5000) than an incoming import row.
+                        listOf(single, batch).forEach { repo ->
+                            repo.recordPosition(
+                                userId = "uA",
+                                bookId = "book-stale",
+                                positionMs = 100L,
+                                lastPlayedAt = 5_000L,
+                                finished = false,
+                                playbackSpeed = 1.0f,
+                                currentChapterId = null,
+                            )
+                        }
+
+                        // Note: the position batch writes in fixture order (it groups only for the read),
+                        // so users may interleave freely without diverging revisions from the single loop.
+                        val fixture =
+                            listOf(
+                                ImportPositionWrite("uA", "book-fresh", 200L, 1_000L, false, 1.0f, null),
+                                ImportPositionWrite("uA", "book-stale", 999L, 3_000L, false, 1.0f, null),
+                                ImportPositionWrite("uA", "book-flip", 300L, 1_000L, false, 1.0f, null),
+                                ImportPositionWrite("uA", "book-flip", 400L, 2_000L, true, 1.0f, null),
+                                ImportPositionWrite("uA", "book-dup", 500L, 2_000L, false, 1.0f, null),
+                                ImportPositionWrite("uA", "book-dup", 501L, 1_000L, false, 1.0f, null),
+                                ImportPositionWrite("uB", "book-fresh", 210L, 1_000L, false, 1.0f, null),
+                                ImportPositionWrite("uA", "book-finished", 600L, 9_000L, true, 1.0f, null),
+                                ImportPositionWrite("uA", "book-plain", 700L, 4_000L, false, 1.25f, "chap-2"),
+                                ImportPositionWrite("uB", "book-x", 800L, 7_000L, true, 1.0f, null),
+                            )
+
+                        fixture.forEach { row ->
+                            single.recordPosition(
+                                userId = row.userId,
+                                bookId = row.bookId,
+                                positionMs = row.positionMs,
+                                lastPlayedAt = row.lastPlayedAt,
+                                finished = row.finished,
+                                playbackSpeed = row.playbackSpeed,
+                                currentChapterId = row.currentChapterId,
+                                startedBookOccurredAt = row.startedBookOccurredAt,
+                            )
+                        }
+                        batch.recordAllForImport(fixture)
+
+                        listOf("uA", "uB").forEach { user ->
+                            positionSnapshot(single, user) shouldBe positionSnapshot(batch, user)
+                        }
+                    }
+                }
+            }
+        }
+    })
+
+/**
+ * A user's live positions projected to a stable, comparable form — every domain + sync-discipline
+ * field except the random surrogate `id`, sorted so two databases written in the same order compare
+ * value-for-value.
+ */
+private suspend fun positionSnapshot(
+    repo: PlaybackPositionRepository,
+    userId: String,
+): List<String> =
+    repo
+        .listForUser(UserId(userId), limit = 1_000)
+        .map {
+            listOf(
+                it.bookId,
+                it.positionMs,
+                it.lastPlayedAt,
+                it.finished,
+                it.playbackSpeed,
+                it.currentChapterId,
+                it.revision,
+                it.createdAt,
+                it.updatedAt,
+                it.deletedAt,
+            ).joinToString("|")
+        }.sorted()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/UserStatsDerivationStreakDivergenceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/UserStatsDerivationStreakDivergenceTest.kt
@@ -1,0 +1,89 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the bounded divergence between the two streak engines (Plan 117). The server's
+ * [deriveUserStats] unions the days from its append-only `book_reads` completion log, so a re-read
+ * contributes every historical finish day. The client's `StatsRepositoryImpl` sees only the
+ * last-write-wins `playback_positions.finishedAt`/`last_played_at` — a single latest finish — so it
+ * cannot reconstruct earlier re-read finish days. That divergence is accepted (Home derives locally,
+ * leaderboards from this derivation); this test keeps it a known, named property rather than a bug
+ * the next maintainer chases toward a false parity.
+ */
+class UserStatsDerivationStreakDivergenceTest :
+    FunSpec({
+
+        // 2026-05-22 12:00:00 UTC, and the day after.
+        val day0Ms = 1_779_451_200_000L
+        val dayMs = 86_400_000L
+        val day1Ms = day0Ms + dayMs
+
+        test(
+            "streak counts every book_reads finish day — the client's position-only view cannot see " +
+                "earlier re-read finishes (bounded divergence, see KDoc)",
+        ) {
+            withSqlDatabase {
+                sql.seedTestUser("u1") // UTC home timezone
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("b1")
+
+                // The position is last-write-wins: it holds ONLY the latest finish (day 1). This is
+                // exactly the primitive the client can see locally.
+                sql.transaction {
+                    sql.playbackPositionsQueries.insert(
+                        id = "pos-u1-b1",
+                        user_id = "u1",
+                        book_id = "b1",
+                        position_ms = 3_600_000L,
+                        last_played_at = day1Ms,
+                        finished = 1L,
+                        playback_speed = 1.0,
+                        current_chapter_id = null,
+                        revision = 0L,
+                        created_at = 0L,
+                        updated_at = 0L,
+                        deleted_at = null,
+                        client_op_id = null,
+                    )
+                    // The append-only completion log: the same book finished on TWO different days.
+                    // The earlier finish (day 0) survives here but nowhere the client can reach.
+                    sql.bookReadsQueries.insert(
+                        id = "read-day0",
+                        user_id = "u1",
+                        book_id = "b1",
+                        finished_at = day0Ms,
+                        source = "test",
+                        created_at = 0L,
+                    )
+                    sql.bookReadsQueries.insert(
+                        id = "read-day1",
+                        user_id = "u1",
+                        book_id = "b1",
+                        finished_at = day1Ms,
+                        source = "test",
+                        created_at = 0L,
+                    )
+                }
+
+                runTest {
+                    val stats = deriveUserStats(sql = sql, userId = "u1", nowMs = day1Ms)
+
+                    // Both finish days (day 0 and day 1) are in the streak day-set, so a consecutive
+                    // 2-day streak resolves as-of day 1. The only source of day 0 is `book_reads`:
+                    // the position's last-played/finished timestamp is day 1 alone. A client deriving
+                    // from positions would see just {day 1} → a 1-day streak. That is the divergence.
+                    stats.currentStreakDays shouldBe 2
+                    stats.longestStreakDays shouldBe 2
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/AccessFilteredReadsTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/AccessFilteredReadsTest.kt
@@ -1,0 +1,288 @@
+package com.calypsan.listenup.server.sync
+
+import app.cash.sqldelight.db.SqlDriver
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
+import com.calypsan.listenup.server.io.hashBytesSha256
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Unit-pins the three engine-neutral helpers in [AccessFilteredReads] that back every access-scoped
+ * `pullSince` / `pullByIds` / `digest`:
+ *
+ *  - [selectIdRevAccessFiltered] — SQL assembly + the **security-load-bearing bind order**
+ *    (predicate args, then access-subquery args, then `LIMIT`), the `includeTombstones` OR-clause,
+ *    the `extraWhere = null` unconstrained path, and ordering + limit.
+ *  - [accessFilteredDigest] — the permanent-wire-contract SHA-256 format, pinned to a HARD-CODED
+ *    literal so a helper change breaks the pin.
+ *  - [bindRaw] — the runtime-type dispatch and its loud failure on an unsupported type.
+ *
+ * These properties are covered only transitively by the E2E access suites (allow/deny outcomes);
+ * pinning them here makes a future regression fail at the invariant in milliseconds. Schema is a
+ * test-only `afr_test` table so ids / revisions / tombstones are fully controlled — the helper takes
+ * `table` as a string, so any seeded table exercises the same code path production uses.
+ */
+class AccessFilteredReadsTest :
+    FunSpec({
+
+        test("binds predicate args, then access-subquery args, then limit — in that exact order") {
+            withSqlDatabase {
+                val db = sql
+                val rawDriver = driver
+                rawDriver.createAfrTable()
+                rawDriver.seedAfrRow("a", revision = 10)
+                rawDriver.seedAfrRow("b", revision = 20)
+                rawDriver.seedAfrRow("decoy", revision = 5)
+
+                runTest {
+                    // Correct order: predicate carries [cursor=0, "decoy"], the access subquery
+                    // carries the accessible ids ["a", "b"], limit last.
+                    val correct =
+                        readFiltered(
+                            db,
+                            rawDriver,
+                            predicate = SqlFragment("revision > ? AND id != ?", listOf(0L, "decoy")),
+                            extraWhere = SqlFragment("SELECT ? UNION SELECT ?", listOf("a", "b")),
+                            ascendingByRevision = true,
+                            limit = 50,
+                        )
+                    correct.map { it.id } shouldContainExactly listOf("a", "b")
+
+                    // CONTRAST: swap the predicate and access-subquery arg lists. If the helper bound
+                    // in a different order this swap would be invisible; because the order is fixed,
+                    // the cursor/ids land in the wrong placeholders and the result set changes.
+                    val swapped =
+                        readFiltered(
+                            db,
+                            rawDriver,
+                            predicate = SqlFragment("revision > ? AND id != ?", listOf("a", "b")),
+                            extraWhere = SqlFragment("SELECT ? UNION SELECT ?", listOf(0L, "decoy")),
+                            ascendingByRevision = true,
+                            limit = 50,
+                        )
+                    swapped.map { it.id } shouldNotBe listOf("a", "b")
+                }
+            }
+        }
+
+        test("includeTombstones lets tombstoned rows past the access gate, never live-inaccessible rows") {
+            withSqlDatabase {
+                val db = sql
+                val rawDriver = driver
+                rawDriver.createAfrTable()
+                rawDriver.seedAfrRow("live-accessible", revision = 10)
+                rawDriver.seedAfrRow("live-inaccessible", revision = 20)
+                rawDriver.seedAfrRow("tomb-inaccessible", revision = 30, deletedAt = 999L)
+
+                runTest {
+                    // Access subquery admits only the accessible id.
+                    val access = SqlFragment("SELECT ?", listOf("live-accessible"))
+
+                    val gated =
+                        readFiltered(
+                            db,
+                            rawDriver,
+                            predicate = SqlFragment("revision > ?", listOf(0L)),
+                            extraWhere = access,
+                            includeTombstones = false,
+                        )
+                    gated.map { it.id } shouldContainExactly listOf("live-accessible")
+
+                    val ungatedTombstones =
+                        readFiltered(
+                            db,
+                            rawDriver,
+                            predicate = SqlFragment("revision > ?", listOf(0L)),
+                            extraWhere = access,
+                            includeTombstones = true,
+                        )
+                    ungatedTombstones.map { it.id } shouldContainExactlyInAnyOrder
+                        listOf("live-accessible", "tomb-inaccessible")
+                }
+            }
+        }
+
+        test("extraWhere = null returns every predicate-matched row, tombstones included") {
+            withSqlDatabase {
+                val db = sql
+                val rawDriver = driver
+                rawDriver.createAfrTable()
+                rawDriver.seedAfrRow("a", revision = 10)
+                rawDriver.seedAfrRow("b", revision = 20)
+                rawDriver.seedAfrRow("gone", revision = 30, deletedAt = 999L)
+
+                runTest {
+                    val all =
+                        readFiltered(
+                            db,
+                            rawDriver,
+                            predicate = SqlFragment("revision > ?", listOf(0L)),
+                            extraWhere = null,
+                        )
+                    all.map { it.id } shouldContainExactlyInAnyOrder listOf("a", "b", "gone")
+                }
+            }
+        }
+
+        test("ascendingByRevision orders by revision and limit caps to the lowest revisions") {
+            withSqlDatabase {
+                val db = sql
+                val rawDriver = driver
+                rawDriver.createAfrTable()
+                rawDriver.seedAfrRow("hi", revision = 30)
+                rawDriver.seedAfrRow("lo", revision = 10)
+                rawDriver.seedAfrRow("mid", revision = 20)
+
+                runTest {
+                    val page =
+                        readFiltered(
+                            db,
+                            rawDriver,
+                            predicate = SqlFragment("revision > ?", listOf(0L)),
+                            extraWhere = null,
+                            ascendingByRevision = true,
+                            limit = 2,
+                        )
+                    // The two lowest revisions, ascending.
+                    page.map { it.id } shouldContainExactly listOf("lo", "mid")
+                    page.map { it.revision } shouldContainExactly listOf(10L, 20L)
+                }
+            }
+        }
+
+        test("accessFilteredDigest matches the permanent-wire-contract SHA-256 format") {
+            val rows = listOf(IdRev("a", 1L), IdRev("b", 2L), IdRev("c", 3L))
+
+            val digest = accessFilteredDigest(cursor = 42L, rows = rows)
+
+            // The exact bytes the wire contract hashes: "<id>|<revision>" per row, newline-joined,
+            // trailing newline. Fed through the same helper the production code uses ...
+            val wireBytes = rows.joinToString(separator = "\n") { "${it.id}|${it.revision}" } + "\n"
+            val derived = "sha256:" + hashBytesSha256(wireBytes.encodeToByteArray())
+            digest.hash shouldBe derived
+            // ... AND pinned to a hard-coded literal, so a change to either the join format or the
+            // hash algorithm breaks this assertion even if both sides drift together.
+            digest.hash shouldBe "sha256:2fe596462312a803ea8282038cb14f3c5965cf84d60693081ee95cf77d76e3f2"
+            digest.count shouldBe 3
+            digest.cursor shouldBe 42L
+        }
+
+        test("accessFilteredDigest of an empty slice is count 0, empty hash, cursor passed through") {
+            val digest = accessFilteredDigest(cursor = 7L, rows = emptyList())
+
+            digest.count shouldBe 0
+            digest.hash shouldBe ""
+            digest.cursor shouldBe 7L
+        }
+
+        test("bindRaw dispatches String, Long, Int, Boolean, and Double") {
+            withSqlDatabase {
+                val db = sql
+                val rawDriver = driver
+                rawDriver.createAfrTable()
+                rawDriver.seedAfrRow("a", revision = 10)
+
+                runTest {
+                    // Exercises Long (cursor), Int, Boolean, and Double binders in one predicate;
+                    // String binders are exercised by every id-carrying test above. A broken
+                    // dispatch would throw during binding rather than return the row.
+                    val rows =
+                        readFiltered(
+                            db,
+                            rawDriver,
+                            predicate =
+                                SqlFragment(
+                                    "revision > ? AND ? = ? AND ? = ? AND ? = ?",
+                                    listOf(0L, 7, 7, true, true, 2.5, 2.5),
+                                ),
+                            extraWhere = null,
+                        )
+                    rows.map { it.id } shouldContainExactly listOf("a")
+                }
+            }
+        }
+
+        test("bindRaw fails loud on an unsupported arg type") {
+            withSqlDatabase {
+                val rawDriver = driver
+                rawDriver.createAfrTable()
+
+                shouldThrow<IllegalStateException> {
+                    rawDriver.selectIdRevAccessFiltered(
+                        table = "afr_test",
+                        // A Float matches no bind* binder — bindRaw's else branch errors.
+                        predicate = SqlFragment("revision > ?", listOf(1.5f)),
+                        extraWhere = null,
+                        ascendingByRevision = false,
+                        limit = null,
+                        includeTombstones = false,
+                    )
+                }
+            }
+        }
+    })
+
+/** Creates the test-only `afr_test` table (`id`, `revision`, nullable `deleted_at`) via raw DDL. */
+private fun SqlDriver.createAfrTable() {
+    execute(
+        identifier = null,
+        sql =
+            """
+            CREATE TABLE IF NOT EXISTS afr_test (
+                id TEXT NOT NULL PRIMARY KEY,
+                revision INTEGER NOT NULL,
+                deleted_at INTEGER
+            )
+            """.trimIndent(),
+        parameters = 0,
+    )
+}
+
+/** Seeds one `afr_test` row; a non-null [deletedAt] makes it a tombstone. */
+private fun SqlDriver.seedAfrRow(
+    id: String,
+    revision: Long,
+    deletedAt: Long? = null,
+) {
+    execute(
+        identifier = null,
+        sql = "INSERT INTO afr_test (id, revision, deleted_at) VALUES (?, ?, ?)",
+        parameters = 3,
+        binders = {
+            bindString(0, id)
+            bindLong(1, revision)
+            bindLong(2, deletedAt)
+        },
+    )
+}
+
+/**
+ * Runs [selectIdRevAccessFiltered] over `afr_test` inside a real [suspendTransaction] — mirroring
+ * production, where the helper is only ever called from inside an aggregate's open transaction.
+ */
+private suspend fun readFiltered(
+    db: ListenUpDatabase,
+    driver: SqlDriver,
+    predicate: SqlFragment,
+    extraWhere: SqlFragment?,
+    ascendingByRevision: Boolean = false,
+    limit: Int? = null,
+    includeTombstones: Boolean = false,
+): List<IdRev> =
+    suspendTransaction(db) {
+        driver.selectIdRevAccessFiltered(
+            table = "afr_test",
+            predicate = predicate,
+            extraWhere = extraWhere,
+            ascendingByRevision = ascendingByRevision,
+            limit = limit,
+            includeTombstones = includeTombstones,
+        )
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
@@ -168,7 +168,9 @@ internal interface PlaybackPositionDao {
      * time (falling back to [PlaybackPositionEntity.updatedAt] for legacy rows with no
      * [PlaybackPositionEntity.lastPlayedAt]) unioned with its finish time. Feeds the client streak so
      * imported mediaProgress — which advances a position without ever producing a listening_events
-     * session — still counts as a listening day, matching the server's streak day-set (Finding #20).
+     * session — still counts as a listening day, approximating the server's streak day-set
+     * (Finding #20) — the server additionally counts historical re-read finish days from its
+     * append-only book_reads log, which this last-write-wins position view cannot reconstruct.
      */
     @Query(
         "SELECT COALESCE(lastPlayedAt, updatedAt) FROM playback_positions WHERE deletedAt IS NULL " +

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImpl.kt
@@ -43,8 +43,11 @@ private const val MIDNIGHT_PULSE_DELAY_MS = 60_000L
  * finish day) in the device timezone — real-time, tz-correct, and self-correcting on idle days via
  * the [midnightPulse] ticker. Including the playback days is what makes imported listening visible:
  * ABS mediaProgress lands as playback_positions with no matching listening_events session, so an
- * events-only streak shows false gaps (Finding #20). The server's [StatsRepositoryImpl] twin unions
- * the same primitives so the two engines agree. This deliberately diverges from the old
+ * events-only streak shows false gaps (Finding #20). The server's twin derivation unions the same
+ * local primitives this one does AND additionally counts every historical finish day from its
+ * append-only `book_reads` log, so the two streaks match except for re-read finish days: this client
+ * only holds the latest finish in its last-write-wins position, so earlier re-read finishes are
+ * invisible here. That divergence is accepted. This deliberately diverges from the old
  * server-authoritative streak math: the server's `user_stats` still drives the cross-user
  * leaderboard (a different consumer); the Home display derives locally for immediate reactivity.
  *

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataLocalDbIsInternalRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataLocalDbIsInternalRule.kt
@@ -53,9 +53,18 @@ class DataLocalDbIsInternalRule :
                         "/data/local/db/" in it.path && it.isTopLevel &&
                             it.hasPublicOrDefaultModifier
                     }.map { it.name }
-            // Top-level typealiases are not gated here: Konsist 0.17.3's KoTypeAliasDeclaration
-            // lacks `isTopLevel`, so it can't share the predicate above.
-            val offenders = (classes + interfaces + objects + properties + functions).filterNot { it in allowList }
+            // Typealiases are top-level-only by Kotlin language rule, so no isTopLevel filter is
+            // needed — path + visibility is the complete predicate (Konsist 0.17.3's
+            // KoTypeAliasDeclaration lacks isTopLevel, which is why the shared predicate above
+            // can't be reused verbatim).
+            val typealiases =
+                scope
+                    .typeAliases
+                    .filter { "/data/local/db/" in it.path && it.hasPublicOrDefaultModifier }
+                    .map { it.name }
+            val offenders =
+                (classes + interfaces + objects + properties + functions + typealiases)
+                    .filterNot { it in allowList }
             offenders.shouldBeEmpty()
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataSyncIsInternalRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataSyncIsInternalRule.kt
@@ -10,9 +10,10 @@ import io.kotest.matchers.collections.shouldBeEmpty
  * it from every client export path (iOS framework, Swift Export, JS, R8). A new public
  * declaration here would silently re-bloat the export, so make it a build failure.
  *
- * Gates top-level classes, interfaces, objects, properties, and functions. Top-level
- * typealiases are not gated: Konsist 0.17.3's `KoTypeAliasDeclaration` lacks `isTopLevel`,
- * so it cannot be filtered with the same predicate as the other declaration kinds.
+ * Gates top-level classes, interfaces, objects, properties, functions, and typealiases.
+ * Typealiases are top-level-only by Kotlin language rule, so a path + visibility predicate
+ * gates them completely — the `isTopLevel` filter the other kinds use is unnecessary (and
+ * Konsist 0.17.3's `KoTypeAliasDeclaration` lacks it anyway).
  */
 class DataSyncIsInternalRule :
     FunSpec({
@@ -51,10 +52,18 @@ class DataSyncIsInternalRule :
                     .functions()
                     .filter { "/data/sync/" in it.path && it.isTopLevel && it.hasPublicOrDefaultModifier }
                     .map { it.name }
-            // Top-level typealiases are not gated here: Konsist 0.17.3's KoTypeAliasDeclaration
-            // lacks `isTopLevel`, so it can't share the predicate above.
+            // Typealiases are top-level-only by Kotlin language rule, so no isTopLevel filter is
+            // needed — path + visibility is the complete predicate (Konsist 0.17.3's
+            // KoTypeAliasDeclaration lacks isTopLevel, which is why the shared predicate above
+            // can't be reused verbatim).
+            val typealiases =
+                scope
+                    .typeAliases
+                    .filter { "/data/sync/" in it.path && it.hasPublicOrDefaultModifier }
+                    .map { it.name }
             val offenders =
-                (classes + interfaces + objects + properties + functions).filterNot { it in allowList }
+                (classes + interfaces + objects + properties + functions + typealiases)
+                    .filterNot { it in allowList }
             offenders.shouldBeEmpty()
         }
     })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaBaselineDriftTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaBaselineDriftTest.kt
@@ -1,0 +1,106 @@
+package com.calypsan.listenup.client.data.local.db.migration
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.room.useReaderConnection
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Drift guard for the squashed Room v1 schema baseline.
+ *
+ * PR #1060 collapsed the client migration chain to a single committed export,
+ * `schemas/…/ListenUpDatabase/1.json`, which is the authoritative baseline the
+ * first real v1 → v2 migration will be written against. Nothing else asserts
+ * that this JSON still matches the compiled `@Entity` set: Room's Gradle plugin
+ * *re-exports* the JSON on build instead of failing, so an entity edit that
+ * forgets to commit the regenerated `1.json` — or a JSON edit that doesn't
+ * match the entities — is invisible to CI.
+ *
+ * This test closes that gap. It creates a database whose schema (and stored
+ * identity hash) comes from the committed `1.json`, then reopens the same file
+ * with the real compiled [ListenUpDatabase] WITHOUT the destructive fallback the
+ * platform modules use. Room validates the stored identity hash against the
+ * compiled schema on first connection use, so any drift between the JSON and the
+ * entities fails this test loudly.
+ *
+ * When the first real schema change lands (v1 → v2), this evolves into the
+ * migration-and-validate suite the [SchemaMigrationSmokeTest] KDoc promises; the
+ * temp-file + reopen pattern here is the scaffold for it.
+ */
+class SchemaBaselineDriftTest :
+    FunSpec({
+        test("compiled ListenUpDatabase opens a database created from the committed 1.json baseline") {
+            // Resolve the exported-schema directory the same way the shared helper does:
+            // Gradle runs :sharedLogic:jvmTest with the module root as working directory,
+            // so `schemas` points at the Room-plugin export folder.
+            val schemaDirectory: Path = Paths.get("schemas").toAbsolutePath()
+            check(Files.isDirectory(schemaDirectory)) {
+                "Room schemas directory not found at $schemaDirectory. " +
+                    "Run `./gradlew :sharedLogic:kspKotlinJvm` to regenerate `sharedLogic/schemas/`."
+            }
+
+            // We must hold the temp-file path ourselves so the same file can be reopened
+            // with the real database class, so we construct MigrationTestHelper directly
+            // rather than through createMigrationTestHelper() (which hides its temp file).
+            val databasePath: Path = Files.createTempFile("listenup-schema-baseline-test", ".db")
+            Files.deleteIfExists(databasePath)
+            databasePath.toFile().deleteOnExit()
+
+            val helper =
+                MigrationTestHelper(
+                    schemaDirectoryPath = schemaDirectory,
+                    databasePath = databasePath,
+                    driver = BundledSQLiteDriver(),
+                    databaseClass = ListenUpDatabase::class,
+                )
+
+            try {
+                // Create the schema in `databasePath` FROM the committed 1.json (this also
+                // writes the JSON's identity hash into room_master_table), then release it.
+                helper.createDatabase(version = 1).close()
+
+                // Reopen the SAME file with the real compiled database — deliberately WITHOUT
+                // fallbackToDestructiveMigration, so Room's identity-hash validation runs
+                // instead of silently nuking on mismatch.
+                val database =
+                    Room
+                        .databaseBuilder<ListenUpDatabase>(name = databasePath.toString())
+                        .setDriver(BundledSQLiteDriver())
+                        .build()
+
+                try {
+                    withClue(
+                        "committed 1.json no longer matches the compiled @Entity schema — " +
+                            "regenerate sharedLogic/schemas/…/ListenUpDatabase/1.json " +
+                            "(the build re-exports it) and commit the diff",
+                    ) {
+                        // First connection use forces Room to open and validate the stored
+                        // identity hash against the compiled schema.
+                        runBlocking {
+                            database.useReaderConnection { }
+                        }
+                    }
+                } finally {
+                    database.close()
+                }
+            } finally {
+                // Close the helper's managed connections. `finished(Description?)` is a
+                // protected method on a final class, so reflection is the only path in —
+                // the shared wrapper's close() does the same.
+                val finished =
+                    MigrationTestHelper::class.java.getDeclaredMethod(
+                        "finished",
+                        org.junit.runner.Description::class.java,
+                    )
+                finished.isAccessible = true
+                finished.invoke(helper, null)
+            }
+        }
+    })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Tests for [BrowseTreeProvider.getChildren].
@@ -52,7 +51,6 @@ import org.robolectric.annotation.Config
  * of [BrowseTreeProvider.getChildren] without naming any `:shared` DAO or `@Entity` type.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class BrowseTreeProviderTest {
     // ──────────────────────────────────────────────────────────────────────────────
     // ROOT branch

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbarSemanticsTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbarSemanticsTest.kt
@@ -15,7 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Verifies that [AlphabetScrollbar] exposes the accessibility semantics required for
@@ -29,7 +28,6 @@ import org.robolectric.annotation.Config
  * JUnit4 + Robolectric (consistent with [WavySeekBarTest]).
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class AlphabetScrollbarSemanticsTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/ListenUpScaffoldTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/ListenUpScaffoldTest.kt
@@ -15,10 +15,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class ListenUpScaffoldTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/haptics/ProvideHapticsTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/haptics/ProvideHapticsTest.kt
@@ -8,10 +8,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class ProvideHapticsTest {
     @get:Rule val composeRule = createComposeRule()
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactoryRoutingTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactoryRoutingTest.kt
@@ -10,7 +10,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Routing coverage for [ListenUpWorkerFactory.createWorker].
@@ -38,7 +37,6 @@ import org.robolectric.annotation.Config
  * [Class.getDeclaredField] does not traverse the class hierarchy.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class ListenUpWorkerFactoryRoutingTest {
     private lateinit var context: Context
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/admin/ManagementSectionTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/admin/ManagementSectionTest.kt
@@ -10,7 +10,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Verifies the admin Management section surfaces a Library Settings tile and that
@@ -18,13 +17,11 @@ import org.robolectric.annotation.Config
  * makes the (previously unreachable) [LibrarySettingsScreen] reachable.
  *
  * JUnit4 + Robolectric — the canonical shape for Compose UI tests in this module
- * (a `createComposeRule()` rule requires JUnit4). `@Config(sdk = [35])` pins
- * Robolectric to the highest SDK its release ships, and supplies the real Android
- * resource environment so `stringResource` resolves the packaged English strings
- * (per [com.calypsan.listenup.client.presentation.error.AppErrorLocalizationTest]).
+ * (a `createComposeRule()` rule requires JUnit4). Robolectric supplies the real
+ * Android resource environment so `stringResource` resolves the packaged English
+ * strings (per [com.calypsan.listenup.client.presentation.error.AppErrorLocalizationTest]).
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class ManagementSectionTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScanWarningTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScanWarningTest.kt
@@ -6,7 +6,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Verifies the book-detail scan-warning advisory banner appears only when the
@@ -20,7 +19,6 @@ import org.robolectric.annotation.Config
  * JUnit4 + Robolectric (consistent with [com.calypsan.listenup.client.features.nowplaying.WavySeekBarTest]).
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class BookDetailScanWarningTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/bookdetail/DetailsSectionTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/bookdetail/DetailsSectionTest.kt
@@ -10,10 +10,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class DetailsSectionTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingProgressRecompositionTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingProgressRecompositionTest.kt
@@ -13,7 +13,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Proves the structural fix for the 4 Hz now-playing recomposition storm: the fast-changing
@@ -33,7 +32,6 @@ import org.robolectric.annotation.Config
  * JUnit4 + Robolectric (consistent with [WavySeekBarTest]).
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class NowPlayingProgressRecompositionTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/WavySeekBarTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/WavySeekBarTest.kt
@@ -15,7 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import kotlin.math.abs
@@ -36,7 +35,6 @@ import kotlin.math.abs
  * JUnit4 + Robolectric (consistent with [PhaseABoundarySuiteTest]).
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class WavySeekBarTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/navigation/PhaseABoundarySuiteTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/navigation/PhaseABoundarySuiteTest.kt
@@ -13,7 +13,6 @@ import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicReference
@@ -25,13 +24,8 @@ import java.util.concurrent.atomic.AtomicReference
  *  - process-death back-stack survival via `rememberNavBackStack`.
  *  - every `NavDisplay` invocation site installs both standard entry decorators.
  *  - per-entry ViewModel scoping (VM-per-entry + cleared-on-pop).
- *
- * `@Config(sdk = [35])` pins Robolectric to the highest SDK its 4.15.1 release
- * supports; the project's compileSdk = 37 outpaces Robolectric's currently-shipped
- * SDK shadows. Bump in lockstep when Robolectric ships an SDK 37 build.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class PhaseABoundarySuiteTest {
     @get:Rule val composeRule = createComposeRule()
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AudiobookNotificationProviderTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AudiobookNotificationProviderTest.kt
@@ -12,7 +12,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 import io.kotest.matchers.shouldBe
 
 /**
@@ -35,7 +34,6 @@ import io.kotest.matchers.shouldBe
  * in a unit test.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 @OptIn(UnstableApi::class)
 class AudiobookNotificationProviderTest {
     private lateinit var provider: AudiobookNotificationProvider

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
@@ -61,7 +61,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -91,7 +90,6 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  * as a gap in the coverage report.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 @OptIn(UnstableApi::class)
 class PlaybackErrorHandlerTest {
     // ── classify — Network ────────────────────────────────────────────────────

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/presentation/error/AppErrorLocalizationTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/presentation/error/AppErrorLocalizationTest.kt
@@ -10,7 +10,6 @@ import listenup.composeapp.generated.resources.error_not_found
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
@@ -23,11 +22,9 @@ import io.kotest.matchers.shouldNotBe
  * Robolectric supplies a real Android resource environment (default locale `en`), so `getString`
  * reads the packaged `error_*` strings exactly as production code does. JUnit4 +
  * [RobolectricTestRunner] follows the precedent set by
- * [com.calypsan.listenup.client.deeplink.DeepLinkParserTest]. `@Config(sdk = [35])` pins
- * Robolectric to the highest SDK its 4.15.1 release ships, since the module's compileSdk is newer.
+ * [com.calypsan.listenup.client.deeplink.DeepLinkParserTest].
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class AppErrorLocalizationTest {
     @Test
     fun `resourceKey lowercases the error code with the error_ prefix`() {

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/shortcuts/ListenUpShortcutManagerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/shortcuts/ListenUpShortcutManagerTest.kt
@@ -19,7 +19,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 
 /**
  * Tests for [ListenUpShortcutManager.calculateSampleSize] and
@@ -36,7 +35,6 @@ import org.robolectric.annotation.Config
  * their "Visible for testing" KDoc marks the intent.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
 class ListenUpShortcutManagerTest {
     private val manager: ListenUpShortcutManager by lazy {
         ListenUpShortcutManager(

--- a/sharedUI/src/androidHostTest/resources/robolectric.properties
+++ b/sharedUI/src/androidHostTest/resources/robolectric.properties
@@ -1,0 +1,5 @@
+# Central Robolectric config for every :sharedUI host test.
+# sdk pins the shadow SDK to the highest release Robolectric ships shadows for;
+# the project's compileSdk (37) outpaces it. Bump this ONE line (and delete this
+# sentence's apology) when Robolectric ships SDK-37 shadows.
+sdk=35

--- a/sharedUI/src/commonMain/composeResources/files/aboutlibraries.json
+++ b/sharedUI/src/commonMain/composeResources/files/aboutlibraries.json
@@ -5802,7 +5802,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-core-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "core",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5826,7 +5826,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-client-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-client",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5850,7 +5850,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-core-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-core",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5874,7 +5874,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-client-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-ktor-client",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5898,7 +5898,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-core-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-ktor-core",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5922,7 +5922,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-logging-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-logging",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5946,7 +5946,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-core-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-serialization-core",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5970,7 +5970,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-json-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-serialization-json",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5994,7 +5994,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-utils-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "utils",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",


### PR DESCRIPTION
## Batch 8 audit — combined PR

Eleven independent Batch 8 audit plans (2026-07-08 full-repo deep audit), each implemented TDD-first in its own isolated worktree and self-verified, then assembled onto one branch so CI runs once instead of eleven times.

**Gate:** the full Linux lane is green on the combined branch — `verifyLocal` (spotless, detekt, verifyStrings/verifyLicenses, contract/sharedLogic/server JVM tests, Android + shared host tests, build-logic) + `:server:compileKotlinLinuxX64 :server:linuxX64Test` (native) + `:androidApp:assembleDebug` → **BUILD SUCCESSFUL in 29m**. The two iOS plans (119, 120) were gated on a Mac (Xcode 26.5): `swiftlint` clean (0 errors) and `xcodebuild build-for-testing` SUCCEEDED; iOS test *execution* is left to CI's `Test (iOS)` lane, since local execution is blocked by a pre-existing simulator host-bootstrap crash (confirmed content-independent — an unrelated suite crashes identically). No commonMain public types or export-surface entries changed, so the Swift-export baseline is unaffected.

### Plans included
- **109** — metadata-image upload: enforce the 10 MiB cap *during* the multipart read (was buffered-then-checked, unbounded when no Content-Length) and delete the content-addressed file on downstream rejection so rejected uploads can't orphan on disk. (3 tests)
- **111** — Room v1 schema baseline drift guard: opens the compiled DB against the committed `1.json` without destructive fallback, so an un-regenerated schema fails loudly. (drift-proven by hand)
- **112** — ABS-import apply batching: chunked transactions + throttled progress frames replacing the per-row commit storm. Live single-row `recordPosition`/`upsert` paths are byte-identical; the batch seams are purely additive. (2 equivalence test files)
- **113** — export-surface Konsist rules now gate public `typealias`es, closing the bypass in the DataSync / DataLocalDb internal rules. (canary-proven)
- **114** — CI supply-chain: dependency-review gate + dependency-graph submission, SHA-pinned `gradle/actions/setup-gradle` (v6.2.0), and folded the two lint steps into one invocation.
- **115** — docs: pipe/exit-code foot-gun warning in `client/CLAUDE.md`, README native-header prerequisite, and dropped the parked desktop run line.
- **116** — AccessFilteredReads unit tests: bind order (security-load-bearing), digest identity, tombstone clause. (8 tests)
- **117** — streak "twin" comments corrected to the real bounded-divergence contract (the server counts historical re-read finish days the client's last-write-wins view can't see) + a pinning test.
- **118** — centralized the Robolectric SDK pin into `robolectric.properties`, removing 15 per-file `@Config(sdk=[35])` annotations and stale version comments.
- **119** *(iOS)* — extracted a generic `NamedEntityPickerSheet` (DesignSystem) and collapsed the four near-identical collection/shelf picker sheets into thin wrappers (≈480 → 129 lines); the inline-create block now lives in exactly one place.
- **120** *(iOS)* — added an `AdminInboxObserver` phase/row-mapping Swift Testing suite (the one untested observer), via a `nonisolated static func phase(from:)` seam mirroring the backup observers.

### Incidental — please review
- **OSS license manifest refresh** (`sharedUI/.../aboutlibraries.json`): the kotlinx-rpc dev-channel bumped `0.11.0-grpc-188 → -189` under AboutLibraries. This drift **pre-exists on `main`** — `:sharedUI:verifyLicenses` fails identically on a clean main checkout — and is unrelated to the plans; it's regenerated here only so the gate is green. Drop this commit if you refresh the manifest separately.

### Caveats
- **109**: the failure-branch delete uses `mustExist = false`; if a concurrent *successful* upload of identical bytes shares the content hash, this could remove a still-referenced file — acceptable because content-addressed metadata images are re-uploadable.
- **114**: three checks are only verifiable on real CI — (a) `dependency-review` needs Settings → Security → Dependency graph enabled; (b) `dependency-submission` may fail resolving iOS/native targets on ubuntu; (c) confirm the first post-merge `main` run submits the graph.

### Not in this PR
- **110** (workspace `CLAUDE.md` rewrite) and **121** (CollectionServiceImpl split design) — done, but non-repo per project convention.

That completes all 13 Batch 8 plans (11 code plans here; 110 and 121 are non-repo docs).
