### PR TITLE
♻️ refactor(shared): registry-driven access delta — fix activity-grant latency, compile-enforce delta participation

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -555,8 +555,10 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
      * result is therefore ⊆ what an unbounded `since = 0` catch-up would return — no new surface.
      *
      * [matchColumn] is a closed, code-controlled column name (`"id"` for the books/collections
-     * targeted fetch, `"collection_id"` for the collection-books-by-collection fetch), never user
-     * input — the same trust level as [rootTableName]. [matchValues] are bound positionally.
+     * targeted fetch, `"collection_id"` for the collection-books-by-collection fetch, `"book_id"` for
+     * the activities-by-book fetch), never user input — the same trust level as [rootTableName]. The
+     * sync route allowlists `book_id` to domains that actually have that column. [matchValues] are
+     * bound positionally.
      *
      * Tombstones are included ([selectIdRevAccessFiltered]'s `includeTombstones = true`), matching
      * the filtered [pullSince] catch-up contract: a deletion the client missed is delivered so it

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -54,11 +54,17 @@ private const val ACTIVITIES_DOMAIN = "activities"
 private const val COLLECTION_SHARES_DOMAIN = "collection_shares"
 private const val COLLECTION_BOOKS_DOMAIN = "collection_books"
 
-// Cap on a single targeted `?ids=` / `?collectionIds=` fetch (the scoped AccessChanged delta).
-// The client chunks larger scopes into ≤ this many ids per request; the server rejects an
+// Cap on a single targeted `?ids=` / `?collectionIds=` / `?bookIds=` fetch (the scoped AccessChanged
+// delta). The client chunks larger scopes into ≤ this many ids per request; the server rejects an
 // over-cap request rather than silently truncating — a truncated response would look to the
 // client like "these ids are no longer accessible" and wrongly tombstone them.
 private const val MAX_TARGETED_IDS = 100
+
+// Domains whose rows carry a `book_id` column, so a targeted `?bookIds=` fetch (the activities half
+// of the scoped AccessChanged delta) can match on it. `matchColumn` is code-controlled, never user
+// input — and honoring `?bookIds=` for a domain WITHOUT a `book_id` column would be a SQL error — so
+// a `?bookIds=` request naming any other domain is a 400, not a query against a phantom column.
+private val BOOK_ID_MATCH_DOMAINS = setOf(ACTIVITIES_DOMAIN)
 
 // Admin-only domain: a row carries an absolute server filesystem path (operator disk
 // topology), which members must never see. Unlike the per-row book/collection gates, this
@@ -270,10 +276,12 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
         val typedRepo = repo as SyncableRepo<Any>
 
         // Targeted scoped-delta fetch: `?ids=` matches the row's own id (books, collections),
-        // `?collectionIds=` matches its `collection_id` (collection_books). Both are access-
-        // filtered, capped, and un-paged. Absent both, fall back to the `?since=` catch-up page.
+        // `?collectionIds=` matches its `collection_id` (collection_books), `?bookIds=` matches its
+        // `book_id` (activities only — the allowlist keeps `matchColumn` sound). All three are access-
+        // filtered, capped, and un-paged. Absent all three, fall back to the `?since=` catch-up page.
         val idsParam = call.request.queryParameters["ids"]
         val collectionIdsParam = call.request.queryParameters["collectionIds"]
+        val bookIdsParam = call.request.queryParameters["bookIds"]
 
         val page: Page<Any> =
             when {
@@ -288,6 +296,23 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
                         typedRepo.pullByIds(
                             userId,
                             matchColumn = "collection_id",
+                            matchValues = ids,
+                            extraWhere = extraWhere,
+                        )
+                    } ?: return@get call.respond(HttpStatusCode.BadRequest, "too many ids (max $MAX_TARGETED_IDS)")
+                }
+
+                bookIdsParam != null -> {
+                    if (domainName !in BOOK_ID_MATCH_DOMAINS) {
+                        return@get call.respond(
+                            HttpStatusCode.BadRequest,
+                            "bookIds fetch not supported for domain: $domainName",
+                        )
+                    }
+                    parseTargetedIds(bookIdsParam)?.let { ids ->
+                        typedRepo.pullByIds(
+                            userId,
+                            matchColumn = "book_id",
                             matchValues = ids,
                             extraWhere = extraWhere,
                         )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityCatchUpAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityCatchUpAccessTest.kt
@@ -85,6 +85,40 @@ class ActivityCatchUpAccessTest :
             }
         }
 
+        test("activities pullByIds(book_id) returns the accessible book's activity, never the private-book row") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestBook("public-book")
+                sql.seedTestBook("private-book")
+                val f = fixture()
+                runTest {
+                    f.makePublic("public-book", memberId = "member")
+                    f.collectionRepo.upsert(aclCollection("private-col", owner = "stranger"))
+                    f.collectionBookRepo.upsert(aclMembership("private-col", "private-book"))
+
+                    f.recorder.record(userId = "alice", type = ActivityType.FINISHED_BOOK, bookId = "public-book")
+                    f.recorder.record(userId = "alice", type = ActivityType.FINISHED_BOOK, bookId = "private-book")
+
+                    // The scoped AccessChanged delta fetches activities by book_id; the same access
+                    // filter the route applies must still hide the private-book row.
+                    val extra = activitiesAccessFilter(f.policy, "member", UserRole.MEMBER)
+                    val bookIds =
+                        f.activityRepo
+                            .pullByIds(
+                                "member",
+                                matchColumn = "book_id",
+                                matchValues = listOf("public-book", "private-book"),
+                                extraWhere = extra,
+                            ).items
+                            .map { it.bookId }
+
+                    bookIds shouldContain "public-book"
+                    bookIds shouldNotContain "private-book"
+                }
+            }
+        }
+
         test("activities digest is access-scoped per user (member sees 2, admin sees all 3)") {
             withSqlDatabase {
                 sql.seedTestLibraryAndFolder()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncCatchUpRouteTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncCatchUpRouteTest.kt
@@ -56,4 +56,22 @@ class SyncCatchUpRouteTest :
                 response.status shouldBe HttpStatusCode.BadRequest
             }
         }
+
+        test("a ?bookIds= fetch on a domain without a book_id column returns 400 (allowlist keeps matchColumn sound)") {
+            withTestApplication {
+                // `tags` has no `book_id` column, so honoring the fetch would be a SQL error — the
+                // per-domain allowlist rejects it before the repo read.
+                val response = client.get("/api/v1/sync/tags?bookIds=b1,b2")
+                response.status shouldBe HttpStatusCode.BadRequest
+            }
+        }
+
+        test("a ?bookIds= fetch over the 100-id cap returns 400 on activities") {
+            withTestApplication(playbackEvents = true) {
+                // activities is on the allowlist, so this reaches the id-cap guard.
+                val ids = (1..101).joinToString(",") { "book-$it" }
+                val response = client.get("/api/v1/sync/activities?bookIds=$ids")
+                response.status shouldBe HttpStatusCode.BadRequest
+            }
+        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
@@ -239,6 +239,10 @@ internal fun withTestApplication(
                         single { sqlDb }
                         single { bus }
                         single { registry }
+                        // The sync route lazily injects BookAccessPolicy to access-filter gated domains
+                        // (books/activities/collections). Ungated tag tests never resolve it; a request to
+                        // a gated domain (e.g. activities ?bookIds=) does, so provide it here.
+                        single { BookAccessPolicy(sqlDb, driver) }
                         single(createdAtStart = true) { tagRepo }
                         if (userScopedRepo != null) single(createdAtStart = true) { userScopedRepo }
                         if (playbackPositionRepo != null) single(createdAtStart = true) { playbackPositionRepo }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
@@ -100,21 +100,15 @@ internal interface ActivityDao {
     )
 
     /**
-     * Soft-delete every live activity whose gating book is gone or tombstoned — the activities half of
-     * the books access-gate `afterPrune` cascade. A scoped `AccessChanged` delta only fetches the
-     * `books`/`collections`/`collection_books` domains, so an activity whose book was just revoked
-     * would otherwise linger live locally while the server's access-filtered activities digest no
-     * longer counts it → permanent digest drift. Tombstoning it here (soft, like [tombstoneByIds] —
-     * `activities` is a cursored domain, so a hard delete would itself drift the digest) converges the
-     * two sides; a re-grant re-delivers the row live via catch-up. Book-less activities (`bookId IS
-     * NULL`) are always visible and are left untouched.
+     * The ids of every live activity whose gating book is in [ids] — the candidate set the scoped
+     * `AccessChanged` delta prunes for the `activities` domain. A requested book whose activity does
+     * not come back accessible is tombstoned via `pruneWithin`; an activity gating on a book OUTSIDE
+     * the delta scope is never returned here, so it can never be a prune candidate. Book-less
+     * activities (`bookId IS NULL`) are always visible and never match. Callers chunk [ids] under the
+     * SQLite bind-variable ceiling.
      */
-    @Query(
-        "UPDATE activities SET deletedAt = :now " +
-            "WHERE deletedAt IS NULL AND bookId IS NOT NULL " +
-            "AND bookId NOT IN (SELECT id FROM books WHERE deletedAt IS NULL)",
-    )
-    suspend fun tombstoneWhereBookNotLive(now: Long)
+    @Query("SELECT id FROM activities WHERE deletedAt IS NULL AND bookId IN (:ids)")
+    suspend fun liveIdsForBooks(ids: List<String>): List<String>
 
     /**
      * Insert or update an activity entity.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessFilteredSyncHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessFilteredSyncHandler.kt
@@ -1,5 +1,7 @@
 package com.calypsan.listenup.client.data.sync
 
+import com.calypsan.listenup.client.data.sync.domains.AccessDeltaPolicy
+
 /**
  * Capability marker for sync handlers whose domain is access-gated on the server.
  *
@@ -15,6 +17,13 @@ package com.calypsan.listenup.client.data.sync
  * [com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry.accessFilteredHandlers].
  */
 internal interface AccessFilteredSyncHandler {
+    /**
+     * This domain's declared participation in the scoped `AccessChanged` delta, plumbed from its
+     * [com.calypsan.listenup.client.data.sync.domains.AccessGate]. The reconciler reads it to decide
+     * whether — and how — to fetch and prune this domain for a targeted change.
+     */
+    val deltaPolicy: AccessDeltaPolicy
+
     /**
      * The ids of every live (non-tombstoned) local row in this domain. For composite-key
      * domains (e.g. `collection_books`) the id is the synthetic `"$collectionId:$bookId"`

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessReconciler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessReconciler.kt
@@ -2,6 +2,8 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.AccessScope
+import com.calypsan.listenup.client.data.sync.domains.AccessDeltaPolicy
+import com.calypsan.listenup.client.data.sync.domains.ScopeAxis
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import io.github.oshai.kotlinlogging.KotlinLogging
 
@@ -19,15 +21,17 @@ private val logger = KotlinLogging.logger {}
  *    [CatchUp.catchUpTransient] (server-access-filtered, so it returns exactly what the caller may
  *    now see) and [AccessFilteredSyncHandler.pruneTo] evicts every locally-live row not in that set.
  *
- *  - **Delta** ([reconcile] with a scope): O(changed) instead of O(library). Only the named
- *    entities are fetched — access-filtered — and pruned within the scope
- *    ([AccessFilteredSyncHandler.pruneWithin]), so a row the server returns is upserted and one it
- *    asked about but did not return is tombstoned, while a live row OUTSIDE the scope is never
- *    touched. Domains run in dependency order `collections → collection_books → books`; the books
- *    prune's `afterPrune` cascade drops readership + Continue-Listening positions for the now-dead
- *    books. `collection_shares` is revision-cursored and rides the coarse anchor / live tail;
- *    `activities` gains ride the digest backstop and losses ride the books `afterPrune` cascade —
- *    neither is fetched here.
+ *  - **Delta** ([reconcile] with a scope): O(changed) instead of O(library). Which domains the delta
+ *    fetches is REGISTRY-DRIVEN, not hardcoded: it iterates every access-gated handler and reads its
+ *    [AccessDeltaPolicy] (declared on the domain's gate, no default), so a new gated domain cannot be
+ *    forgotten here. Each [AccessDeltaPolicy.Targeted] domain is fetched — access-filtered — and
+ *    pruned within its scope ([AccessFilteredSyncHandler.pruneWithin]), so a row the server returns is
+ *    upserted and one it asked about but did not return is tombstoned, while a live row OUTSIDE the
+ *    scope is never touched. Domains run in the policy's declared `order` (`collections →
+ *    collection_books → books → activities`); the books prune's `afterPrune` cascade drops readership
+ *    + Continue-Listening positions for the now-dead books, and `activities` self-prunes against its
+ *    own book-scoped candidate set. `collection_shares` is [AccessDeltaPolicy.LiveTailOnly] — it is
+ *    revision-cursored and rides the coarse anchor / live tail, so the delta never fetches it.
  *
  * A delta pass ends in exactly the state a coarse pass restricted to the scope would: same upserts,
  * same tombstones, no leak. A per-domain failure never strands the others — the pass continues — but
@@ -72,10 +76,12 @@ internal class AccessReconciler(
     }
 
     /**
-     * Scoped delta: fetch + prune only the named entities, in dependency order so a collection's
-     * membership is reconciled before the books it gates. Each step is independent — a failure logs
-     * and moves on — but its ids are collected into the failed remainder so the engine can re-queue
-     * exactly that portion; the coarse anchor backstops any gap after the one retry.
+     * Scoped delta: iterate every access-gated handler, keep those whose [AccessDeltaPolicy] is
+     * [AccessDeltaPolicy.Targeted], and run them in the declared `order` so a collection's membership
+     * is reconciled before the books it gates. Each domain fetches over its axis's id list and prunes
+     * its own candidate set; a failure logs and moves on, folding that axis's ids into the failed
+     * remainder so the engine can re-queue exactly that portion. The coarse anchor backstops any gap
+     * after the one retry.
      */
     private suspend fun reconcileDelta(scope: AccessScope): AccessReconcileOutcome {
         logger.info {
@@ -84,86 +90,45 @@ internal class AccessReconciler(
         val ts = now()
         val failedCollectionIds = mutableSetOf<String>()
         val failedBookIds = mutableSetOf<String>()
-        if (!fetchAndPruneById("collections", scope.collectionIds, ts)) failedCollectionIds += scope.collectionIds
-        if (!fetchAndPruneCollectionBooks(scope, ts)) failedCollectionIds += scope.collectionIds
-        if (!fetchAndPruneById("books", scope.bookIds, ts)) failedBookIds += scope.bookIds
+
+        val targeted =
+            registry
+                .accessFilteredHandlers()
+                .mapNotNull { handler ->
+                    ((handler as AccessFilteredSyncHandler).deltaPolicy as? AccessDeltaPolicy.Targeted)
+                        ?.let { handler to it }
+                }.sortedBy { (_, policy) -> policy.order }
+
+        for ((handler, policy) in targeted) {
+            val ids =
+                when (policy.axis) {
+                    ScopeAxis.Collections -> scope.collectionIds
+                    ScopeAxis.Books -> scope.bookIds
+                }
+            if (ids.isEmpty()) continue
+
+            @Suppress("UNCHECKED_CAST")
+            val typed = handler as SyncDomainHandler<Any>
+            when (val returned = catchUp.fetchTransient(typed, policy.fetchFor(ids))) {
+                is AppResult.Success -> {
+                    (handler as AccessFilteredSyncHandler).pruneWithin(policy.candidatesFor(ids), returned.data, ts)
+                }
+
+                is AppResult.Failure -> {
+                    logger.warn { "AccessChanged delta fetch failed for ${handler.domainName}: ${returned.error.code}" }
+                    when (policy.axis) {
+                        ScopeAxis.Collections -> failedCollectionIds += scope.collectionIds
+                        ScopeAxis.Books -> failedBookIds += scope.bookIds
+                    }
+                }
+            }
+        }
+
         return if (failedCollectionIds.isEmpty() && failedBookIds.isEmpty()) {
             AccessReconcileOutcome.Clean
         } else {
             AccessReconcileOutcome.Requeue(AccessScope(failedCollectionIds.toList(), failedBookIds.toList()))
         }
-    }
-
-    /**
-     * Delta one own-id-keyed domain (`books` / `collections`): fetch [ids] access-filtered, upsert
-     * what comes back, and [AccessFilteredSyncHandler.pruneWithin] the candidate set [ids] against
-     * the returned accessible subset — so an id asked about but not returned is tombstoned, and
-     * every row outside [ids] is left untouched. Returns `true` when the step completed (including
-     * the no-op paths: empty ids or a non-access-gated handler), `false` only on a fetch failure.
-     */
-    private suspend fun fetchAndPruneById(
-        domainName: String,
-        ids: List<String>,
-        ts: Long,
-    ): Boolean {
-        if (ids.isEmpty()) return true
-        val handler = accessGatedHandler(domainName) ?: return true
-
-        @Suppress("UNCHECKED_CAST")
-        val typed = handler as SyncDomainHandler<Any>
-        return when (val returned = catchUp.fetchTransient(typed, TargetedFetch.ByIds(ids))) {
-            is AppResult.Success -> {
-                (handler as AccessFilteredSyncHandler).pruneWithin(ids.toSet(), returned.data, ts)
-                true
-            }
-
-            is AppResult.Failure -> {
-                logger.warn { "AccessChanged delta fetch failed for $domainName: ${returned.error.code}" }
-                false
-            }
-        }
-    }
-
-    /**
-     * Delta the `collection_books` domain by the scope's collections: fetch every membership of the
-     * affected collections (access-filtered), then prune the LOCAL memberships of just those
-     * collections against what came back. The candidate set is the local live membership rows whose
-     * `collectionId` is in scope — derived from the synthetic `"$collectionId:$bookId"` wire id — so
-     * a membership in a collection the delta never named can never be tombstoned.
-     */
-    private suspend fun fetchAndPruneCollectionBooks(
-        scope: AccessScope,
-        ts: Long,
-    ): Boolean {
-        if (scope.collectionIds.isEmpty()) return true
-        val handler = accessGatedHandler("collection_books") ?: return true
-        val gated = handler as AccessFilteredSyncHandler
-
-        @Suppress("UNCHECKED_CAST")
-        val typed = handler as SyncDomainHandler<Any>
-        val scopeCols = scope.collectionIds.toSet()
-        val candidateIds = gated.localLiveIds().filterTo(mutableSetOf()) { it.substringBefore(':') in scopeCols }
-        return when (val returned = catchUp.fetchTransient(typed, TargetedFetch.ByCollectionIds(scope.collectionIds))) {
-            is AppResult.Success -> {
-                gated.pruneWithin(candidateIds, returned.data, ts)
-                true
-            }
-
-            is AppResult.Failure -> {
-                logger.warn { "AccessChanged delta fetch failed for collection_books: ${returned.error.code}" }
-                false
-            }
-        }
-    }
-
-    /** The registered handler for [domainName] if it is an [AccessFilteredSyncHandler]; else null (logged). */
-    private fun accessGatedHandler(domainName: String): SyncDomainHandler<*>? {
-        val handler = registry.lookup(domainName)
-        if (handler !is AccessFilteredSyncHandler) {
-            logger.warn { "AccessChanged delta: '$domainName' is not an access-gated handler; skipping" }
-            return null
-        }
-        return handler
     }
 }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CatchUp.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CatchUp.kt
@@ -65,4 +65,15 @@ internal sealed interface TargetedFetch {
     data class ByCollectionIds(
         val collectionIds: List<String>,
     ) : TargetedFetch
+
+    /**
+     * Match rows by their `book_id` — activities, to pull the activity rows gating on a set of books.
+     *
+     * Version skew: a new client sending `?bookIds=` to an OLD server (no `book_id` branch) hits the
+     * server's `else`/`400` path, which surfaces as an [AppResult.Failure] → one bounded delta requeue
+     * → the digest backstop. Same eventual convergence as before this fetch existed; acceptable.
+     */
+    data class ByBookIds(
+        val bookIds: List<String>,
+    ) : TargetedFetch
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncCatchUpClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncCatchUpClient.kt
@@ -173,6 +173,7 @@ internal class SyncCatchUpClient(
                 when (fetch) {
                     is TargetedFetch.ByIds -> "ids" to fetch.ids
                     is TargetedFetch.ByCollectionIds -> "collectionIds" to fetch.collectionIds
+                    is TargetedFetch.ByBookIds -> "bookIds" to fetch.bookIds
                 }
             val returnedIds = mutableSetOf<String>()
             for (chunk in values.distinct().chunked(TARGETED_FETCH_LIMIT)) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/AccessGate.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/AccessGate.kt
@@ -1,5 +1,7 @@
 package com.calypsan.listenup.client.data.sync.domains
 
+import com.calypsan.listenup.client.data.sync.TargetedFetch
+
 /**
  * Access-gating hooks for domains whose server `pullSince` is filtered to the
  * caller's accessible set. Presence of a gate on a [MirroredDomain] makes its
@@ -12,27 +14,63 @@ package com.calypsan.listenup.client.data.sync.domains
  * [tombstoneByIds] + [afterPrune] — so every gate is two DAO method references (plus
  * an optional cascade), and the bind-variable ceiling is closed uniformly for all of
  * them, not latently per domain.
+ *
+ * [delta] is REQUIRED with no default: every access-gated domain must declare how it
+ * participates in the scoped `AccessChanged` delta, so a new gated domain cannot compile
+ * without a decision — the delta path can never silently forget a domain the way a
+ * hardcoded fetch list could.
  */
 internal class AccessGate(
     /** Ids of every live (non-tombstoned) local row, in wire-id form. */
     val liveIds: suspend () -> List<String>,
     /** Tombstone the given live local rows by wire id (called per bounded chunk). */
     val tombstoneByIds: suspend (ids: List<String>, now: Long) -> Unit,
+    /** How this domain participates in the scoped `AccessChanged` delta — see [AccessDeltaPolicy]. */
+    val delta: AccessDeltaPolicy,
     /**
      * Optional cascade run once after ANY prune (coarse or scoped) completes — the sweep for pure
      * caches that have no sync domain of their own (e.g. books' readership + Continue-Listening
      * positions). Safe to run in both paths because these rows are re-fetched, never digested.
      */
     val afterPrune: suspend () -> Unit = {},
-    /**
-     * Optional cascade run once after a SCOPED prune ([AccessFilteredSyncHandler.pruneWithin]) only,
-     * receiving that prune's tombstone timestamp. Reserved for dependents that ARE their own
-     * access-gated sync domain — e.g. `activities`, which the coarse path re-derives authoritatively
-     * via its own prune, but a scoped delta never fetches. Running this in the coarse path would
-     * double-tombstone against that domain's own re-derivation, so it fires on the delta path alone.
-     */
-    val afterScopedPrune: suspend (now: Long) -> Unit = {},
 )
+
+/**
+ * How a domain participates in the SCOPED `AccessChanged` delta — the per-gate declaration the
+ * reconciler reads to decide whether, and how, to fetch and prune that domain for a targeted change.
+ *
+ * The reconciler iterates every access-gated handler and branches on this value alone, so adding a
+ * new gated domain forces a delta decision at compile time (the gate's [AccessGate.delta] has no
+ * default). The whole-library coarse path is unaffected — it always sweeps every gated domain.
+ */
+internal sealed interface AccessDeltaPolicy {
+    /**
+     * The domain IS fetched in the delta pass: pull the rows named by [fetchFor] over the [axis] id
+     * list, then [AccessFilteredSyncHandler.pruneWithin] the [candidatesFor] set against what came
+     * back. [order] fixes dependency order (a collection's membership reconciles before the books it
+     * gates); a requested id that does not come back is tombstoned, one outside [candidatesFor] never.
+     */
+    class Targeted(
+        val order: Int,
+        val axis: ScopeAxis,
+        val fetchFor: (ids: List<String>) -> TargetedFetch,
+        val candidatesFor: suspend (ids: List<String>) -> Set<String>,
+    ) : AccessDeltaPolicy
+
+    /**
+     * The domain is NOT fetched in the delta pass: its rows are revision-cursored and converge via
+     * the live SSE tail, with the coarse anchor as the frame-loss backstop. [rationale] records why.
+     */
+    class LiveTailOnly(
+        val rationale: String,
+    ) : AccessDeltaPolicy
+}
+
+/** Which [com.calypsan.listenup.api.sync.AccessScope] id list keys a [AccessDeltaPolicy.Targeted] fetch. */
+internal enum class ScopeAxis {
+    Collections,
+    Books,
+}
 
 /**
  * SQLite's compiled bind-variable ceiling is ~32,766; the access-gate prune chunks the

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ActivitiesDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ActivitiesDomain.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.sync.ActivitySyncPayload
 import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.ActivityEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.sync.TargetedFetch
 
 /**
  * The `activities` domain: the social activity feed as a cursored mirror. Server-authored and
@@ -22,9 +23,14 @@ import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
  * **Access-gated** (like `books`): the server filters catch-up/digest to the caller's accessible set
  * (a row is visible iff its book is accessible or it has no book). The [AccessGate] makes the composed
  * handler an `AccessFilteredSyncHandler`, so a book deletion / share revocation — which drops the
- * activity out of the member's accessible set — prunes it locally via `AccessChanged` (and via the
- * Phase-0 digest-drift backstop for a dropped frame) instead of stranding it visible and re-pulling
- * the whole table on every reconcile edge.
+ * activity out of the member's accessible set — prunes it locally via `AccessChanged`.
+ *
+ * **Delta participation:** the domain is fetched on the `books` axis by the changed books' ids
+ * ([TargetedFetch.ByBookIds]) — a GRANT re-delivers the now-accessible activity live in the same
+ * delta pass, and a REVOKE tombstones the requested-but-not-returned rows via `pruneWithin`. The
+ * candidate set is exactly the local live activities gating on the scoped books, so an activity on a
+ * book outside the scope is never a prune candidate. The coarse anchor and digest backstop cover any
+ * dropped frame.
  */
 internal fun activitiesDomain(database: ListenUpDatabase): MirroredDomain<ActivitySyncPayload> =
     MirroredDomain(
@@ -41,6 +47,19 @@ internal fun activitiesDomain(database: ListenUpDatabase): MirroredDomain<Activi
             AccessGate(
                 liveIds = database.activityDao()::liveIds,
                 tombstoneByIds = database.activityDao()::tombstoneByIds,
+                delta =
+                    AccessDeltaPolicy.Targeted(
+                        order = 3,
+                        axis = ScopeAxis.Books,
+                        fetchFor = { TargetedFetch.ByBookIds(it) },
+                        // The local live activities gating on the scoped books — chunked under the
+                        // bind-variable ceiling because a scope can name more books than SQLite holds.
+                        candidatesFor = { bookIds ->
+                            bookIds
+                                .chunked(SQLITE_IN_CHUNK)
+                                .flatMapTo(mutableSetOf()) { database.activityDao().liveIdsForBooks(it) }
+                        },
+                    ),
             ),
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.BookEntityMapper
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.documents.DocumentStorage
+import com.calypsan.listenup.client.data.sync.TargetedFetch
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.Timestamp
@@ -78,6 +79,14 @@ internal fun booksDomain(
             AccessGate(
                 liveIds = database.bookDao()::liveIds,
                 tombstoneByIds = database.bookDao()::tombstoneByIds,
+                // A book is fetched by its own id; every requested id is a prune candidate.
+                delta =
+                    AccessDeltaPolicy.Targeted(
+                        order = 2,
+                        axis = ScopeAxis.Books,
+                        fetchFor = { TargetedFetch.ByIds(it) },
+                        candidatesFor = { it.toSet() },
+                    ),
                 // Readership rows AND Continue-Listening positions follow their book's liveness:
                 // once the prune tombstones the revoked/removed books, drop the reader rows and the
                 // playback_positions that now point at a non-live book (so the book leaves Continue
@@ -86,11 +95,6 @@ internal fun booksDomain(
                     database.bookReadershipDao().deleteWhereBookNotLive()
                     database.playbackPositionDao().deleteWhereBookNotLive()
                 },
-                // Delta-only: a scoped AccessChanged never fetches the activities domain, so an
-                // activity gating on a now-revoked book must be tombstoned here for the access-filtered
-                // activities digest to converge. Soft-delete — activities is a cursored domain. The
-                // coarse path re-derives activities via their own prune, so this must NOT run there.
-                afterScopedPrune = { now -> database.activityDao().tombstoneWhereBookNotLive(now) },
             ),
     )
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionBooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionBooksDomain.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
 import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.CollectionBookEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.sync.TargetedFetch
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -46,6 +47,23 @@ internal fun collectionBooksDomain(database: ListenUpDatabase): MirroredDomain<C
             AccessGate(
                 liveIds = database.collectionBookDao()::liveSyntheticIds,
                 tombstoneByIds = database.collectionBookDao()::tombstoneByIds,
+                // Fetched by the scope's collection ids. The candidate set is the local live
+                // membership rows whose collection is in scope — derived from the synthetic
+                // `"$collectionId:$bookId"` wire id — so a membership in a collection the delta never
+                // named can never be tombstoned.
+                delta =
+                    AccessDeltaPolicy.Targeted(
+                        order = 1,
+                        axis = ScopeAxis.Collections,
+                        fetchFor = { TargetedFetch.ByCollectionIds(it) },
+                        candidatesFor = { collectionIds ->
+                            val scopeCols = collectionIds.toSet()
+                            database
+                                .collectionBookDao()
+                                .liveSyntheticIds()
+                                .filterTo(mutableSetOf()) { it.substringBefore(':') in scopeCols }
+                        },
+                    ),
             ),
     )
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionSharesDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionSharesDomain.kt
@@ -35,6 +35,11 @@ internal fun collectionSharesDomain(database: ListenUpDatabase): MirroredDomain<
             AccessGate(
                 liveIds = database.collectionShareDao()::liveIds,
                 tombstoneByIds = database.collectionShareDao()::tombstoneByIds,
+                delta =
+                    AccessDeltaPolicy.LiveTailOnly(
+                        "share rows are revision-cursored and ride the live tail; " +
+                            "the coarse anchor backstops frame loss",
+                    ),
             ),
     )
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionsDomain.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.sync.CollectionSyncPayload
 import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.CollectionEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.sync.TargetedFetch
 
 /**
  * The `collections` domain (Collections — Room v24): server-wins apply, soft-delete
@@ -31,6 +32,14 @@ internal fun collectionsDomain(database: ListenUpDatabase): MirroredDomain<Colle
             AccessGate(
                 liveIds = database.collectionDao()::liveIds,
                 tombstoneByIds = database.collectionDao()::tombstoneByIds,
+                // A collection is fetched by its own id; every requested id is a prune candidate.
+                delta =
+                    AccessDeltaPolicy.Targeted(
+                        order = 0,
+                        axis = ScopeAxis.Collections,
+                        fetchFor = { TargetedFetch.ByIds(it) },
+                        candidatesFor = { it.toSet() },
+                    ),
             ),
     )
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ComposedSyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ComposedSyncDomainHandler.kt
@@ -155,6 +155,8 @@ internal class AccessFilteredComposedSyncDomainHandler<T : SyncPayload>(
     registry: ClientSyncDomainRegistry,
 ) : ComposedSyncDomainHandler<T>(domain, transactionRunner, registry),
     AccessFilteredSyncHandler {
+    override val deltaPolicy: AccessDeltaPolicy = gate.delta
+
     override suspend fun localLiveIds(): Set<String> = gate.liveIds().toSet()
 
     override suspend fun pruneTo(
@@ -182,10 +184,6 @@ internal class AccessFilteredComposedSyncDomainHandler<T : SyncPayload>(
         val doomed = (candidateIds intersect gate.liveIds().toSet()) - accessibleIds
         doomed.chunked(SQLITE_IN_CHUNK).forEach { chunk -> gate.tombstoneByIds(chunk, now) }
         gate.afterPrune()
-        // Scoped-only: cascade to dependents that ARE their own access-gated domain (activities). The
-        // coarse path re-derives them via their own prune, but a delta never fetches them — so this
-        // fires here, not in pruneTo, to keep the activities digest converging after a scoped delta.
-        gate.afterScopedPrune(now)
     }
 }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncReconcilerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncReconcilerTest.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.sync.DomainDigest
 import com.calypsan.listenup.api.sync.SyncEvent
 import com.calypsan.listenup.api.sync.Tag
 import com.calypsan.listenup.client.data.local.db.SyncCursorDao
+import com.calypsan.listenup.client.data.sync.domains.AccessDeltaPolicy
 import com.calypsan.listenup.client.data.local.db.SyncCursorEntity
 import com.calypsan.listenup.api.result.AppResult
 import dev.mokkery.answering.returns
@@ -253,6 +254,7 @@ private fun accessGatedHandler(
     object : SyncDomainHandler<Tag>, AccessFilteredSyncHandler {
         override val domainName = name
         override val payloadSerializer: KSerializer<Tag> = Tag.serializer()
+        override val deltaPolicy: AccessDeltaPolicy = AccessDeltaPolicy.LiveTailOnly("test fake: delta path unused here")
 
         override fun syncId(item: Tag): String = item.id
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
@@ -297,7 +297,9 @@ class AccessChangedReconcileTest :
 
                 harness.engine.handleAccessChanged(AccessScope(collectionIds = listOf("c1"), bookIds = listOf("b1")))
 
-                harness.fakeCatchUp.fetches.map { it.domain }.toSet() shouldBe expected
+                harness.fakeCatchUp.fetches
+                    .map { it.domain }
+                    .toSet() shouldBe expected
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
@@ -12,6 +12,9 @@ import com.calypsan.listenup.client.data.local.db.BookEntityMapper
 import com.calypsan.listenup.client.data.local.db.BookReadershipEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.api.sync.SyncPayload
+import com.calypsan.listenup.api.sync.Tombstoned
+import com.calypsan.listenup.client.data.sync.domains.AccessDeltaPolicy
 import com.calypsan.listenup.client.data.sync.domains.RefreshedDomainRouter
 import com.calypsan.listenup.client.data.sync.domains.activitiesDomain
 import com.calypsan.listenup.client.data.sync.domains.booksDomain
@@ -259,7 +262,7 @@ class AccessChangedReconcileTest :
 
         // ---- Scoped delta path -------------------------------------------------------------------
 
-        test("delta: fetches exactly the scoped ids — collections + collection_books + books, in dependency order") {
+        test("delta: fetches exactly the scoped ids — collections → collection_books → books → activities, in dependency order") {
             withReconcileEngine { harness, _, _ ->
                 // A returned set per domain so the prune step is a no-op; we assert only the fetch shape.
                 harness.fakeCatchUp.returnedByDomain["collections"] = setOf("c1")
@@ -272,9 +275,49 @@ class AccessChangedReconcileTest :
                         RecordedFetch("collections", TargetedFetch.ByIds(listOf("c1"))),
                         RecordedFetch("collection_books", TargetedFetch.ByCollectionIds(listOf("c1"))),
                         RecordedFetch("books", TargetedFetch.ByIds(listOf("b1"))),
+                        RecordedFetch("activities", TargetedFetch.ByBookIds(listOf("b1"))),
                     )
                 // A scoped delta never re-derives the whole library — the coarse sweep must not run.
                 harness.fakeCatchUp.coarseCalls.shouldBeEmpty()
+            }
+        }
+
+        test("delta drift-killer: the fetched domains equal the registry's Targeted set — a new gated domain auto-enters") {
+            withReconcileEngine { harness, _, _ ->
+                // The expectation is DERIVED from the registry, not hand-copied: every access-gated
+                // handler whose declared delta policy is Targeted must be fetched by a full-scope delta.
+                // A future gated domain declaring Targeted therefore auto-enters this assertion — the
+                // delta path can never silently forget it.
+                val expected =
+                    harness.registry
+                        .accessFilteredHandlers()
+                        .filter { (it as AccessFilteredSyncHandler).deltaPolicy is AccessDeltaPolicy.Targeted }
+                        .map { it.domainName }
+                        .toSet()
+
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = listOf("c1"), bookIds = listOf("b1")))
+
+                harness.fakeCatchUp.fetches.map { it.domain }.toSet() shouldBe expected
+            }
+        }
+
+        test("delta GRANT convergence: a newly-accessible activity goes LIVE within the delta pass (the bug)") {
+            withReconcileEngine { harness, db, _ ->
+                // No local activity is seeded — the grant is brand new to this client.
+                db.activityDao().liveIds().shouldBeEmpty()
+
+                // The book was just granted; the server's access-filtered fetch returns its activity row.
+                // The fake applies these payloads through the real handler (exactly like the production
+                // fetchTransient), so a returned-and-applied row lands LIVE in Room.
+                harness.fakeCatchUp.fetchPayloadsByDomain["activities"] =
+                    listOf(activityPayload("aGranted", bookId = "bGranted"))
+
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = emptyList(), bookIds = listOf("bGranted")))
+
+                // Convergence happened in the delta pass itself — no digest/coarse backstop was needed.
+                harness.fakeCatchUp.coarseCalls.shouldBeEmpty()
+                db.activityDao().getById("aGranted")!!.deletedAt shouldBe null
+                db.activityDao().liveIds() shouldBe listOf("aGranted")
             }
         }
 
@@ -348,28 +391,25 @@ class AccessChangedReconcileTest :
             }
         }
 
-        test("delta: revoking a scoped book cascades to activities — its activity is tombstoned, a book-less one survives") {
+        test("delta: revoking a scoped book self-prunes its activity via pruneWithin — book-less + out-of-scope survive") {
             withReconcileEngine { harness, db, _ ->
-                val books =
-                    booksDomain(
-                        database = db,
-                        mapper = BookEntityMapper(),
-                        imageStorage = stubImageStorage(),
-                    ).toHandler(transactionRunner = RoomTransactionRunner(db), registry = ClientSyncDomainRegistry())
                 val activities = activitiesDomain(db).toHandler(RoomTransactionRunner(db), ClientSyncDomainRegistry())
-                books.onCatchUpItem(bookPayload("b2"), isTombstone = false)
                 activities.onCatchUpItem(activityPayload("a2", bookId = "b2"), isTombstone = false)
-                // A book-less activity has no gating book, so the cascade must leave it live.
+                // A book-less activity has no gating book, so it is never a prune candidate.
                 activities.onCatchUpItem(activityPayload("aNoBook", bookId = null), isTombstone = false)
+                // An activity on a book OUTSIDE the delta scope must never be a candidate either.
+                activities.onCatchUpItem(activityPayload("aOther", bookId = "bOther"), isTombstone = false)
 
-                // b2 revoked → the delta only touches books, but the books afterPrune cascade must
-                // tombstone a2 so the access-filtered activities digest converges (the delta never
-                // fetches the activities domain).
-                harness.fakeCatchUp.returnedByDomain["books"] = emptySet()
+                // b2 revoked → the delta fetches activities by book_id and gets nothing back for b2, so
+                // the requested-but-not-returned a2 is tombstoned by pruneWithin against the b2-scoped
+                // candidate set. This is the new mechanism — no books afterPrune cascade is involved.
+                harness.fakeCatchUp.returnedByDomain["activities"] = emptySet()
                 harness.engine.handleAccessChanged(AccessScope(collectionIds = emptyList(), bookIds = listOf("b2")))
 
                 db.activityDao().getById("a2")!!.deletedAt shouldNotBe null
                 db.activityDao().getById("aNoBook")!!.deletedAt shouldBe null
+                // The load-bearing substrate assertion: an out-of-scope book's activity is untouched.
+                db.activityDao().getById("aOther")!!.deletedAt shouldBe null
             }
         }
 
@@ -450,10 +490,13 @@ class AccessChangedReconcileTest :
                     leader.join()
                 }
 
-                // Exactly two passes: the leader's [ba], then ONE follow-up over the union {bb, bc}.
-                harness.fakeCatchUp.fetches shouldHaveSize 2
-                harness.fakeCatchUp.fetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("ba"))
-                (harness.fakeCatchUp.fetches[1].fetch as TargetedFetch.ByIds).ids.toSet() shouldBe setOf("bb", "bc")
+                // Exactly two books passes (the coalescer's unit of work): the leader's [ba], then ONE
+                // follow-up over the union {bb, bc}. Activities rides the same Books axis, so it is
+                // filtered out here — the coalescing invariant is about the axis, not the domain count.
+                val bookFetches = harness.fakeCatchUp.fetches.filter { it.domain == "books" }
+                bookFetches shouldHaveSize 2
+                bookFetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("ba"))
+                (bookFetches[1].fetch as TargetedFetch.ByIds).ids.toSet() shouldBe setOf("bb", "bc")
             }
         }
 
@@ -473,10 +516,11 @@ class AccessChangedReconcileTest :
                     leader.join()
                 }
 
-                // Only the leader's single delta fetch ran; the follow-up was a coarse 5-domain sweep,
-                // NOT a targeted fetch of bb.
-                harness.fakeCatchUp.fetches shouldHaveSize 1
-                harness.fakeCatchUp.fetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("ba"))
+                // Only the leader's single delta books fetch ran; the follow-up was a coarse 5-domain
+                // sweep, NOT a targeted fetch of bb. (Activities shares the Books axis; filter to books.)
+                val bookFetches = harness.fakeCatchUp.fetches.filter { it.domain == "books" }
+                bookFetches shouldHaveSize 1
+                bookFetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("ba"))
                 harness.fakeCatchUp.coarseCalls shouldHaveSize 5
             }
         }
@@ -499,8 +543,9 @@ class AccessChangedReconcileTest :
                 harness.fakeCatchUp.fetches.clear()
                 harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("bb")))
 
-                harness.fakeCatchUp.fetches shouldHaveSize 1
-                harness.fakeCatchUp.fetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("bb"))
+                val bookFetches = harness.fakeCatchUp.fetches.filter { it.domain == "books" }
+                bookFetches shouldHaveSize 1
+                bookFetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("bb"))
             }
         }
 
@@ -522,9 +567,10 @@ class AccessChangedReconcileTest :
                 harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
                 harness.engine.handleAccessChanged(AccessScope(collectionIds = emptyList(), bookIds = listOf("b1", "b2")))
 
-                // Two attempts were made over the same scope...
-                harness.fakeCatchUp.fetches shouldHaveSize 2
-                (harness.fakeCatchUp.fetches[1].fetch as TargetedFetch.ByIds).ids.toSet() shouldBe setOf("b1", "b2")
+                // Two books attempts were made over the same scope (activities rides the same axis)...
+                val bookFetches = harness.fakeCatchUp.fetches.filter { it.domain == "books" }
+                bookFetches shouldHaveSize 2
+                (bookFetches[1].fetch as TargetedFetch.ByIds).ids.toSet() shouldBe setOf("b1", "b2")
                 // ...and the retry's prune actually evicted the revoked book.
                 db.bookDao().getById(BookId("b1"))!!.deletedAt shouldBe null
                 db.bookDao().getById(BookId("b2"))!!.deletedAt shouldNotBe null
@@ -561,29 +607,32 @@ class AccessChangedReconcileTest :
                 // Every attempt fails: leader + exactly one retry, then give up (reconnect backstop owns it).
                 harness.fakeCatchUp.failNextByDomain["books"] = 10
                 harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("b1")))
-                harness.fakeCatchUp.fetches shouldHaveSize 2
+                harness.fakeCatchUp.fetches.count { it.domain == "books" } shouldBe 2
 
                 // A fresh frame gets a fresh leader with a fresh retry budget — nothing is wedged.
                 harness.fakeCatchUp.fetches.clear()
                 harness.fakeCatchUp.failNextByDomain.clear()
                 harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
                 harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("b1")))
-                harness.fakeCatchUp.fetches shouldHaveSize 1
+                harness.fakeCatchUp.fetches.count { it.domain == "books" } shouldBe 1
             }
         }
 
-        test("delta requeue: only the FAILED domain's ids are refetched — the succeeded domain is not") {
+        test("delta requeue: only the FAILED axis's ids are refetched — the succeeded axis is not") {
             withReconcileEngine { harness, _, _ ->
-                // collections succeeds; books fails once then succeeds.
+                // The Collections axis (collections + collection_books) succeeds; the Books axis fails
+                // once via books then succeeds. The remainder is folded per AXIS, so only the Books-axis
+                // ids requeue — the succeeded Collections axis is never refetched.
                 harness.fakeCatchUp.returnedByDomain["collections"] = setOf("c1")
                 harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
                 harness.fakeCatchUp.failNextByDomain["books"] = 1
 
                 harness.engine.handleAccessChanged(AccessScope(collectionIds = listOf("c1"), bookIds = listOf("b1")))
 
-                // Pass 1: collections + collection_books + books(FAILED). Pass 2 (requeue): books only.
+                // Pass 1: collections + collection_books + books(FAILED) + activities. Pass 2 (Books-axis
+                // requeue): books + activities only — collections/collection_books do not run again.
                 harness.fakeCatchUp.fetches.map { it.domain } shouldBe
-                    listOf("collections", "collection_books", "books", "books")
+                    listOf("collections", "collection_books", "books", "activities", "books", "activities")
             }
         }
     })
@@ -603,6 +652,13 @@ private data class RecordedFetch(
 private class FakeReconcileCatchUp : CatchUp {
     val accessibleByDomain: MutableMap<String, Set<String>> = mutableMapOf()
     val returnedByDomain: MutableMap<String, Set<String>> = mutableMapOf()
+
+    /**
+     * Payloads a targeted fetch "returns" per domain. When set, [fetchTransient] APPLIES them through
+     * the real handler (exactly like the production client) and derives the returned id set from them
+     * — so a granted row actually lands live in Room. Domains without an entry use [returnedByDomain].
+     */
+    val fetchPayloadsByDomain: MutableMap<String, List<SyncPayload>> = mutableMapOf()
     val fetches: MutableList<RecordedFetch> = mutableListOf()
 
     /** The domain names the coarse pass ([catchUpTransient]) re-derived, in order — for the 5-domain sweep assertion. */
@@ -645,6 +701,19 @@ private class FakeReconcileCatchUp : CatchUp {
             it.await()
         }
         if (consumeFailure(handler.domainName)) return AppResult.Failure(SyncError.SyncFailed())
+        fetchPayloadsByDomain[handler.domainName]?.let { payloads ->
+            // Faithful to production fetchTransient: apply each returned payload through the handler
+            // and collect the non-tombstone ids as the "still-accessible returned" set.
+            @Suppress("UNCHECKED_CAST")
+            val typed = handler as SyncDomainHandler<Any>
+            val returnedIds = mutableSetOf<String>()
+            for (payload in payloads) {
+                val isTomb = (payload as? Tombstoned)?.deletedAt != null
+                typed.onCatchUpItem(payload, isTomb)
+                if (!isTomb) returnedIds += typed.syncId(payload)
+            }
+            return AppResult.Success(returnedIds)
+        }
         val returned = returnedByDomain[handler.domainName] ?: accessibleByDomain[handler.domainName] ?: emptySet()
         return AppResult.Success(returned)
     }
@@ -673,6 +742,8 @@ private class FakeReconcileSse : SseClient {
 private data class ReconcileHarness(
     val engine: SyncEngine,
     val fakeCatchUp: FakeReconcileCatchUp,
+    /** The shared registry the five access-gated handlers registered under — the drift-killer derives its expectation from it. */
+    val registry: ClientSyncDomainRegistry,
     /** The presence signal the access-sensitive router pings — subscribe with Turbine to observe refreshes. */
     val presence: PresenceRefreshSignal,
     /**
@@ -748,7 +819,7 @@ private fun withReconcileEngine(block: suspend (ReconcileHarness, ListenUpDataba
                         ),
                 )
             block(
-                ReconcileHarness(engine, fakeCatchUp, presence, coarseCallsAtPresenceRefresh),
+                ReconcileHarness(engine, fakeCatchUp, registry, presence, coarseCallsAtPresenceRefresh),
                 db,
                 store,
             )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/ComposedSyncDomainHandlerTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/ComposedSyncDomainHandlerTest.kt
@@ -259,7 +259,12 @@ class ComposedSyncDomainHandlerTest :
             val gated =
                 domain(
                     RecordingApply(),
-                    accessGate = AccessGate(liveIds = { listOf("a") }, tombstoneByIds = { _, _ -> }),
+                    accessGate =
+                        AccessGate(
+                            liveIds = { listOf("a") },
+                            tombstoneByIds = { _, _ -> },
+                            delta = AccessDeltaPolicy.LiveTailOnly("test gate: delta participation is irrelevant here"),
+                        ),
                 ).toHandler(runner, ClientSyncDomainRegistry())
             gated.shouldBeInstanceOf<AccessFilteredSyncHandler>()
             (gated as AccessFilteredSyncHandler).localLiveIds() shouldBe setOf("a")

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
@@ -277,6 +277,46 @@ class SyncDomainCompletenessSpec :
             }
         }
 
+        test("access-gated delta participation is frozen: Targeted domains ordered, only collection_shares is LiveTailOnly") {
+            val db = createInMemoryTestDatabase()
+            try {
+                val catalog =
+                    syncDomainCatalog(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                        authSession = FakeAuthSession(userId = "spec-user"),
+                        avatarDownloadRepository = StubAvatarDownloadRepository(),
+                        pingPresence = {},
+                        refetchServerInfo = {},
+                        refetchPreferences = {},
+                    )
+                val gated = catalog.mirrored.filter { it.accessGate != null }
+
+                // The five access-gated domains — the same set AccessGateParitySpec pins to the server.
+                gated.map { it.key.name }.toSet() shouldBe
+                    setOf("books", "activities", "collections", "collection_books", "collection_shares")
+
+                // The Targeted domains, in their declared dependency order. Changing an order or moving a
+                // domain between Targeted and LiveTailOnly is a product decision — update this spec
+                // consciously alongside the gate. (The compile-time no-default on AccessGate.delta is the
+                // stronger lock; this freezes the resulting shape.)
+                gated
+                    .mapNotNull { domain ->
+                        (domain.accessGate!!.delta as? AccessDeltaPolicy.Targeted)?.let { domain.key.name to it.order }
+                    }.sortedBy { it.second }
+                    .map { it.first } shouldBe
+                    listOf("collections", "collection_books", "books", "activities")
+
+                // The one LiveTailOnly domain — deliberately NOT fetched in the delta.
+                gated
+                    .filter { it.accessGate!!.delta is AccessDeltaPolicy.LiveTailOnly }
+                    .map { it.key.name } shouldBe listOf("collection_shares")
+            } finally {
+                db.close()
+            }
+        }
+
         test("server registrations mirror SyncDomains.all exactly (1:1, both directions)") {
             val homeDir = Files.createTempDirectory("listenup-completeness-home-")
             val tmpDb =

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
@@ -277,7 +277,9 @@ class SyncDomainCompletenessSpec :
             }
         }
 
-        test("access-gated delta participation is frozen: Targeted domains ordered, only collection_shares is LiveTailOnly") {
+        test(
+            "access-gated delta participation is frozen: Targeted domains ordered, only collection_shares is LiveTailOnly",
+        ) {
             val db = createInMemoryTestDatabase()
             try {
                 val catalog =


### PR DESCRIPTION
Follow-up to #1067 (PR 2 of 2 on the collection access-change propagation asymmetry).

## Problem
When a user is **granted** collection access, the ACTIVITY feed ("X listened for N min") did not appear in real time — it converged only on the slow digest backstop. (Revoke was already live.)

## Root cause
`AccessReconciler.reconcileDelta` hardcoded a 3-domain subset (`collections`, `collection_books`, `books`) and **deliberately skipped `activities`** — the omission was institutionalized in a KDoc, and revoke was compensated by an `afterScopedPrune` cascade on the books gate. The coarse path already iterated all gated domains, so only the delta path could forget one.

## Fix — registry-driven, compile-time-enforced participation
The delta path can no longer forget a domain — the compiler forbids it:

- **`AccessGate.delta: AccessDeltaPolicy`** is now a **required** field (no default). A new `sealed interface AccessDeltaPolicy { Targeted(order, axis, fetchFor, candidatesFor); LiveTailOnly(rationale) }` + `enum ScopeAxis { Collections, Books }`. Adding a gate without declaring `delta` **fails to compile** — empirically proven (the domain factories + `ComposedSyncDomainHandlerTest`/`SyncReconcilerTest` all failed to compile until supplied).
- **`reconcileDelta` now iterates `registry.accessFilteredHandlers()`**, reads each gate's policy, and fetches every `Targeted` domain in declared order (axis-keyed fetch + `pruneWithin(candidatesFor(ids), …)`, axis-level requeue preserved).
- **`activities` joins the delta on the Books axis** via a new `?bookIds=` targeted fetch, so a grant re-delivers the now-accessible activity **live within the delta pass**.
- **Deleted the `afterScopedPrune` workaround** (and `ActivityDao.tombstoneWhereBookNotLive`) — activities now self-prunes via requested-but-not-returned `pruneWithin`, like every other targeted domain.
- **Server `?bookIds=` route** with a `BOOK_ID_MATCH_DOMAINS = {activities}` allowlist so `matchColumn = "book_id"` stays code-controlled (any other domain → 400).
- **`collection_shares`** declares `LiveTailOnly` — its previously-implicit exemption is now an explicit, spec-frozen fact.

## Tests (TDD)
- **Freeze**: delta participation is frozen — the `Targeted` domains in order + `collection_shares` as the only `LiveTailOnly`.
- **Drift-killer**: the fetched domains equal the registry's `Targeted` set, *derived from the registry* — a future gated domain auto-enters the assertion.
- **Grant convergence** (the bug): a newly-accessible activity goes live within the delta pass (no digest pass).
- **Revoke self-prune**: revoking a scoped book self-prunes its activity via `pruneWithin`; book-less and out-of-scope activities survive.
- Server: `?bookIds=` allowlist (non-`book_id` domain → 400), id-cap (>100 → 400), and ACL-filtered `pullByIds(book_id)` returns only the accessible book's activity.

## Verification
`:sharedLogic:jvmTest` and `:server:jvmTest` both **BUILD SUCCESSFUL** on a clean run; `detekt` clean. (Local runs were slow under heavy machine load; CI runs the full lane authoritatively.)

## Net effect
A new access-gated domain now gets correct delta reconciliation **for free** — declare its `AccessDeltaPolicy` or the build breaks. The activity-grant latency is gone, and the two-mechanism drift (`afterScopedPrune` + hardcoded subset) is collapsed into one registry-driven path.