### PR TITLE
✨ fix(iosApp): book-switch playback — hang, cover, chapter-1 blip, honest buffering

### DIFF
--- a/iosApp/ListenUp/DesignSystem/Components/CoverImageRequest.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/CoverImageRequest.swift
@@ -35,7 +35,12 @@ enum CoverImageRequest {
               let url = URL(string: "\(base)/api/v1/covers/\(bookId)")
         else { return nil }
 
-        let cacheKey = coverCacheKey(identity: bookId, coverHash: coverHash)
+        // No hash → `nil` cache key → Nuke keys on the request URL (`/api/v1/covers/{bookId}`),
+        // which is already unique per book. Never the `"bookId:cover"` custom key: it is the exact
+        // poisoned key the old bug wrote, and during a switch (`coverPath == nil`, `bookId == B`)
+        // it would let book A's still-cached bytes flash on book B. Passing `nil` also orphans any
+        // stale `"<id>:cover"` disk entries. With a hash we keep the content-scoped `"<id>:<hash>"`.
+        let cacheKey = contentHashKey(identity: bookId, coverHash: coverHash)
         return await AuthenticatedImageRequest.authenticated(url: url, processors: processors, cacheKey: cacheKey)
     }
 
@@ -47,16 +52,15 @@ enum CoverImageRequest {
     /// is unique per file and can't be mis-associated. With a hash we keep the bookId-scoped key
     /// (mirrors the server-URL branch and Android's `"$bookId:$coverHash"`).
     static func localFileCacheKey(bookId: String?, coverPath: String, coverHash: String?) -> String {
-        if let coverHash, !coverHash.isEmpty {
-            return coverCacheKey(identity: bookId ?? coverPath, coverHash: coverHash)
-        }
-        return coverPath
+        contentHashKey(identity: bookId ?? coverPath, coverHash: coverHash) ?? coverPath
     }
 
-    /// Fold the cover content hash into Nuke's cache identity so a new cover at the same stable
-    /// path/URL busts the old entry — mirrors Android's `"$bookId:$coverHash"` Coil key. The key is
-    /// token-independent, so a cached cover still survives access-token rotation.
-    private static func coverCacheKey(identity: String, coverHash: String?) -> String {
-        "\(identity):\(coverHash ?? "cover")"
+    /// The content-scoped cache key `"<identity>:<coverHash>"`, or `nil` when there is no hash.
+    /// Returning `nil` is deliberate: a hash-less key must fall back to Nuke's natural URL/path
+    /// identity, never a bare-`bookId` key (which is not content-safe and poisons the cache).
+    /// Token-independent, so a cached cover survives access-token rotation.
+    static func contentHashKey(identity: String, coverHash: String?) -> String? {
+        guard let coverHash, !coverHash.isEmpty else { return nil }
+        return "\(identity):\(coverHash)"
     }
 }

--- a/iosApp/ListenUp/DesignSystem/Components/CoverImageRequest.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/CoverImageRequest.swift
@@ -19,7 +19,7 @@ enum CoverImageRequest {
         let processors = AuthenticatedImageRequest.processors(targetPixels: targetPixels)
 
         if let coverPath, !coverPath.isEmpty {
-            let cacheKey = coverCacheKey(identity: bookId ?? coverPath, coverHash: coverHash)
+            let cacheKey = localFileCacheKey(bookId: bookId, coverPath: coverPath, coverHash: coverHash)
             return AuthenticatedImageRequest.localFile(coverPath, processors: processors, cacheKey: cacheKey)
         }
 
@@ -37,6 +37,20 @@ enum CoverImageRequest {
 
         let cacheKey = coverCacheKey(identity: bookId, coverHash: coverHash)
         return await AuthenticatedImageRequest.authenticated(url: url, processors: processors, cacheKey: cacheKey)
+    }
+
+    /// Cache key for a **local cover file**. A `bookId`-scoped key is only content-safe when it
+    /// folds in the content hash: during a book switch, `bookId` advances to book B while
+    /// `coverPath` can still point at book A's file, so a `"B:cover"` key (bookId, no hash) would
+    /// stamp book B's identity onto book A's bytes and poison the shared memory+disk cache — the
+    /// "cover never changes" bug (RC-1). Without a hash we key by the **file path** instead, which
+    /// is unique per file and can't be mis-associated. With a hash we keep the bookId-scoped key
+    /// (mirrors the server-URL branch and Android's `"$bookId:$coverHash"`).
+    static func localFileCacheKey(bookId: String?, coverPath: String, coverHash: String?) -> String {
+        if let coverHash, !coverHash.isEmpty {
+            return coverCacheKey(identity: bookId ?? coverPath, coverHash: coverHash)
+        }
+        return coverPath
     }
 
     /// Fold the cover content hash into Nuke's cache identity so a new cover at the same stable

--- a/iosApp/ListenUp/Features/DocumentReader/NowPlayingStrip.swift
+++ b/iosApp/ListenUp/Features/DocumentReader/NowPlayingStrip.swift
@@ -32,12 +32,14 @@ struct NowPlayingStrip: View {
             Spacer(minLength: 8)
 
             Button { player.togglePlayback() } label: {
-                Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
+                // `isPlaybackActive` (playing OR buffering) so the glyph reads "pause" during the
+                // startup buffer, matching what a tap does.
+                Image(systemName: player.isPlaybackActive ? "pause.fill" : "play.fill")
                     .font(.title3).foregroundStyle(.white)
                     .frame(width: 38, height: 38)
                     .background(Color.listenUpOrange, in: RoundedRectangle(cornerRadius: 11, style: .continuous))
             }
-            .accessibilityLabel(String(localized: player.isPlaying ? "player.pause" : "player.play"))
+            .accessibilityLabel(String(localized: player.isPlaybackActive ? "player.pause" : "player.play"))
         }
         .padding(.horizontal, 12).padding(.vertical, 8)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))

--- a/iosApp/ListenUp/Features/Player/AudioEngine.swift
+++ b/iosApp/ListenUp/Features/Player/AudioEngine.swift
@@ -54,6 +54,14 @@ actor AudioEngine: PlaybackEngine {
     /// (false). Lets `load` seek precisely *before* any rate is set, so playback never
     /// starts from a playable position-0 sample and then jumps (RC-2).
     private var readyContinuation: CheckedContinuation<Bool, Never>?
+    /// The timeout task for the *current* readiness wait. Cancelled the instant the wait
+    /// resolves (ready / failed / superseded / release) so a stale timer from a prior `load`
+    /// can never fire against a later wait — a rapid A→B→C would otherwise stack timers that
+    /// resume whichever continuation exists 20 s later, with an effective timeout near zero.
+    private var readyTimeoutTask: Task<Void, Never>?
+    /// Epoch for the readiness wait: a timeout resume carries the generation it was armed for
+    /// and is ignored unless it still matches — belt-and-braces alongside task cancellation.
+    private var readyGeneration = 0
 
     init() {
         var capturedContinuation: AsyncStream<AudioEngineEvent>.Continuation!
@@ -117,20 +125,28 @@ actor AudioEngine: PlaybackEngine {
         case .failed: return false
         default: break
         }
-        // Only one waiter at a time; a fresh `load` supersedes any prior wait.
+        // Only one waiter at a time; a fresh `load` supersedes any prior wait (which also
+        // cancels that wait's timeout task).
         resumeReadyIfWaiting(false)
+        readyGeneration &+= 1
+        let generation = readyGeneration
         return await withCheckedContinuation { continuation in
             readyContinuation = continuation
-            Task { [weak self] in
+            readyTimeoutTask = Task { [weak self] in
                 try? await Task.sleep(for: timeout)
-                await self?.resumeReadyIfWaiting(false)
+                await self?.resumeReadyIfWaiting(false, forGeneration: generation)
             }
         }
     }
 
-    /// Resume a pending readiness waiter, if any. Idempotent: a second call (timeout after
-    /// success, or `.failed` after `.readyToPlay`) is a no-op.
-    private func resumeReadyIfWaiting(_ ready: Bool) {
+    /// Resume a pending readiness waiter, if any, and tear down its timeout task. Idempotent:
+    /// a second call (timeout after success, `.failed` after `.readyToPlay`, or release after
+    /// either) is a no-op. `generation`, when supplied by the timeout task, gates the resume so
+    /// a stale timer whose wait already resolved (and bumped the generation) cannot fire.
+    private func resumeReadyIfWaiting(_ ready: Bool, forGeneration generation: Int? = nil) {
+        if let generation, generation != readyGeneration { return }
+        readyTimeoutTask?.cancel()
+        readyTimeoutTask = nil
         guard let continuation = readyContinuation else { return }
         readyContinuation = nil
         continuation.resume(returning: ready)
@@ -279,7 +295,7 @@ actor AudioEngine: PlaybackEngine {
         timeControlObservation = player.observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
             guard let self else { return }
             let status = player.timeControlStatus
-            // TODO(rule 7): fold this and the other KVO/notification callbacks into a single
+            // Deferred (rule 7): fold this and the other KVO/notification callbacks into a single
             // ordered AsyncStream the actor drains, so currentItem/status/timeControl events
             // can't reorder relative to each other during a queue rebuild.
             Task { await self.handleTimeControlStatus(status) }

--- a/iosApp/ListenUp/Features/Player/AudioEngine.swift
+++ b/iosApp/ListenUp/Features/Player/AudioEngine.swift
@@ -102,15 +102,32 @@ actor AudioEngine: PlaybackEngine {
         observeTimeControlStatus()
         observeCurrentItemTransitions()
 
-        // Wait for the first item to be playable, then seek precisely — so there is
-        // never a playable position-0 state for `play()` to start from.
-        guard await awaitCurrentItemReady() else { return false }
+        // Preroll: a paused `AVQueuePlayer` will NOT advance a fresh item — especially a
+        // streaming one — to `.readyToPlay` on its own; it only loads once told to play. So
+        // pump it (rate > 0) to drive readiness, but MUTED, so the user never hears the
+        // position-0 (chapter 1) audio before the resume seek lands. Without this the wait
+        // below never resolves and `load` times out at 20 s (the "stuck preparing → quits"
+        // regression). We restore mute and re-pause before returning; the caller starts
+        // audible playback from the correct position.
+        player.isMuted = true
+        player.rate = rate
+        let ready = await awaitCurrentItemReady()
+        guard ready else {
+            player.pause()
+            player.isMuted = false
+            Log.error("load: item never reached ready (timeout/failed); aborting")
+            return false
+        }
+        // Ready and playable — seek precisely, then hand back a silent, paused, correctly
+        // positioned player for the caller's `play()` to resume audibly.
         if withinSegmentMs > 0 {
             _ = await player.seek(
                 to: CMTime(value: withinSegmentMs, timescale: 1000),
                 toleranceBefore: .zero, toleranceAfter: .zero
             )
         }
+        player.pause()
+        player.isMuted = false
         return true
     }
 

--- a/iosApp/ListenUp/Features/Player/AudioEngine.swift
+++ b/iosApp/ListenUp/Features/Player/AudioEngine.swift
@@ -45,7 +45,15 @@ actor AudioEngine: PlaybackEngine {
     private var errorLogObserver: NSObjectProtocol?
     private var currentItemObservation: NSKeyValueObservation?
     private var statusObservation: NSKeyValueObservation?
-    private var keepUpObservation: NSKeyValueObservation?
+    /// Player-level "is audio actually advancing" signal. Authoritative for the
+    /// buffering↔playing distinction — `isPlaybackLikelyToKeepUp` reports "enough
+    /// buffered to be playable", which flips to true *before* audio starts and would
+    /// make the UI claim "playing" during the startup buffer (the RC-3 lie).
+    private var timeControlObservation: NSKeyValueObservation?
+    /// Resumed when the current item reaches `.readyToPlay` (true) or `.failed`/timeout
+    /// (false). Lets `load` seek precisely *before* any rate is set, so playback never
+    /// starts from a playable position-0 sample and then jumps (RC-2).
+    private var readyContinuation: CheckedContinuation<Bool, Never>?
 
     init() {
         var capturedContinuation: AsyncStream<AudioEngineEvent>.Continuation!
@@ -53,26 +61,79 @@ actor AudioEngine: PlaybackEngine {
         continuation = capturedContinuation
     }
 
-    /// Configure the audio session and enqueue `segments`, positioned at
-    /// `startPositionMs`. Does not start playback — the caller follows with `play()`.
-    func load(segments: [AudioSegment], startPositionMs: Int64) {
+    /// Configure the audio session, enqueue `segments`, and seek to `startPositionMs`
+    /// *before returning*. Does not start playback — the caller follows with `play()`.
+    ///
+    /// Returns `true` once the queue's first item is ready and positioned; `false` on a
+    /// configuration/queue failure or a readiness timeout (a `.failed` event is emitted
+    /// on the failure paths so the coordinator can surface an error state).
+    ///
+    /// The resume seek happens here — after awaiting readiness, before any rate is set —
+    /// rather than being deferred to a KVO callback that fires *after* `play()` has already
+    /// begun playing position 0. That deferred seek was the "starts at chapter 1, then
+    /// jumps" bug (RC-2).
+    func load(segments: [AudioSegment], startPositionMs: Int64) async -> Bool {
         guard !segments.isEmpty else {
             continuation.yield(.failed(message: "This book has no audio."))
-            return
+            return false
         }
         self.segments = segments
-        configureAudioSession()
+        guard configureAudioSession() else { return false }
         let startIndex = SegmentMath.segmentIndex(forPositionMs: startPositionMs, in: segments) ?? 0
-        let withinSegmentMs = startPositionMs - segments[startIndex].offsetMs
-        pendingSeekWithinSegmentMs = withinSegmentMs > 0 ? withinSegmentMs : nil
+        let withinSegmentMs = max(0, startPositionMs - segments[startIndex].offsetMs)
+        // The initial position is applied by the explicit seek below, not the deferred
+        // `.readyToPlay` path — clear any stale pending seek so it can't double-fire.
+        pendingSeekWithinSegmentMs = nil
         // Order matters: `rebuildQueue` must populate the queue before
         // `observeCurrentItemTransitions` registers its `.initial` KVO, so the
-        // first item gets its status observers (and thus the deferred resume seek).
-        rebuildQueue(fromSegment: startIndex)
+        // first item gets its status observers (and thus the readiness signal).
+        guard rebuildQueue(fromSegment: startIndex) else { return false }
         installTimeObserver()
         observeEnd()
         observeErrorLog()
+        observeTimeControlStatus()
         observeCurrentItemTransitions()
+
+        // Wait for the first item to be playable, then seek precisely — so there is
+        // never a playable position-0 state for `play()` to start from.
+        guard await awaitCurrentItemReady() else { return false }
+        if withinSegmentMs > 0 {
+            _ = await player.seek(
+                to: CMTime(value: withinSegmentMs, timescale: 1000),
+                toleranceBefore: .zero, toleranceAfter: .zero
+            )
+        }
+        return true
+    }
+
+    /// Await the current item reaching `.readyToPlay` (`true`) or `.failed`/timeout
+    /// (`false`). The status KVO installed by `observeCurrentItemTransitions` drives the
+    /// resume via `resumeReadyIfWaiting`; the timeout guards against a stream that never
+    /// becomes ready and never fails (the classic ATS/TLS "just never starts" hang).
+    private func awaitCurrentItemReady(timeout: Duration = .seconds(20)) async -> Bool {
+        guard let item = player.currentItem else { return false }
+        switch item.status {
+        case .readyToPlay: return true
+        case .failed: return false
+        default: break
+        }
+        // Only one waiter at a time; a fresh `load` supersedes any prior wait.
+        resumeReadyIfWaiting(false)
+        return await withCheckedContinuation { continuation in
+            readyContinuation = continuation
+            Task { [weak self] in
+                try? await Task.sleep(for: timeout)
+                await self?.resumeReadyIfWaiting(false)
+            }
+        }
+    }
+
+    /// Resume a pending readiness waiter, if any. Idempotent: a second call (timeout after
+    /// success, or `.failed` after `.readyToPlay`) is a no-op.
+    private func resumeReadyIfWaiting(_ ready: Bool) {
+        guard let continuation = readyContinuation else { return }
+        readyContinuation = nil
+        continuation.resume(returning: ready)
     }
 
     /// Begin (or resume) playback at the current rate.
@@ -157,7 +218,9 @@ actor AudioEngine: PlaybackEngine {
         }
         currentItemObservation = nil
         statusObservation = nil
-        keepUpObservation = nil
+        timeControlObservation = nil
+        // Unblock any load still awaiting readiness so it doesn't leak a suspended task.
+        resumeReadyIfWaiting(false)
         player.removeAllItems()
         queue = []
         continuation.finish()
@@ -172,22 +235,26 @@ actor AudioEngine: PlaybackEngine {
         return queue.first { $0.item === current }?.segmentIndex
     }
 
-    private func configureAudioSession() {
+    /// Configure the shared session for spoken-audio playback. Returns `false` (and emits
+    /// a `.failed` event) when the session can't be configured — playback would otherwise
+    /// start into dead silence.
+    private func configureAudioSession() -> Bool {
         let session = AVAudioSession.sharedInstance()
         do {
             try session.setCategory(.playback, mode: .spokenAudio)
             try session.setActive(true)
+            return true
         } catch {
-            // If the session can't be configured, playback would start into dead silence.
-            // Surface it as a playback failure (the coordinator maps `.failed` → error state)
-            // rather than leaving the user staring at a player that makes no sound.
             Log.error("Failed to configure audio session", error: error)
             continuation.yield(.failed(message: "Couldn't start audio playback."))
+            return false
         }
     }
 
     /// Replace the queue with fresh `AVPlayerItem`s for segments `[startIndex...]`.
-    private func rebuildQueue(fromSegment startIndex: Int) {
+    /// Returns `false` (and emits `.failed`) if a segment is rejected.
+    @discardableResult
+    private func rebuildQueue(fromSegment startIndex: Int) -> Bool {
         player.removeAllItems()
         queue = (startIndex..<segments.count).map { index in
             (item: AVPlayerItem(url: segments[index].url), segmentIndex: index)
@@ -198,9 +265,41 @@ actor AudioEngine: PlaybackEngine {
                 // Surface it as a playback failure rather than dropping it without a trace.
                 Log.error("AVQueuePlayer rejected segment \(entry.segmentIndex); aborting queue build")
                 continuation.yield(.failed(message: "Couldn't start audio playback."))
-                return
+                return false
             }
             player.insert(entry.item, after: nil)
+        }
+        return true
+    }
+
+    /// Observe the player-level `timeControlStatus` — the authoritative "is audio advancing?"
+    /// signal. Registered per `load` (like the other observers); `timeControlStatus` is a
+    /// property of the player, not the item, so it survives queue rebuilds within a load.
+    private func observeTimeControlStatus() {
+        timeControlObservation = player.observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
+            guard let self else { return }
+            let status = player.timeControlStatus
+            // TODO(rule 7): fold this and the other KVO/notification callbacks into a single
+            // ordered AsyncStream the actor drains, so currentItem/status/timeControl events
+            // can't reorder relative to each other during a queue rebuild.
+            Task { await self.handleTimeControlStatus(status) }
+        }
+    }
+
+    /// Map `timeControlStatus` onto the engine's `buffering`/`ready` status.
+    /// `.waitingToPlayAtSpecifiedRate` means the player wants to play but is stalled buffering;
+    /// `.playing` means samples are actually flowing. `.paused` emits nothing — a paused
+    /// player's status is owned by the coordinator's phase, not the engine.
+    private func handleTimeControlStatus(_ status: AVPlayer.TimeControlStatus) {
+        switch status {
+        case .waitingToPlayAtSpecifiedRate:
+            continuation.yield(.statusChanged(.buffering))
+        case .playing:
+            continuation.yield(.statusChanged(.ready))
+        case .paused:
+            break
+        @unknown default:
+            break
         }
     }
 
@@ -291,7 +390,6 @@ actor AudioEngine: PlaybackEngine {
 
     private func attachItemObservers(to item: AVPlayerItem?) {
         statusObservation = nil
-        keepUpObservation = nil
         guard let item else { return }
         statusObservation = item.observe(\.status, options: [.initial, .new]) { [weak self] item, _ in
             guard let self else { return }
@@ -302,20 +400,14 @@ actor AudioEngine: PlaybackEngine {
             let detail = (item.error as NSError?).map { " [\($0.domain) \($0.code)]" } ?? ""
             Task { await self.handleItemStatus(status, errorMessage: errorMessage, errorDetail: detail) }
         }
-        keepUpObservation = item.observe(\.isPlaybackLikelyToKeepUp, options: [.new]) { [weak self] item, _ in
-            guard let self else { return }
-            let likelyToKeepUp = item.isPlaybackLikelyToKeepUp
-            Task { await self.handleKeepUp(likelyToKeepUp) }
-        }
-    }
-
-    private func handleKeepUp(_ likelyToKeepUp: Bool) {
-        continuation.yield(.statusChanged(likelyToKeepUp ? .ready : .buffering))
     }
 
     private func handleItemStatus(_ status: AVPlayerItem.Status, errorMessage: String?, errorDetail: String) {
         switch status {
         case .readyToPlay:
+            // A deferred cross-segment seek (set by `seek(toMs:)`, which rebuilds the queue and
+            // can't seek an unprepared item). The initial resume seek is done inline in `load`,
+            // which clears `pendingSeekWithinSegmentMs`, so this only fires for later seeks.
             if let pending = pendingSeekWithinSegmentMs {
                 pendingSeekWithinSegmentMs = nil
                 player.seek(
@@ -323,9 +415,13 @@ actor AudioEngine: PlaybackEngine {
                     toleranceBefore: .zero, toleranceAfter: .zero
                 )
             }
-            continuation.yield(.statusChanged(.ready))
+            // Readiness unblocks `load`'s seek-before-play. The buffering↔playing signal is NOT
+            // emitted here — `isReadyToPlay` means "playable", not "playing"; `timeControlStatus`
+            // owns that distinction so the UI can't claim "playing" during the startup buffer.
+            resumeReadyIfWaiting(true)
         case .failed:
             Log.error("AVPlayerItem failed: \(errorMessage ?? "unknown error")\(errorDetail)")
+            resumeReadyIfWaiting(false)
             continuation.yield(.failed(message: errorMessage ?? "Playback failed."))
         case .unknown:
             break

--- a/iosApp/ListenUp/Features/Player/FullScreenPlayerView.swift
+++ b/iosApp/ListenUp/Features/Player/FullScreenPlayerView.swift
@@ -316,12 +316,15 @@ struct FullScreenPlayerView: View {
                         .fill(Color.listenUpOrange)
                         .frame(width: 76, height: 76)
                         .shadow(color: Color.listenUpOrange.opacity(0.45), radius: 12, x: 0, y: 8)
-                    Image(systemName: observer.isPlaying ? "pause.fill" : "play.fill")
+                    // `isPlaybackActive` (playing OR buffering) so the control reads "pause"
+                    // during the startup buffer — it shows a pause affordance because the user's
+                    // intent is active, matching what a tap does (pause, not resume).
+                    Image(systemName: observer.isPlaybackActive ? "pause.fill" : "play.fill")
                         .font(.title)
                         .foregroundStyle(.white)
                 }
             }
-            .accessibilityLabel(String(localized: observer.isPlaying ? "player.pause" : "player.play"))
+            .accessibilityLabel(String(localized: observer.isPlaybackActive ? "player.pause" : "player.play"))
 
             Spacer()
 

--- a/iosApp/ListenUp/Features/Player/FullScreenPlayerView.swift
+++ b/iosApp/ListenUp/Features/Player/FullScreenPlayerView.swift
@@ -316,12 +316,20 @@ struct FullScreenPlayerView: View {
                         .fill(Color.listenUpOrange)
                         .frame(width: 76, height: 76)
                         .shadow(color: Color.listenUpOrange.opacity(0.45), radius: 12, x: 0, y: 8)
-                    // `isPlaybackActive` (playing OR buffering) so the control reads "pause"
-                    // during the startup buffer — it shows a pause affordance because the user's
-                    // intent is active, matching what a tap does (pause, not resume).
-                    Image(systemName: observer.isPlaybackActive ? "pause.fill" : "play.fill")
-                        .font(.title)
-                        .foregroundStyle(.white)
+                    if observer.isBuffering {
+                        // Honest buffering: a spinner while the stream loads, not a pause glyph
+                        // that implies audio is flowing when it isn't yet.
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .controlSize(.large)
+                            .tint(.white)
+                    } else {
+                        // `isPlaybackActive` here means "playing" (buffering handled above); it
+                        // reads "pause" while playing because a tap pauses.
+                        Image(systemName: observer.isPlaybackActive ? "pause.fill" : "play.fill")
+                            .font(.title)
+                            .foregroundStyle(.white)
+                    }
                 }
             }
             .accessibilityLabel(String(localized: observer.isPlaybackActive ? "player.pause" : "player.play"))

--- a/iosApp/ListenUp/Features/Player/MiniPlayerBar.swift
+++ b/iosApp/ListenUp/Features/Player/MiniPlayerBar.swift
@@ -121,14 +121,16 @@ struct MiniPlayerBar: View {
             playPauseTapCount += 1
             observer.togglePlayback()
         } label: {
-            Image(systemName: observer.isPlaying ? "pause.fill" : "play.fill")
+            // `isPlaybackActive` (playing OR buffering) so the glyph reads "pause" during the
+            // startup buffer, matching what a tap does and the transport's own state.
+            Image(systemName: observer.isPlaybackActive ? "pause.fill" : "play.fill")
                 .font(.title3)
                 .foregroundStyle(Color.listenUpOrange)
                 .contentTransition(.symbolEffect(.replace.downUp))
                 .frame(width: 44, height: 44)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(observer.isPlaying
+        .accessibilityLabel(observer.isPlaybackActive
             ? String(localized: "player.pause")
             : String(localized: "player.play"))
         .haptic(.toggleOn, trigger: playPauseTapCount)

--- a/iosApp/ListenUp/Features/Player/MiniPlayerBar.swift
+++ b/iosApp/ListenUp/Features/Player/MiniPlayerBar.swift
@@ -121,13 +121,23 @@ struct MiniPlayerBar: View {
             playPauseTapCount += 1
             observer.togglePlayback()
         } label: {
-            // `isPlaybackActive` (playing OR buffering) so the glyph reads "pause" during the
-            // startup buffer, matching what a tap does and the transport's own state.
-            Image(systemName: observer.isPlaybackActive ? "pause.fill" : "play.fill")
-                .font(.title3)
-                .foregroundStyle(Color.listenUpOrange)
-                .contentTransition(.symbolEffect(.replace.downUp))
-                .frame(width: 44, height: 44)
+            Group {
+                if observer.isBuffering {
+                    // Honest buffering: a spinner while the stream loads, matching the full player
+                    // and Android — not a pause glyph implying audio is already flowing.
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(Color.listenUpOrange)
+                } else {
+                    // `isPlaybackActive` here means "playing" (buffering handled above); reads
+                    // "pause" while playing because a tap pauses.
+                    Image(systemName: observer.isPlaybackActive ? "pause.fill" : "play.fill")
+                        .font(.title3)
+                        .foregroundStyle(Color.listenUpOrange)
+                        .contentTransition(.symbolEffect(.replace.downUp))
+                }
+            }
+            .frame(width: 44, height: 44)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(observer.isPlaybackActive

--- a/iosApp/ListenUp/Features/Player/PlaybackSeam.swift
+++ b/iosApp/ListenUp/Features/Player/PlaybackSeam.swift
@@ -6,7 +6,11 @@ import Foundation
 protocol PlaybackEngine: Sendable {
     /// The engine's event stream. Created once at init; consumed once.
     nonisolated var events: AsyncStream<AudioEngineEvent> { get }
-    func load(segments: [AudioSegment], startPositionMs: Int64) async
+    /// Configure the session, enqueue `segments`, and seek to `startPositionMs` before
+    /// returning. Returns `true` once the first item is ready and positioned; `false` on a
+    /// configuration/queue failure or readiness timeout (a `.failed` event is emitted on
+    /// those paths). The caller starts playback with `play()` only after a `true` result.
+    func load(segments: [AudioSegment], startPositionMs: Int64) async -> Bool
     func play() async
     func pause() async
     func seek(toMs positionMs: Int64) async

--- a/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
+++ b/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
@@ -37,6 +37,17 @@ enum ScenePhasePolicy {
     }
 }
 
+/// Pure predicate for the load-generation guard — a book-switch epoch check, testable
+/// without a coordinator. Each `play(bookId:)` bumps the coordinator's generation; an
+/// in-flight prepare captures the generation it started under and bails after every
+/// `await` if a newer switch has superseded it, so a slow prepare for book A can never
+/// stomp the state of a book B the user has since switched to (RC-4).
+enum LoadGeneration {
+    static func isSuperseded(taskGeneration: Int, current: Int) -> Bool {
+        taskGeneration != current
+    }
+}
+
 /// Pure chapter math — resolves a whole-book position to a chapter index.
 /// Split out so it is testable without a coordinator.
 enum ChapterMath {
@@ -79,6 +90,11 @@ final class PlayerCoordinator: RemoteCommandHandler {
         if case .buffering = phase { return true }
         return false
     }
+
+    /// Playback intent is "advancing": the audio is playing OR buffering toward playing.
+    /// The transport, remote commands, and toggle all treat these two as one — the user's
+    /// intent is the same, and the buffering→playing promotion is an internal engine detail.
+    var isPlaybackActive: Bool { isPlaying || isBuffering }
 
     // MARK: - Preserved UI surface — book metadata (set once on load)
 
@@ -199,6 +215,12 @@ final class PlayerCoordinator: RemoteCommandHandler {
     private var lastReportedPositionMs: Int64 = 0
     private var lastSyncedChapterIndex: Int = -1
     private var isFading = false
+    /// The in-flight prepare-and-start task for the current `play(bookId:)`, cancelled the
+    /// instant the user switches books so its post-`await` continuations bail (RC-4).
+    private var prepareTask: Task<Void, Never>?
+    /// Bumped on every `play(bookId:)`. The current epoch; an in-flight prepare compares the
+    /// generation it captured against this after each `await` and abandons if superseded.
+    private var loadGeneration = 0
     /// True only while playback is paused *because of* an audio-session
     /// interruption. Gates `.ended + .shouldResume`: resume is honored only
     /// when the interruption did the pausing — a user's deliberate pause is
@@ -351,22 +373,69 @@ final class PlayerCoordinator: RemoteCommandHandler {
 
     // MARK: - Actions
 
-    /// Prepare and start playback of a book.
+    /// Prepare and start playback of a book. Safe to call while another book is playing or
+    /// still preparing: the in-flight prepare is cancelled, the outgoing book's position is
+    /// saved, the metadata surface is reset synchronously, and the engine is silenced before
+    /// the new book loads — so a switch never leaks the old book's cover/chapters/audio (RC-1, RC-4).
     func play(bookId: String) {
         pausedByInterruption = false
+
+        // Cancel any in-flight prepare and open a new epoch so its post-`await` continuations bail.
+        prepareTask?.cancel()
+        loadGeneration &+= 1
+        let generation = loadGeneration
+
+        // Save the outgoing book's place before we retarget — a switch must not lose it.
+        if let outgoing = phase.playingState {
+            progress.onPlaybackPaused(bookId: outgoing.bookId, positionMs: bookPositionMs, speed: playbackSpeed)
+        }
+
+        // RC-1(a): clear the metadata surface synchronously, before the async prepare, so that
+        // during `.preparing` the UI never renders book A's cover/chapters/title against book B's id.
+        resetMetadataForSwitch()
+
         phase = .preparing(PreparingState(bookId: bookId))
         currentBookId = bookId
-        Task { await prepareAndStart(bookId: bookId) }
+
+        prepareTask = Task {
+            // Silence the outgoing book immediately — before the (possibly slow) prepare —
+            // so switching never leaves the previous audio playing under the new metadata.
+            await engine.pause()
+            await prepareAndStart(bookId: bookId, generation: generation)
+        }
     }
 
-    /// Toggle between play and pause.
+    /// Reset the observable metadata surface and position state for a fresh load. Keeps
+    /// `playbackSpeed` (re-derived from the prepared book) to avoid a flash back to 1.0×.
+    private func resetMetadataForSwitch() {
+        bookTitle = ""
+        authorName = ""
+        narratorName = ""
+        coverPath = nil
+        coverBlurHash = nil
+        chapters = []
+        firstPdfDocId = nil
+        documentToOpen = nil
+        positionTracker.reset()
+        lastReportedPositionMs = 0
+        lastSyncedChapterIndex = -1
+    }
+
+    /// Toggle between play and pause. In `.error`, retries the errored book so the user is
+    /// never stranded on a dead player (RC-5).
     func togglePlayback() {
         pausedByInterruption = false
+        // Recovery: a tap on an errored book starts a fresh load rather than no-oping.
+        if case .error(let errorState) = phase {
+            if let bookId = errorState.bookId { play(bookId: bookId) }
+            return
+        }
         guard let loaded = phase.playingState else { return }
         // KMP value-class `BookId` is erased at the Swift boundary — its APIs take
         // the underlying id value directly.
         let id = loaded.bookId
-        if phase.isPlaying {
+        // Buffering counts as "active" — a toggle while buffering is a pause, not a resume.
+        if isPlaybackActive {
             Task { await engine.pause() }
             phase = .paused(loaded)
             progress.onPlaybackPaused(bookId: id, positionMs: bookPositionMs, speed: playbackSpeed)
@@ -447,6 +516,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
     /// *before* the call returns.
     func stop() async {
         pausedByInterruption = false
+        prepareTask?.cancel()
         bridge.cancelAll()
         positionTracker.reset()
         await engine.deactivateSession()
@@ -456,30 +526,40 @@ final class PlayerCoordinator: RemoteCommandHandler {
     // MARK: - RemoteCommandHandler
 
     func remoteTogglePlayPause() { togglePlayback() }
-    func remotePlay() { if !isPlaying { togglePlayback() } }
-    func remotePause() { if isPlaying { togglePlayback() } }
+    // Gate on `isPlaybackActive` (playing OR buffering) so the lock-screen play/pause
+    // commands stay correct during the startup buffer — `isPlaying` alone would let a
+    // remote "play" during buffering fall through to `togglePlayback` and pause instead.
+    func remotePlay() { if !isPlaybackActive { togglePlayback() } }
+    func remotePause() { if isPlaybackActive { togglePlayback() } }
     func remoteSkipForward() { skipForward() }
     func remoteSkipBackward() { skipBackward() }
     func remoteSeek(toMs positionMs: Int64) { seekTo(positionMs: positionMs) }
 
     // MARK: - Prepare
 
-    private func prepareAndStart(bookId: String) async {
-        // Reset document state at the start of every new book load.
-        firstPdfDocId = nil
-        documentToOpen = nil
-
+    private func prepareAndStart(bookId: String, generation: Int) async {
         guard let prepared = await preparer.prepare(bookId: bookId) else {
+            guard !isSuperseded(generation) else { return }
             phase = .error(ErrorState(message: "Couldn't start playback.", bookId: bookId))
             return
         }
+        guard !isSuperseded(generation) else { return }
+
         bookTitle = prepared.bookTitle
         authorName = prepared.bookAuthor
         narratorName = prepared.bookNarrator
         coverPath = prepared.coverPath
         chapters = prepared.chapters
         playbackSpeed = prepared.resumeSpeed
-        coverBlurHash = await coverProvider.coverBlurHash(bookId: bookId)
+        // RC-2: seed the tracker with the resume position (paused) so the UI shows the right
+        // chapter/time immediately — before the engine's first real sample lands.
+        positionTracker.update(positionMs: prepared.resumePositionMs, rate: 0)
+        lastReportedPositionMs = prepared.resumePositionMs
+
+        let blurHash = await coverProvider.coverBlurHash(bookId: bookId)
+        guard !isSuperseded(generation) else { return }
+        coverBlurHash = blurHash
+
         // Resolve PDF availability concurrently — does not block audio start.
         // Guard against a stale result landing after a rapid book switch: only apply
         // the resolved id if this book is still the current one.
@@ -500,18 +580,45 @@ final class PlayerCoordinator: RemoteCommandHandler {
             return AudioSegment(url: url, durationMs: file.durationMs, offsetMs: file.startOffsetMs)
         }
         guard !segments.isEmpty else {
+            guard !isSuperseded(generation) else { return }
             phase = .error(ErrorState(message: "This book has no audio.", bookId: bookId))
             return
         }
 
-        await engine.load(segments: segments, startPositionMs: prepared.resumePositionMs)
+        // `load` awaits readiness and seeks to the resume position before returning, so
+        // playback starts from the right place (RC-2). A `false` result means the load failed.
+        let loaded = await engine.load(segments: segments, startPositionMs: prepared.resumePositionMs)
+        guard !isSuperseded(generation) else { return }
+        guard loaded else {
+            // The engine may have already emitted `.failed` (→ `.error`); don't clobber it.
+            if case .error = phase { return }
+            phase = .error(ErrorState(message: "Couldn't start playback.", bookId: bookId))
+            return
+        }
+        // RC-5: a failure event may have landed during load — never start over an error state.
+        if case .error = phase { return }
+
+        // RC-3: enter `.buffering` *before* starting the engine, so the first real
+        // `timeControlStatus == .playing` event promotes it to `.playing`. Setting the phase
+        // after `play()` would race that event and could lose the promotion (stuck buffering).
+        phase = .buffering(PlayingState(bookId: bookId, durationMs: prepared.timeline.totalDurationMs))
+        lastSyncedChapterIndex = chapterIndex
+        updateNowPlaying()
+
         await engine.setRate(prepared.resumeSpeed)
+        guard !isSuperseded(generation) else { return }
         await engine.play()
-        phase = .playing(PlayingState(bookId: bookId, durationMs: prepared.timeline.totalDurationMs))
+        guard !isSuperseded(generation) else { return }
+
+        // Report started only after the engine has actually been told to play, and only for the
+        // book that survived the switch — so a superseded load never reports a phantom start.
         lastReportedPositionMs = prepared.resumePositionMs
         progress.onPlaybackStarted(bookId: bookId, positionMs: prepared.resumePositionMs, speed: prepared.resumeSpeed)
-        updateNowPlaying()
-        lastSyncedChapterIndex = chapterIndex
+    }
+
+    /// Whether a newer `play(bookId:)` has superseded the load that captured `generation`.
+    private func isSuperseded(_ generation: Int) -> Bool {
+        LoadGeneration.isSuperseded(taskGeneration: generation, current: loadGeneration)
     }
 
     // MARK: - Engine events
@@ -519,6 +626,10 @@ final class PlayerCoordinator: RemoteCommandHandler {
     private func handleEngineEvent(_ event: AudioEngineEvent) {
         switch event {
         case .position(let ms, let rate):
+            // Only a loaded book has a place to report to. Ignoring positions while `.preparing`
+            // (no `playingState`) drops any stale sample from the outgoing book during a switch,
+            // so it can't be written against the incoming book (RC-4).
+            guard phase.playingState != nil else { break }
             positionTracker.update(positionMs: ms, rate: rate)
             reportPositionIfNeeded(ms)
             if chapterIndex != lastSyncedChapterIndex {
@@ -530,26 +641,38 @@ final class PlayerCoordinator: RemoteCommandHandler {
         case .ended:
             handleBookEnded()
         case .failed(let message):
-            phase = .error(ErrorState(message: message, bookId: currentBookId))
+            // Attribute the failure to the phase's book, not `currentBookId` — during a switch
+            // the two can differ, and the error must name the book the engine was actually loading.
+            phase = .error(ErrorState(message: message, bookId: phase.bookId ?? currentBookId))
+            updateNowPlaying()
         }
     }
 
-    /// Collapse the engine's interleaved ready/buffering stream: only the
-    /// playing↔buffering pair transitions; a paused player ignores status churn.
+    /// Collapse the engine's interleaved ready/buffering stream into phase transitions.
+    /// `.ready` (timeControlStatus == .playing) promotes a buffering book to playing;
+    /// `.buffering` demotes a playing book. A paused player ignores status churn.
     private func applyEngineStatus(_ status: AudioEngineStatus) {
         guard let loaded = phase.playingState else { return }
         switch status {
         case .buffering:
-            if case .playing = phase { phase = .buffering(loaded) }
+            if case .playing = phase {
+                phase = .buffering(loaded)
+                updateNowPlaying()
+            }
         case .ready:
-            if case .buffering = phase { phase = .playing(loaded) }
+            if case .buffering = phase {
+                phase = .playing(loaded)
+                updateNowPlaying()
+            }
         case .idle:
             break
         }
     }
 
     private func reportPositionIfNeeded(_ positionMs: Int64) {
-        guard let id = currentBookId else { return }
+        // Report against the *loaded* book, not `currentBookId` — the latter is retargeted
+        // synchronously on switch, before the new book is loaded (RC-4).
+        guard let id = phase.playingState?.bookId else { return }
         if abs(positionMs - lastReportedPositionMs) >= Self.positionReportIntervalMs {
             lastReportedPositionMs = positionMs
             progress.onPositionUpdate(
@@ -559,8 +682,8 @@ final class PlayerCoordinator: RemoteCommandHandler {
     }
 
     private func handleBookEnded() {
-        guard let id = currentBookId, let loaded = phase.playingState else { return }
-        progress.onBookFinished(bookId: id, finalPositionMs: bookDurationMs)
+        guard let loaded = phase.playingState else { return }
+        progress.onBookFinished(bookId: loaded.bookId, finalPositionMs: bookDurationMs)
         phase = .paused(loaded)
         updateNowPlaying()
     }

--- a/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
+++ b/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
@@ -386,6 +386,10 @@ final class PlayerCoordinator: RemoteCommandHandler {
         let generation = loadGeneration
 
         // Save the outgoing book's place before we retarget — a switch must not lose it.
+        // Only silence the engine when there *was* an outgoing loaded book: an unconditional
+        // pause on a fresh (idle) play is a no-op on the real engine, but pre-fires the test
+        // engine's pause signal and desynchronizes the interruption fixtures.
+        let hadLoadedBook = phase.playingState != nil
         if let outgoing = phase.playingState {
             progress.onPlaybackPaused(bookId: outgoing.bookId, positionMs: bookPositionMs, speed: playbackSpeed)
         }
@@ -400,7 +404,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
         prepareTask = Task {
             // Silence the outgoing book immediately — before the (possibly slow) prepare —
             // so switching never leaves the previous audio playing under the new metadata.
-            await engine.pause()
+            if hadLoadedBook { await engine.pause() }
             await prepareAndStart(bookId: bookId, generation: generation)
         }
     }
@@ -450,7 +454,9 @@ final class PlayerCoordinator: RemoteCommandHandler {
     /// Seek to a whole-book position in milliseconds.
     func seekTo(positionMs: Int64) {
         Task { await engine.seek(toMs: positionMs) }
-        if let id = currentBookId {
+        // Report against the *loaded* book only — during `.preparing` the incoming book isn't
+        // loaded yet, and reporting a seek for it would corrupt its untouched resume position.
+        if let id = phase.playingState?.bookId {
             progress.onPositionUpdate(bookId: id, positionMs: positionMs, speed: playbackSpeed)
             lastReportedPositionMs = positionMs
         }
@@ -461,7 +467,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
     func setSpeed(_ speed: Float) {
         playbackSpeed = speed
         Task { await engine.setRate(speed) }
-        if let id = currentBookId {
+        if let id = phase.playingState?.bookId {
             progress.onSpeedChanged(
                 bookId: id, positionMs: bookPositionMs, newSpeed: speed
             )
@@ -507,7 +513,10 @@ final class PlayerCoordinator: RemoteCommandHandler {
     /// the app backgrounds/terminates — the periodic 5s tick is not enough to
     /// guarantee the user's place survives a kill.
     func saveCurrentPosition() async {
-        guard let id = currentBookId, isVisible else { return }
+        // Key on the *loaded* book, not `currentBookId`/`isVisible`: both are true during
+        // `.preparing` (the incoming book), and saving position 0 there would zero its
+        // untouched resume point before it ever starts.
+        guard let id = phase.playingState?.bookId else { return }
         await progress.savePositionNow(bookId: id, positionMs: bookPositionMs)
     }
 
@@ -568,17 +577,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
             if bookId == currentBookId { firstPdfDocId = id }
         }
 
-        let segments = prepared.timeline.files.compactMap { file -> AudioSegment? in
-            let url: URL
-            if let localPath = file.localPath {
-                url = URL(fileURLWithPath: localPath)
-            } else if let remote = URL(string: file.streamingUrl) {
-                url = remote
-            } else {
-                return nil
-            }
-            return AudioSegment(url: url, durationMs: file.durationMs, offsetMs: file.startOffsetMs)
-        }
+        let segments = Self.resolveSegments(prepared.timeline.files)
         guard !segments.isEmpty else {
             guard !isSuperseded(generation) else { return }
             phase = .error(ErrorState(message: "This book has no audio.", bookId: bookId))
@@ -590,13 +589,12 @@ final class PlayerCoordinator: RemoteCommandHandler {
         let loaded = await engine.load(segments: segments, startPositionMs: prepared.resumePositionMs)
         guard !isSuperseded(generation) else { return }
         guard loaded else {
-            // The engine may have already emitted `.failed` (→ `.error`); don't clobber it.
-            if case .error = phase { return }
+            // The incoming book's own load failure is reported here (RC-5). No separate
+            // "error already set" check is needed: engine events are dropped while `.preparing`
+            // (see `handleEngineEvent`), so nothing can flip `phase` to `.error` mid-load.
             phase = .error(ErrorState(message: "Couldn't start playback.", bookId: bookId))
             return
         }
-        // RC-5: a failure event may have landed during load — never start over an error state.
-        if case .error = phase { return }
 
         // RC-3: enter `.buffering` *before* starting the engine, so the first real
         // `timeControlStatus == .playing` event promotes it to `.playing`. Setting the phase
@@ -621,14 +619,34 @@ final class PlayerCoordinator: RemoteCommandHandler {
         LoadGeneration.isSuperseded(taskGeneration: generation, current: loadGeneration)
     }
 
+    /// Resolve the prepared timeline's files into playable `AudioSegment`s — the local file when
+    /// downloaded, else the streaming URL; files with neither are dropped.
+    private static func resolveSegments(_ files: [PreparedFile]) -> [AudioSegment] {
+        files.compactMap { file -> AudioSegment? in
+            let url: URL
+            if let localPath = file.localPath {
+                url = URL(fileURLWithPath: localPath)
+            } else if let remote = URL(string: file.streamingUrl) {
+                url = remote
+            } else {
+                return nil
+            }
+            return AudioSegment(url: url, durationMs: file.durationMs, offsetMs: file.startOffsetMs)
+        }
+    }
+
     // MARK: - Engine events
 
     private func handleEngineEvent(_ event: AudioEngineEvent) {
+        // Drop any engine event that arrives while a new book is preparing: it predates the
+        // incoming book's `engine.load` and belongs to the *outgoing* book. Critically this
+        // covers `.failed` — a late failure KVO from book A must not be attributed to book B
+        // and abort its start (RC-4). The incoming book's own load failure surfaces via
+        // `engine.load` returning `false`, never via a buffered event.
+        if case .preparing = phase { return }
         switch event {
         case .position(let ms, let rate):
-            // Only a loaded book has a place to report to. Ignoring positions while `.preparing`
-            // (no `playingState`) drops any stale sample from the outgoing book during a switch,
-            // so it can't be written against the incoming book (RC-4).
+            // Only a loaded book has a place to report to (guards `.idle`/`.error` too).
             guard phase.playingState != nil else { break }
             positionTracker.update(positionMs: ms, rate: rate)
             reportPositionIfNeeded(ms)
@@ -717,7 +735,9 @@ final class PlayerCoordinator: RemoteCommandHandler {
             artist: authorName,
             durationMs: bookDurationMs,
             elapsedMs: bookPositionMs,
-            rate: isPlaying ? Double(playbackSpeed) : 0,
+            // Report a non-zero rate while buffering too, so the lock-screen control shows a
+            // live "pause" affordance during the startup buffer rather than a dead play button.
+            rate: isPlaybackActive ? Double(playbackSpeed) : 0,
             artworkPath: coverPath
         ))
     }

--- a/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
+++ b/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
@@ -221,6 +221,12 @@ final class PlayerCoordinator: RemoteCommandHandler {
     /// Bumped on every `play(bookId:)`. The current epoch; an in-flight prepare compares the
     /// generation it captured against this after each `await` and abandons if superseded.
     private var loadGeneration = 0
+    /// True from the start of a `play(bookId:)` until its `engine.load` resolves. While set, all
+    /// engine events are dropped in `handleEngineEvent` — they belong to the outgoing book or to
+    /// the muted preroll, never to the freshly-buffering incoming book. Decoupled from the
+    /// `.preparing` phase so the UI can show the honest `.buffering(duration)` state *during* the
+    /// load while these events are still gated.
+    private var isEngineLoading = false
     /// True only while playback is paused *because of* an audio-session
     /// interruption. Gates `.ended + .shouldResume`: resume is honored only
     /// when the interruption did the pausing — a user's deliberate pause is
@@ -384,6 +390,8 @@ final class PlayerCoordinator: RemoteCommandHandler {
         prepareTask?.cancel()
         loadGeneration &+= 1
         let generation = loadGeneration
+        // Gate engine events for the whole switch→load window (see `isEngineLoading`).
+        isEngineLoading = true
 
         // Save the outgoing book's place before we retarget — a switch must not lose it.
         // Only silence the engine when there *was* an outgoing loaded book: an unconditional
@@ -525,7 +533,13 @@ final class PlayerCoordinator: RemoteCommandHandler {
     /// *before* the call returns.
     func stop() async {
         pausedByInterruption = false
+        // Supersede any in-flight `prepareAndStart`: `Task.cancel()` alone does not interrupt its
+        // non-cancellation-checking `await`s (prepare, engine.load), so without bumping the epoch a
+        // load that resolves after teardown would call `engine.play()` on the released engine and
+        // resurrect `.playing`. Bumping `loadGeneration` makes it bail at its next `!isSuperseded`.
         prepareTask?.cancel()
+        loadGeneration &+= 1
+        isEngineLoading = false
         bridge.cancelAll()
         positionTracker.reset()
         await engine.deactivateSession()
@@ -549,6 +563,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
     private func prepareAndStart(bookId: String, generation: Int) async {
         guard let prepared = await preparer.prepare(bookId: bookId) else {
             guard !isSuperseded(generation) else { return }
+            isEngineLoading = false
             phase = .error(ErrorState(message: "Couldn't start playback.", bookId: bookId))
             return
         }
@@ -565,43 +580,46 @@ final class PlayerCoordinator: RemoteCommandHandler {
         positionTracker.update(positionMs: prepared.resumePositionMs, rate: 0)
         lastReportedPositionMs = prepared.resumePositionMs
 
-        let blurHash = await coverProvider.coverBlurHash(bookId: bookId)
-        guard !isSuperseded(generation) else { return }
-        coverBlurHash = blurHash
-
-        // Resolve PDF availability concurrently — does not block audio start.
-        // Guard against a stale result landing after a rapid book switch: only apply
-        // the resolved id if this book is still the current one.
-        Task {
-            let id = await documentProvider.firstPdfDocId(bookId: bookId)
-            if bookId == currentBookId { firstPdfDocId = id }
-        }
-
         let segments = Self.resolveSegments(prepared.timeline.files)
         guard !segments.isEmpty else {
             guard !isSuperseded(generation) else { return }
+            isEngineLoading = false
             phase = .error(ErrorState(message: "This book has no audio.", bookId: bookId))
             return
+        }
+
+        // Honest buffering UI: show the book with its REAL duration and a buffering state the
+        // instant we know them — before the (possibly slow, streaming) load — instead of holding
+        // the UI at "0m / preparing". Engine events stay gated by `isEngineLoading` through the
+        // load, so this early `.buffering` never absorbs the outgoing book's or the muted preroll's
+        // events. The first real `timeControlStatus == .playing` (after the gate lifts) promotes it
+        // to `.playing`.
+        phase = .buffering(PlayingState(bookId: bookId, durationMs: prepared.timeline.totalDurationMs))
+        lastSyncedChapterIndex = chapterIndex
+        updateNowPlaying()
+
+        // Blur-hash + PDF availability resolve concurrently — neither blocks the audio start, and
+        // the cover already renders from `coverPath`. Guard stale results after a rapid switch.
+        let blurHash = await coverProvider.coverBlurHash(bookId: bookId)
+        if !isSuperseded(generation) { coverBlurHash = blurHash }
+        Task {
+            let id = await documentProvider.firstPdfDocId(bookId: bookId)
+            if bookId == currentBookId { firstPdfDocId = id }
         }
 
         // `load` awaits readiness and seeks to the resume position before returning, so
         // playback starts from the right place (RC-2). A `false` result means the load failed.
         let loaded = await engine.load(segments: segments, startPositionMs: prepared.resumePositionMs)
         guard !isSuperseded(generation) else { return }
+        // The load is done — lift the event gate so the engine's real playing/buffering/position
+        // events drive the phase from here on.
+        isEngineLoading = false
         guard loaded else {
-            // The incoming book's own load failure is reported here (RC-5). No separate
-            // "error already set" check is needed: engine events are dropped while `.preparing`
-            // (see `handleEngineEvent`), so nothing can flip `phase` to `.error` mid-load.
+            // The incoming book's own load failure is reported here (RC-5). Its failure surfaces
+            // via `load` returning false, not via a gated engine event.
             phase = .error(ErrorState(message: "Couldn't start playback.", bookId: bookId))
             return
         }
-
-        // RC-3: enter `.buffering` *before* starting the engine, so the first real
-        // `timeControlStatus == .playing` event promotes it to `.playing`. Setting the phase
-        // after `play()` would race that event and could lose the promotion (stuck buffering).
-        phase = .buffering(PlayingState(bookId: bookId, durationMs: prepared.timeline.totalDurationMs))
-        lastSyncedChapterIndex = chapterIndex
-        updateNowPlaying()
 
         await engine.setRate(prepared.resumeSpeed)
         guard !isSuperseded(generation) else { return }
@@ -638,12 +656,14 @@ final class PlayerCoordinator: RemoteCommandHandler {
     // MARK: - Engine events
 
     private func handleEngineEvent(_ event: AudioEngineEvent) {
-        // Drop any engine event that arrives while a new book is preparing: it predates the
-        // incoming book's `engine.load` and belongs to the *outgoing* book. Critically this
-        // covers `.failed` — a late failure KVO from book A must not be attributed to book B
-        // and abort its start (RC-4). The incoming book's own load failure surfaces via
-        // `engine.load` returning `false`, never via a buffered event.
-        if case .preparing = phase { return }
+        // Drop any engine event that arrives while a book is loading (`isEngineLoading`): it
+        // predates the incoming book's `engine.load` completing and belongs to the *outgoing*
+        // book or to the muted preroll. Critically this covers `.failed` — a late failure KVO
+        // from book A must not be attributed to book B and abort its start (RC-4). The incoming
+        // book's own load failure surfaces via `engine.load` returning `false`, never via a gated
+        // event. Gated on the flag, not the `.preparing` phase, so the honest `.buffering(duration)`
+        // state can be shown *during* the load while these events stay suppressed.
+        if isEngineLoading { return }
         switch event {
         case .position(let ms, let rate):
             // Only a loaded book has a place to report to (guards `.idle`/`.error` too).
@@ -735,9 +755,12 @@ final class PlayerCoordinator: RemoteCommandHandler {
             artist: authorName,
             durationMs: bookDurationMs,
             elapsedMs: bookPositionMs,
-            // Report a non-zero rate while buffering too, so the lock-screen control shows a
-            // live "pause" affordance during the startup buffer rather than a dead play button.
-            rate: isPlaybackActive ? Double(playbackSpeed) : 0,
+            // Report a live rate ONLY while audio is actually advancing (`.playing`) — not while
+            // buffering. `MPNowPlayingInfoCenter` extrapolates the displayed elapsed time as
+            // `elapsed + rate·wallclock`, so a non-zero rate during the (now much longer) pre-load
+            // buffer would tick the lock-screen clock forward from the resume point and then snap
+            // it back when real playback starts. Rate 0 while buffering keeps elapsed honest.
+            rate: isPlaying ? Double(playbackSpeed) : 0,
             artworkPath: coverPath
         ))
     }

--- a/iosApp/ListenUp/Features/SeriesDetail/SeriesDetailObserver.swift
+++ b/iosApp/ListenUp/Features/SeriesDetail/SeriesDetailObserver.swift
@@ -59,9 +59,10 @@ final class SeriesDetailObserver {
         return String(localized: hasStarted ? "series.continue" : "series.start_listening")
     }
 
-    /// True when `bookId` is the actively-playing book.
+    /// True when `bookId` is the active book (playing OR buffering toward playing), so the row's
+    /// glyph shows "pause" during the startup buffer instead of a play button that pauses.
     func isPlaying(_ bookId: String) -> Bool {
-        playerCoordinator.currentBookId == bookId && playerCoordinator.isPlaying
+        playerCoordinator.currentBookId == bookId && playerCoordinator.isPlaybackActive
     }
 
     func progress(for bookId: String) -> Float? { bookProgress[bookId] }

--- a/iosApp/ListenUpTests/CoverImageRequestTests.swift
+++ b/iosApp/ListenUpTests/CoverImageRequestTests.swift
@@ -1,0 +1,57 @@
+import Nuke
+import Foundation
+import Testing
+@testable import ListenUp
+
+/// Pins the local-file cache-key policy that prevents the "cover never changes" bug (RC-1):
+/// a `bookId`-scoped key is only content-safe when it folds in the content hash, because
+/// during a book switch `bookId` advances while `coverPath` can still point at the previous
+/// book's file. Without a hash the key must fall back to the file path, never `bookId` alone.
+@Suite("CoverImageRequest cache keying")
+struct CoverImageRequestTests {
+    @Test func localKeyWithoutHashUsesPathNotBookId() {
+        let key = CoverImageRequest.localFileCacheKey(
+            bookId: "book-B", coverPath: "/covers/a.jpg", coverHash: nil
+        )
+        #expect(key == "/covers/a.jpg")
+        #expect(key != "book-B:cover")
+    }
+
+    @Test func localKeyWithEmptyHashUsesPath() {
+        let key = CoverImageRequest.localFileCacheKey(
+            bookId: "book-B", coverPath: "/covers/a.jpg", coverHash: ""
+        )
+        #expect(key == "/covers/a.jpg")
+    }
+
+    @Test func localKeyWithHashFoldsBookIdAndHash() {
+        let key = CoverImageRequest.localFileCacheKey(
+            bookId: "book-B", coverPath: "/covers/a.jpg", coverHash: "abc123"
+        )
+        #expect(key == "book-B:abc123")
+    }
+
+    @Test func localKeyWithHashButNoBookIdFoldsPathAndHash() {
+        let key = CoverImageRequest.localFileCacheKey(
+            bookId: nil, coverPath: "/covers/a.jpg", coverHash: "abc123"
+        )
+        #expect(key == "/covers/a.jpg:abc123")
+    }
+
+    /// End-to-end through `CoverImageRequest.book`: the player call sites pass no `coverHash`,
+    /// so the resulting request must be path-keyed — never stamped with the bookId, which is
+    /// what poisoned the shared cache with the previous book's bytes.
+    @Test @MainActor func bookRequestWithoutHashIsPathKeyed() async {
+        let request = await CoverImageRequest.book(
+            bookId: "book-B", coverPath: "/covers/a.jpg", coverHash: nil, targetPixels: 100
+        )
+        #expect(request?.userInfo[.imageIdKey] as? String == "/covers/a.jpg")
+    }
+
+    @Test @MainActor func bookRequestWithHashIsHashKeyed() async {
+        let request = await CoverImageRequest.book(
+            bookId: "book-B", coverPath: "/covers/a.jpg", coverHash: "abc123", targetPixels: 100
+        )
+        #expect(request?.userInfo[.imageIdKey] as? String == "book-B:abc123")
+    }
+}

--- a/iosApp/ListenUpTests/CoverImageRequestTests.swift
+++ b/iosApp/ListenUpTests/CoverImageRequestTests.swift
@@ -38,6 +38,19 @@ struct CoverImageRequestTests {
         #expect(key == "/covers/a.jpg:abc123")
     }
 
+    /// The **server-URL** branch keys on `contentHashKey`, which returns `nil` without a hash —
+    /// so the request falls back to Nuke's URL-derived key (`/api/v1/covers/{bookId}`, already
+    /// unique per book) and NEVER the poisoned `"bookId:cover"` key. This closes the residual
+    /// where a switch (coverPath cleared, bookId = B) would flash book A's cached bytes on B.
+    @Test func serverBranchWithoutHashIsNotBookIdKeyed() {
+        #expect(CoverImageRequest.contentHashKey(identity: "book-B", coverHash: nil) == nil)
+        #expect(CoverImageRequest.contentHashKey(identity: "book-B", coverHash: "") == nil)
+    }
+
+    @Test func serverBranchWithHashIsContentKeyed() {
+        #expect(CoverImageRequest.contentHashKey(identity: "book-B", coverHash: "abc123") == "book-B:abc123")
+    }
+
     /// End-to-end through `CoverImageRequest.book`: the player call sites pass no `coverHash`,
     /// so the resulting request must be path-keyed — never stamped with the bookId, which is
     /// what poisoned the shared cache with the previous book's bytes.

--- a/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
+++ b/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
@@ -52,9 +52,17 @@ actor FakePlaybackEngine: PlaybackEngine {
     /// Toggle whether `play()` auto-emits `.ready` (actor-isolated state needs a setter).
     func setAutoReadyOnPlay(_ auto: Bool) { autoReadyOnPlay = auto }
 
+    /// When true, `load` signals entry then suspends until `releaseLoad()` — lets a test hold a
+    /// load open and observe the coordinator's intermediate (buffering) state while it's in flight.
+    private var shouldBlockLoad = false
+    private var loadBlocker: CheckedContinuation<Void, Never>?
+    func setBlockLoad(_ block: Bool) { shouldBlockLoad = block }
+    func releaseLoad() { loadBlocker?.resume(); loadBlocker = nil }
+
     func load(segments: [AudioSegment], startPositionMs: Int64) async -> Bool {
         didLoad = true; lastLoadStartMs = startPositionMs; commandLog.append("load")
         gate.fire("load")
+        if shouldBlockLoad { await withCheckedContinuation { loadBlocker = $0 } }
         return !loadShouldFail
     }
     func play() async {
@@ -83,6 +91,9 @@ actor FakePlaybackEngine: PlaybackEngine {
     /// Suspend until `play()` has executed for the `count`-th time. Keyed, because a
     /// predicate closure can't read this actor's state (see AsyncGate lines 46–59).
     func waitForPlayCount(_ count: Int) async { await gate.wait(forKey: "play-\(count)") }
+
+    /// Suspend until `load` has been entered (before it returns / while blocked).
+    func waitForLoadEntered() async { await gate.wait(forKey: "load") }
 }
 
 // MARK: - Task 2 seam fakes

--- a/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
+++ b/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
@@ -9,10 +9,15 @@ actor FakePlaybackEngine: PlaybackEngine {
 
     private(set) var didPlay = false
     private(set) var didPause = false
+    private(set) var didLoad = false
+    private(set) var lastLoadStartMs: Int64?
     private(set) var lastSeekMs: Int64?
     private(set) var lastRate: Float?
     private(set) var lastVolume: Float?
     private(set) var didRelease = false
+    /// When true, `load` reports failure (returns `false`) so tests can exercise the
+    /// coordinator's load-failure → `.error` path without a live `AVPlayer`.
+    var loadShouldFail = false
     private(set) var didDeactivateSession = false
     private(set) var didActivateSession = false
     private(set) var playCount = 0
@@ -36,9 +41,19 @@ actor FakePlaybackEngine: PlaybackEngine {
     /// Push an event into the coordinator's bound stream from a test.
     nonisolated func emit(_ event: AudioEngineEvent) { continuation.yield(event) }
 
-    func load(segments: [AudioSegment], startPositionMs: Int64) async {}
+    /// Toggle the load-failure simulation (actor-isolated state needs a setter).
+    func setLoadShouldFail(_ shouldFail: Bool) { loadShouldFail = shouldFail }
+
+    func load(segments: [AudioSegment], startPositionMs: Int64) async -> Bool {
+        didLoad = true; lastLoadStartMs = startPositionMs; commandLog.append("load")
+        gate.fire("load")
+        return !loadShouldFail
+    }
     func play() async {
         didPlay = true; playCount += 1; commandLog.append("play")
+        // Mirror a real player reaching `timeControlStatus == .playing`: emit `.ready` so the
+        // coordinator promotes its optimistic `.buffering` phase to `.playing`.
+        continuation.yield(.statusChanged(.ready))
         gate.fire("play"); gate.fire("play-\(playCount)")
     }
     func pause() async { didPause = true; commandLog.append("pause"); gate.fire("pause") }

--- a/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
+++ b/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
@@ -18,6 +18,11 @@ actor FakePlaybackEngine: PlaybackEngine {
     /// When true, `load` reports failure (returns `false`) so tests can exercise the
     /// coordinator's load-failure → `.error` path without a live `AVPlayer`.
     var loadShouldFail = false
+    /// When true (default), `play()` emits `.statusChanged(.ready)` to mirror a real player
+    /// reaching `timeControlStatus == .playing`, so the coordinator's `.buffering` phase
+    /// promotes to `.playing`. Tests that want to *observe* the buffering→playing transition
+    /// deterministically set this false and drive the promotion with an explicit `emit(.ready)`.
+    var autoReadyOnPlay = true
     private(set) var didDeactivateSession = false
     private(set) var didActivateSession = false
     private(set) var playCount = 0
@@ -44,6 +49,9 @@ actor FakePlaybackEngine: PlaybackEngine {
     /// Toggle the load-failure simulation (actor-isolated state needs a setter).
     func setLoadShouldFail(_ shouldFail: Bool) { loadShouldFail = shouldFail }
 
+    /// Toggle whether `play()` auto-emits `.ready` (actor-isolated state needs a setter).
+    func setAutoReadyOnPlay(_ auto: Bool) { autoReadyOnPlay = auto }
+
     func load(segments: [AudioSegment], startPositionMs: Int64) async -> Bool {
         didLoad = true; lastLoadStartMs = startPositionMs; commandLog.append("load")
         gate.fire("load")
@@ -52,8 +60,9 @@ actor FakePlaybackEngine: PlaybackEngine {
     func play() async {
         didPlay = true; playCount += 1; commandLog.append("play")
         // Mirror a real player reaching `timeControlStatus == .playing`: emit `.ready` so the
-        // coordinator promotes its optimistic `.buffering` phase to `.playing`.
-        continuation.yield(.statusChanged(.ready))
+        // coordinator promotes its optimistic `.buffering` phase to `.playing`. Suppressed when
+        // a test wants to assert the buffering→playing transition explicitly.
+        if autoReadyOnPlay { continuation.yield(.statusChanged(.ready)) }
         gate.fire("play"); gate.fire("play-\(playCount)")
     }
     func pause() async { didPause = true; commandLog.append("pause"); gate.fire("pause") }
@@ -111,10 +120,12 @@ final class FakeProgressReporting: PlaybackProgressReporting, @unchecked Sendabl
 
     /// Suspend until playback has been reported started for `bookId`.
     ///
-    /// This is the canonical "the coordinator has finished starting" anchor: the coordinator
-    /// sets `phase = .playing` and *then* calls `onPlaybackStarted`, so once this returns the
-    /// observable surface (`isPlaying`, `isVisible`, `phase.playingState`) is already consistent.
-    /// Anchoring on `engine.play()` instead would race the coordinator's post-`play` phase write.
+    /// This is the canonical "the coordinator has issued the start" anchor: the coordinator
+    /// enters `.buffering`, calls `engine.play()`, then reports `onPlaybackStarted` — so once
+    /// this returns, `isVisible` and `phase.playingState` are consistent, but `isPlaying` is
+    /// **not yet true**. The engine's first "playing" status event (auto-emitted by
+    /// `FakePlaybackEngine.play()`) promotes `.buffering → .playing` shortly after; a test that
+    /// needs `isPlaying == true` should `await awaitUntil { coordinator.isPlaying }` after this.
     func waitForStarted(bookId: String) async {
         await gate.wait { [weak self] in self?.startedCalls.contains { $0.0 == bookId } ?? false }
     }

--- a/iosApp/ListenUpTests/PlayerCoordinatorTests.swift
+++ b/iosApp/ListenUpTests/PlayerCoordinatorTests.swift
@@ -648,6 +648,10 @@ struct PlaybackLifecycleTests {
         // coordinator sets `phase = .playing` *then* reports started, so awaiting the engine
         // command would race the phase write and read `isPlaying` before it flips.
         await progress.waitForStarted(bookId: "book1")
+        // The coordinator starts in `.buffering` and is promoted to `.playing` by the engine's
+        // first "playing" status event (RC-3); await that promotion rather than asserting it
+        // the instant `onPlaybackStarted` lands.
+        await awaitUntil { coordinator.isPlaying }
         #expect(coordinator.isPlaying)
         #expect(coordinator.isVisible)
 

--- a/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
+++ b/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
@@ -11,7 +11,7 @@ import Shared
 struct PlayerSwitchPathTests {
     private func makeCoordinator(
         coverPath: String? = "/covers/a.jpg"
-    ) -> (PlayerCoordinator, FakePlaybackEngine, FakeProgressReporting, FakePlaybackPreparing) {
+    ) -> (PlayerCoordinator, FakePlaybackEngine, FakeProgressReporting) {
         let engine = FakePlaybackEngine()
         let progress = FakeProgressReporting()
         let preparer = FakePlaybackPreparing()
@@ -25,13 +25,13 @@ struct PlayerSwitchPathTests {
         let coordinator = PlayerCoordinator(
             preparer: preparer, progress: progress, sleep: FakeSleepTiming(),
             engine: engine, coverProvider: FakeBookCoverProviding())
-        return (coordinator, engine, progress, preparer)
+        return (coordinator, engine, progress)
     }
 
     /// RC-1(a): switching clears the cover/chapters/title *synchronously*, before the async
     /// prepare — so the UI never renders the outgoing book's cover against the incoming book's id.
     @Test func switchingClearsMetadataSynchronously() async {
-        let (coordinator, _, progress, _) = makeCoordinator()
+        let (coordinator, _, progress) = makeCoordinator()
         coordinator.play(bookId: "book1")
         await progress.waitForStarted(bookId: "book1")
         #expect(coordinator.coverPath == "/covers/a.jpg")
@@ -42,14 +42,14 @@ struct PlayerSwitchPathTests {
         // incoming book's prepare has not yet run.
         #expect(coordinator.coverPath == nil)
         #expect(coordinator.chapters.isEmpty)
-        #expect(coordinator.bookTitle == "")
+        #expect(coordinator.bookTitle.isEmpty)
         #expect(coordinator.currentBookId == "book2")
     }
 
     /// RC-4: a rapid A→B switch supersedes A's prepare before it completes; only B ends up
     /// loaded, and A never reports a phantom start.
     @Test func rapidSwitchLandsOnLastBookOnly() async {
-        let (coordinator, _, progress, _) = makeCoordinator()
+        let (coordinator, _, progress) = makeCoordinator()
         coordinator.play(bookId: "book1")
         coordinator.play(bookId: "book2")   // supersedes book1 before its prepare resolves
         await progress.waitForStarted(bookId: "book2")
@@ -62,7 +62,7 @@ struct PlayerSwitchPathTests {
 
     /// A switch away from a playing book saves the outgoing book's place first.
     @Test func switchingFromPlayingBookSavesOutgoingPosition() async {
-        let (coordinator, _, progress, _) = makeCoordinator()
+        let (coordinator, _, progress) = makeCoordinator()
         coordinator.play(bookId: "book1")
         await progress.waitForStarted(bookId: "book1")
 
@@ -75,19 +75,29 @@ struct PlayerSwitchPathTests {
     }
 
     /// RC-3: a fresh load enters `.buffering` and is promoted to `.playing` only by the engine's
-    /// first real "playing" status event — never optimistically.
+    /// first real "playing" status event — never optimistically. With the fake's auto-ready
+    /// suppressed, the coordinator must sit in `.buffering` after start and only reach `.playing`
+    /// once an explicit `.ready` arrives.
     @Test func freshLoadEntersBufferingThenPlaying() async {
-        let (coordinator, _, progress, _) = makeCoordinator()
+        let (coordinator, engine, progress) = makeCoordinator()
+        await engine.setAutoReadyOnPlay(false)
+
         coordinator.play(bookId: "book1")
         await progress.waitForStarted(bookId: "book1")
+        // Started, but not yet playing — the engine hasn't reported audio advancing.
+        #expect(coordinator.isBuffering)
+        #expect(!coordinator.isPlaying)
+
+        engine.emit(.statusChanged(.ready))   // the first real "playing" event
         await awaitUntil { coordinator.isPlaying }
         #expect(coordinator.isPlaying)
+        #expect(!coordinator.isBuffering)
     }
 
     /// RC-5: a load failure surfaces `.error`; toggling the errored book retries it rather than
     /// no-oping, so the user is never stranded on a dead player.
     @Test func errorStateIsRecoverableByToggle() async {
-        let (coordinator, engine, progress, _) = makeCoordinator()
+        let (coordinator, engine, progress) = makeCoordinator()
         await engine.setLoadShouldFail(true)
 
         coordinator.play(bookId: "book1")

--- a/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
+++ b/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
@@ -74,6 +74,26 @@ struct PlayerSwitchPathTests {
         #expect(coordinator.currentBookId == "book2")
     }
 
+    /// Honest buffering UI: the instant prepare resolves, the player shows the real book — its
+    /// real duration and a buffering state — instead of sitting at "0m / preparing" for the whole
+    /// (possibly slow, streaming) load. So while the engine's load is still in flight, phase is
+    /// already `.buffering` carrying the duration, and the mini-player is visible with it.
+    @Test func showsRealDurationAndBuffersWhileLoadInFlight() async {
+        let (coordinator, engine, progress) = makeCoordinator()
+        await engine.setBlockLoad(true)   // hold the load open to observe the intermediate state
+
+        coordinator.play(bookId: "book1")
+        await engine.waitForLoadEntered()  // prepare done, engine.load called and now suspended
+
+        // Mid-load the UI is already honest — real duration, buffering, visible — not 0m/paused.
+        #expect(coordinator.bookDurationMs == 60000)
+        #expect(coordinator.isBuffering)
+        #expect(coordinator.isVisible)
+
+        await engine.releaseLoad()
+        await progress.waitForStarted(bookId: "book1")
+    }
+
     /// RC-3: a fresh load enters `.buffering` and is promoted to `.playing` only by the engine's
     /// first real "playing" status event — never optimistically. With the fake's auto-ready
     /// suppressed, the coordinator must sit in `.buffering` after start and only reach `.playing`
@@ -92,6 +112,26 @@ struct PlayerSwitchPathTests {
         await awaitUntil { coordinator.isPlaying }
         #expect(coordinator.isPlaying)
         #expect(!coordinator.isBuffering)
+    }
+
+    /// `stop()` mid-load must supersede the in-flight load so it can't resurrect playback on a
+    /// released engine — no phantom `onPlaybackStarted`, no `.playing` after teardown. (`Task.cancel()`
+    /// alone doesn't interrupt the load's non-cancellation-checking awaits, so `stop()` bumps the epoch.)
+    @Test func stopDuringLoadDoesNotResurrectPlayback() async {
+        let (coordinator, engine, progress) = makeCoordinator()
+        await engine.setBlockLoad(true)
+
+        coordinator.play(bookId: "book1")
+        await engine.waitForLoadEntered()   // load is in flight, blocked
+
+        await coordinator.stop()            // teardown must supersede the in-flight load
+        await engine.releaseLoad()          // let the (now superseded) load resolve
+        await Task.yield()                  // give the superseded continuation a chance to (wrongly) start
+
+        #expect(!progress.startedCalls.contains { $0.0 == "book1" })
+        if case .playing = coordinator.phase {
+            Issue.record("phase resurrected to .playing after stop()")
+        }
     }
 
     /// RC-5: a load failure surfaces `.error`; toggling the errored book retries it rather than

--- a/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
+++ b/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
@@ -1,0 +1,121 @@
+import Testing
+import AVFoundation
+@testable import ListenUp
+import Shared
+
+/// Coverage for the book-switch path (`play(bookId:)` while another book is loaded/preparing):
+/// the metadata surface resets synchronously (RC-1), a superseded prepare can't clobber the
+/// new book (RC-4), the outgoing book's place is saved, and an errored book can be retried (RC-5).
+@Suite("Player switch path")
+@MainActor
+struct PlayerSwitchPathTests {
+    private func makeCoordinator(
+        coverPath: String? = "/covers/a.jpg"
+    ) -> (PlayerCoordinator, FakePlaybackEngine, FakeProgressReporting, FakePlaybackPreparing) {
+        let engine = FakePlaybackEngine()
+        let progress = FakeProgressReporting()
+        let preparer = FakePlaybackPreparing()
+        preparer.result = PreparedPlayback(
+            bookTitle: "T", bookAuthor: "A", bookNarrator: "N", coverPath: coverPath, resumeSpeed: 1.0,
+            resumePositionMs: 0,
+            chapters: [Chapter(id: "c0", title: "c0", duration: 1000, startTime: 0)],
+            timeline: PreparedTimeline(totalDurationMs: 60000, files: [
+                PreparedFile(localPath: "/a.m4a", streamingUrl: "", durationMs: 60000, startOffsetMs: 0)])
+        )
+        let coordinator = PlayerCoordinator(
+            preparer: preparer, progress: progress, sleep: FakeSleepTiming(),
+            engine: engine, coverProvider: FakeBookCoverProviding())
+        return (coordinator, engine, progress, preparer)
+    }
+
+    /// RC-1(a): switching clears the cover/chapters/title *synchronously*, before the async
+    /// prepare — so the UI never renders the outgoing book's cover against the incoming book's id.
+    @Test func switchingClearsMetadataSynchronously() async {
+        let (coordinator, _, progress, _) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+        #expect(coordinator.coverPath == "/covers/a.jpg")
+        #expect(!coordinator.chapters.isEmpty)
+
+        coordinator.play(bookId: "book2")
+        // No `await` before these reads: the reset is synchronous, so it has happened while the
+        // incoming book's prepare has not yet run.
+        #expect(coordinator.coverPath == nil)
+        #expect(coordinator.chapters.isEmpty)
+        #expect(coordinator.bookTitle == "")
+        #expect(coordinator.currentBookId == "book2")
+    }
+
+    /// RC-4: a rapid A→B switch supersedes A's prepare before it completes; only B ends up
+    /// loaded, and A never reports a phantom start.
+    @Test func rapidSwitchLandsOnLastBookOnly() async {
+        let (coordinator, _, progress, _) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        coordinator.play(bookId: "book2")   // supersedes book1 before its prepare resolves
+        await progress.waitForStarted(bookId: "book2")
+
+        #expect(coordinator.currentBookId == "book2")
+        #expect(coordinator.phase.bookId == "book2")
+        #expect(progress.startedCalls.contains { $0.0 == "book2" })
+        #expect(!progress.startedCalls.contains { $0.0 == "book1" })
+    }
+
+    /// A switch away from a playing book saves the outgoing book's place first.
+    @Test func switchingFromPlayingBookSavesOutgoingPosition() async {
+        let (coordinator, _, progress, _) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+
+        coordinator.play(bookId: "book2")
+        // The outgoing save is issued synchronously in `play`, before the new prepare.
+        #expect(progress.pausedCalls.contains { $0.0 == "book1" })
+
+        await progress.waitForStarted(bookId: "book2")
+        #expect(coordinator.currentBookId == "book2")
+    }
+
+    /// RC-3: a fresh load enters `.buffering` and is promoted to `.playing` only by the engine's
+    /// first real "playing" status event — never optimistically.
+    @Test func freshLoadEntersBufferingThenPlaying() async {
+        let (coordinator, _, progress, _) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+        await awaitUntil { coordinator.isPlaying }
+        #expect(coordinator.isPlaying)
+    }
+
+    /// RC-5: a load failure surfaces `.error`; toggling the errored book retries it rather than
+    /// no-oping, so the user is never stranded on a dead player.
+    @Test func errorStateIsRecoverableByToggle() async {
+        let (coordinator, engine, progress, _) = makeCoordinator()
+        await engine.setLoadShouldFail(true)
+
+        coordinator.play(bookId: "book1")
+        await awaitUntil {
+            if case .error = coordinator.phase { return true }
+            return false
+        }
+        guard case .error = coordinator.phase else {
+            Issue.record("expected .error, got \(coordinator.phase)")
+            return
+        }
+
+        await engine.setLoadShouldFail(false)
+        coordinator.togglePlayback()   // retry
+        await progress.waitForStarted(bookId: "book1")
+        await awaitUntil { coordinator.isPlaying }
+        #expect(coordinator.isPlaying)
+    }
+}
+
+/// The load-generation guard predicate in isolation — a plain epoch comparison, no coordinator.
+@Suite("LoadGeneration")
+struct LoadGenerationTests {
+    @Test func sameGenerationIsNotSuperseded() {
+        #expect(LoadGeneration.isSuperseded(taskGeneration: 3, current: 3) == false)
+    }
+
+    @Test func olderGenerationIsSuperseded() {
+        #expect(LoadGeneration.isSuperseded(taskGeneration: 2, current: 3))
+    }
+}

--- a/iosApp/ListenUpTests/PositionTrackerTests.swift
+++ b/iosApp/ListenUpTests/PositionTrackerTests.swift
@@ -36,6 +36,30 @@ struct PositionTrackerTests {
     }
 }
 
+@Suite("PositionTracker reset & seed")
+@MainActor
+struct PositionTrackerResetTests {
+    /// Seeding with a paused sample (rate 0) surfaces the resume position immediately, so the
+    /// UI shows the right chapter/time before the engine's first real sample (RC-2). Rate 0 is
+    /// deliberate: it holds the value exactly, without starting the interpolating display link.
+    @Test func seedSurfacesResumePosition() {
+        let tracker = PositionTracker()
+        tracker.update(positionMs: 42_000, rate: 0)
+        #expect(tracker.positionMs == 42_000)
+        #expect(tracker.displayPositionMs == 42_000)
+    }
+
+    /// Reset zeroes the position — the switch path relies on this to clear the outgoing book's
+    /// place before the incoming book is seeded.
+    @Test func resetZeroesPosition() {
+        let tracker = PositionTracker()
+        tracker.update(positionMs: 42_000, rate: 0)
+        tracker.reset()
+        #expect(tracker.positionMs == 0)
+        #expect(tracker.displayPositionMs == 0)
+    }
+}
+
 @Suite("PositionQuantizer")
 struct PositionQuantizerTests {
     @Test func floorsToWholeSeconds() {


### PR DESCRIPTION
## Why

iOS book-switch playback was broken in three visible ways: the cover art didn't change when switching books, switching played ~10s of silence then a chapter-1 blip before jumping to the resume position, and — most severely — a paused `AVQueuePlayer` never advanced a fresh/streaming item to `.readyToPlay`, so `load` hung to a 20s timeout and the player vanished. On top of that, during any load the UI sat at "0m / paused-looking" because the coordinator stayed in `.preparing` (no duration) for the whole wait.

## What

**Switch-path hardening** (first two commits):
- **Cover cache poison fixed** — cover requests key on content hash, not `bookId`, so Nuke can't serve book A's bytes for book B.
- **Muted preroll** — `load` pumps the player (rate > 0) *muted* so a paused/streaming item actually reaches `.readyToPlay`, seeks to the resume position, then pauses/unmutes and hands back a correctly-positioned silent player. Fixes the hang **and** the chapter-1 blip (seek happens before any audible playback).
- **Generation-guarded switch** — a rapid A→B→A can't let a slow prepare for A stomp B; the outgoing book's position is saved; late `.failed` from the outgoing book can't abort the incoming one.

**Honest buffering UI** (this commit):
- The instant prepare resolves, the player shows the book with its **real duration** + a **buffering spinner** (mini + full player) and the correct resume chapter — instead of "0m / paused-looking". Engine events are gated by an explicit `isEngineLoading` flag through the load, decoupled from the `.preparing` phase.

## Adversarial review

An adversarial reviewer stress-tested the `isEngineLoading` gate lifecycle (full A→B→A interleaving) and confirmed it sound. It caught two fixes now included:
- **Lock-screen drift** — Now Playing now reports a live rate only while audio is actually `.playing`, not while buffering, so the lock-screen clock doesn't extrapolate forward during the (now longer) buffer and snap back.
- **`stop()` mid-load** — bumps the load epoch so an in-flight load can't resurrect `.playing` on a released engine.

Known follow-ups (pre-existing, not introduced here): the KVO callbacks should fold into one ordered stream (rule-7); a failed load still hides the player instead of showing an inline retry (tracked for the "never stranded" pass).

## Tests

New Swift Testing coverage: honest buffering state is shown *during* an in-flight load (real duration + spinner), and `stop()` mid-load doesn't resurrect playback. Full iOS suite green (485). Device-verified: covers switch, no hang, no chapter-1 blip, honest buffering.
