### PR TITLE
✨ feat(iosApp): never-stranded server-unreachable UI (player retry, book-detail banner, offline indicators)

### DIFF
--- a/iosApp/ListenUp/Core/Dependencies.swift
+++ b/iosApp/ListenUp/Core/Dependencies.swift
@@ -61,6 +61,7 @@ final class Dependencies {
     var imageRepository: ImageRepository { resolve { KoinHelper.shared.getImageRepository() } }
     var userProfileRepository: UserProfileRepository { resolve { KoinHelper.shared.getUserProfileRepository() } }
     var downloadService: DownloadService { resolve { KoinHelper.shared.getDownloadService() } }
+    var serverReachability: ServerReachability { resolve { KoinHelper.shared.getServerReachability() } }
 
     // MARK: - Player coordinator (app-wide Swift singleton)
 
@@ -73,6 +74,19 @@ final class Dependencies {
         let coordinator = PlayerCoordinator(deps: self)
         cachedPlayerCoordinator = coordinator
         return coordinator
+    }
+
+    // MARK: - Server reachability observer (app-wide Swift singleton)
+
+    @MainActor private var cachedServerReachabilityObserver: ServerReachabilityObserver?
+
+    /// The single app-wide server-reachability observer — drives offline indicators + Retry across
+    /// screens off the shared `ServerReachability` firehose signal.
+    @MainActor var serverReachabilityObserver: ServerReachabilityObserver {
+        if let cachedServerReachabilityObserver { return cachedServerReachabilityObserver }
+        let observer = ServerReachabilityObserver(deps: self)
+        cachedServerReachabilityObserver = observer
+        return observer
     }
 
     // MARK: - Detail ViewModels (fresh instance per screen)

--- a/iosApp/ListenUp/Core/ServerReachabilityObserver.swift
+++ b/iosApp/ListenUp/Core/ServerReachabilityObserver.swift
@@ -1,0 +1,60 @@
+import Foundation
+@preconcurrency import Shared
+
+/// Native reachability state, mapped from the shared `Reachability` at the observer boundary so
+/// views never touch a bridged Kotlin object.
+enum ServerConnection {
+    /// The server connection is live.
+    case reachable
+    /// The server connection is down.
+    case unreachable
+    /// Not yet determined (e.g. connecting at startup) — treat optimistically.
+    case unknown
+}
+
+/// App-wide `@Observable` over the shared `ServerReachability` firehose signal. Drives offline
+/// indicators + Retry across screens off a single source of truth (the same signal Book Detail's
+/// shared availability uses), so the whole app agrees on whether the server is reachable.
+@Observable
+@MainActor
+final class ServerReachabilityObserver {
+    /// Latest reachability, projected to a native enum. Starts `.unknown` (optimistic) until the
+    /// firehose reports.
+    private(set) var connection: ServerConnection = .unknown
+
+    /// The server is confirmed unreachable — drives offline banners/indicators. `.unknown` is
+    /// treated optimistically (not "unreachable"), matching the shared derivation.
+    var isUnreachable: Bool { connection == .unreachable }
+
+    private let reachability: ServerReachability
+    private let bridge = FlowBridge()
+
+    init(reachability: ServerReachability) {
+        self.reachability = reachability
+        bridge.bind(reachability.state) { [weak self] value in
+            self?.connection = Self.map(value)
+        }
+    }
+
+    convenience init(deps: Dependencies) {
+        self.init(reachability: deps.serverReachability)
+    }
+
+    /// Force a reachability recheck (re-opens the SSE firehose). Backs the "Retry" affordance.
+    /// The `Task` stays MainActor-isolated so the non-`Sendable` `ServerReachability` is never sent
+    /// across an isolation boundary (it lives on this MainActor observer).
+    func retry() {
+        Task { @MainActor in try? await reachability.retry() }
+    }
+
+    private static func map(_ value: Reachability) -> ServerConnection {
+        switch onEnum(of: value) {
+        case .reachable: return .reachable
+        case .unreachable: return .unreachable
+        // `.unknown` plus the export's synthetic future-case catch-all → treat optimistically.
+        default: return .unknown
+        }
+    }
+
+    deinit { bridge.cancelAll() }
+}

--- a/iosApp/ListenUp/DesignSystem/Components/OfflineTopBanner.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/OfflineTopBanner.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// A thin "you're offline" bar pinned to the top of a browse screen, with a Retry. Shown when the
+/// server is unreachable so a silently-no-op pull-to-refresh has a visible explanation (the library
+/// still renders from the local store — this just says why it isn't updating).
+struct OfflineTopBanner: View {
+    var onRetry: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "cloud.slash.fill")
+                .font(.caption)
+            Text("book.detail_offline_title")
+                .font(.caption.weight(.medium))
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            Button(action: onRetry) {
+                Text("book.detail_retry")
+                    .font(.caption.weight(.semibold))
+                    .frame(minHeight: 32)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "book.detail_retry"))
+        }
+        .foregroundStyle(Color.listenUpOrange)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial)
+    }
+}
+
+extension View {
+    /// Pins an offline banner (with Retry) to the top when the server is unreachable, reading the
+    /// app-wide ``ServerReachabilityObserver`` from the environment. Apply to browse-screen roots.
+    func offlineTopBanner() -> some View {
+        modifier(OfflineTopBannerModifier())
+    }
+}
+
+private struct OfflineTopBannerModifier: ViewModifier {
+    // Optional so a host without the observer in its environment (SwiftUI previews) renders no
+    // banner instead of trapping — the runtime app always injects it at `RootView`.
+    @Environment(ServerReachabilityObserver.self) private var reachability: ServerReachabilityObserver?
+
+    private var isUnreachable: Bool { reachability?.isUnreachable ?? false }
+
+    func body(content: Content) -> some View {
+        content
+            .safeAreaInset(edge: .top) {
+                if isUnreachable {
+                    OfflineTopBanner(onRetry: { reachability?.retry() })
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.smooth, value: isUnreachable)
+    }
+}

--- a/iosApp/ListenUp/DesignSystem/Components/ServerUnreachableBanner.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/ServerUnreachableBanner.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Inline "server unreachable" banner for content screens — a Liquid-Glass card with a
+/// cloud-slash icon, a short explanation, and a Retry action. Shown when the server can't be
+/// reached and the content isn't available offline, so the user is never left guessing why an
+/// action is disabled (never stranded). The retry is delegated to the caller.
+struct ServerUnreachableBanner: View {
+    var onRetry: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "cloud.slash.fill")
+                .font(.title3)
+                .foregroundStyle(Color.listenUpOrange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("book.detail_offline_title")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text("book.detail_offline_body")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            Button(action: onRetry) {
+                Text("book.detail_retry")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.listenUpOrange)
+                    .frame(minHeight: 44)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "book.detail_retry"))
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassControl(in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+}

--- a/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
+++ b/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
@@ -88,6 +88,16 @@ final class BookDetailObserver {
     private(set) var isDownloaded: Bool = false
     private(set) var downloadError: String?
 
+    // MARK: - Connectivity (from the shared `BookAvailability`, on `.ready`)
+
+    /// Play is possible — the book is downloaded OR the server is reachable to stream. Defaults
+    /// true so the button is never spuriously disabled before the first state arrives.
+    private(set) var canPlay: Bool = true
+    /// Download is possible — the server is reachable. Defaults true (see `canPlay`).
+    private(set) var canDownload: Bool = true
+    /// The server is unreachable AND the book isn't downloaded — drives the offline banner.
+    private(set) var showServerWarning: Bool = false
+
     // MARK: - Documents
 
     private(set) var documents: [DocumentRow] = []
@@ -174,6 +184,12 @@ final class BookDetailObserver {
     func play() {
         guard let book else { return }
         playerCoordinator.play(bookId: book.idString)
+    }
+
+    /// Retry the server connection (re-opens the SSE firehose) — the offline banner's Retry.
+    /// The shared `retryConnection` folds failures itself; reachability recovers via the firehose.
+    func retryConnection() {
+        viewModel.retryConnection()
     }
 
     func downloadBook() {
@@ -286,6 +302,9 @@ final class BookDetailObserver {
             isMarkingComplete = r.isMarkingComplete
             isDiscardingProgress = r.isDiscardingProgress
             isRestarting = r.isRestarting
+            canPlay = r.canPlay
+            canDownload = r.canDownload
+            showServerWarning = r.showServerWarning
         case .error(let e):
             isLoading = false
             error = e.message

--- a/iosApp/ListenUp/Features/BookDetail/BookDetailView.swift
+++ b/iosApp/ListenUp/Features/BookDetail/BookDetailView.swift
@@ -140,6 +140,7 @@ struct BookDetailView: View {
             )
 
             VStack(spacing: 20) {
+                serverBanner(observer)
                 resumeBar(observer)
                 actionPills(observer)
 
@@ -197,6 +198,7 @@ struct BookDetailView: View {
                     onOpenCast: { showCast = true }
                 )
 
+                serverBanner(observer)
                 resumeBar(observer)
                 actionPills(observer)
             }
@@ -244,11 +246,23 @@ struct BookDetailView: View {
             currentChapterLabel: currentChapterLabel(observer),
             downloadState: observer.downloadState,
             downloadProgress: observer.downloadProgress,
+            canPlay: observer.canPlay,
+            canDownload: observer.canDownload,
             onResume: { observer.play() },
             onDownload: { observer.downloadBook() },
             onCancelDownload: { observer.cancelDownload() },
             onDeleteDownload: { observer.deleteDownload() }
         )
+    }
+
+    /// The "server unreachable" banner — shown only when the book can't be reached AND isn't
+    /// downloaded (`showServerWarning`), explaining why Play/Download are disabled and offering a
+    /// Retry. Rendered above the resume bar on both the phone and wide layouts.
+    @ViewBuilder
+    private func serverBanner(_ observer: BookDetailObserver) -> some View {
+        if observer.showServerWarning {
+            ServerUnreachableBanner(onRetry: { observer.retryConnection() })
+        }
     }
 
     private func actionPills(_ observer: BookDetailObserver) -> some View {

--- a/iosApp/ListenUp/Features/BookDetail/Components/ResumeBar.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/ResumeBar.swift
@@ -20,6 +20,11 @@ struct ResumeBar: View {
     let currentChapterLabel: String?
     let downloadState: DownloadUIState
     let downloadProgress: Float
+    /// Play is possible (downloaded or server reachable). When false the Resume/Play control is
+    /// disabled and relabeled "Unavailable offline". Defaults true.
+    var canPlay: Bool = true
+    /// Download is possible (server reachable). When false the download control is disabled.
+    var canDownload: Bool = true
     let onResume: () -> Void
     let onDownload: () -> Void
     let onCancelDownload: () -> Void
@@ -52,12 +57,14 @@ struct ResumeBar: View {
     // MARK: - Resume button
 
     private var resumeButton: some View {
-        PrimaryButton(title: resumeTitle, icon: "play.fill", action: onResume)
+        PrimaryButton(title: resumeTitle, icon: canPlay ? "play.fill" : "cloud.slash.fill", action: onResume)
+            .disabled(!canPlay)
             .accessibilityLabel(resumeAccessibilityLabel)
     }
 
     private var resumeTitle: String {
-        isInProgress
+        if !canPlay { return String(localized: "book.detail_unavailable_offline") }
+        return isInProgress
             ? String(localized: "book.detail_resume")
             : String(localized: "book.detail_play")
     }
@@ -81,6 +88,9 @@ struct ResumeBar: View {
             onDelete: onDeleteDownload
         )
         .frame(width: controlHeight, height: controlHeight)
+        // Only the ability to START a new download is gated on reachability; an in-flight or
+        // completed download stays interactive (cancel / delete work offline).
+        .disabled(!canDownload && downloadState == .notDownloaded)
     }
 
     // MARK: - Progress detail line

--- a/iosApp/ListenUp/Features/Discover/DiscoverView.swift
+++ b/iosApp/ListenUp/Features/Discover/DiscoverView.swift
@@ -44,6 +44,7 @@ struct DiscoverView: View {
             }
         }
         .background(Color(.systemBackground))
+        .offlineTopBanner()
         .navigationTitle(String(localized: "common.discover"))
         // Collapse the large title while selecting so the selection toolbar's principal "N selected"
         // count doesn't render alongside a large "Discover" title (Home is already .inline).

--- a/iosApp/ListenUp/Features/DocumentReader/NowPlayingStrip.swift
+++ b/iosApp/ListenUp/Features/DocumentReader/NowPlayingStrip.swift
@@ -9,7 +9,9 @@ struct NowPlayingStrip: View {
 
     var body: some View {
         let player = dependencies.playerCoordinator
-        if player.isVisible {
+        // `.error` is "visible" (so the main mini-player shows the inline error+retry), but the
+        // reader's strip has no honest content then — hide it rather than render a blank "0s" card.
+        if player.isVisible, !player.isErrored {
             content(player)
         }
     }

--- a/iosApp/ListenUp/Features/Home/HomeView.swift
+++ b/iosApp/ListenUp/Features/Home/HomeView.swift
@@ -39,6 +39,7 @@ struct HomeView: View {
             }
         }
         .background(Color(.systemBackground))
+        .offlineTopBanner()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/iosApp/ListenUp/Features/Library/LibraryView.swift
+++ b/iosApp/ListenUp/Features/Library/LibraryView.swift
@@ -31,6 +31,7 @@ struct LibraryView: View {
                 loadingState
             }
         }
+        .offlineTopBanner()
         .navigationTitle(String(localized: "common.library"))
         // While selecting, collapse the large "Library" title so the toolbar's principal item shows
         // the live "N selected" count (Photos idiom); the tab bar hides so the bottom action bar owns

--- a/iosApp/ListenUp/Features/Player/FullScreenPlayerView.swift
+++ b/iosApp/ListenUp/Features/Player/FullScreenPlayerView.swift
@@ -41,6 +41,9 @@ struct FullScreenPlayerView: View {
         layout
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(frostedBackground)
+        // Never stranded: if a load fails while the full player is open, show an inline
+        // error + Retry over the (now empty) transport rather than a dead screen.
+        .overlay { if observer.isErrored { errorOverlay } }
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: tint)
         .task(id: observer.currentBookId) { resolveTint() }
         .statusBarHidden(false)
@@ -101,6 +104,40 @@ struct FullScreenPlayerView: View {
                 .glassControl(in: Rectangle())
         }
         .ignoresSafeArea()
+    }
+
+    /// Inline failure surface for the full player — a centered card with the failure message and a
+    /// Retry that re-drives the errored book, so a failed load never leaves a dead screen.
+    private var errorOverlay: some View {
+        ZStack {
+            Color(.systemBackground).opacity(0.85).ignoresSafeArea()
+            VStack(spacing: 16) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.largeTitle)
+                    .foregroundStyle(tint)
+                Text(observer.errorMessage ?? String(localized: "common.something_went_wrong"))
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.primary)
+                Button { observer.togglePlayback() } label: {
+                    Text("book.detail_retry")
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 28)
+                        .frame(minHeight: 44)
+                        .background(Capsule().fill(tint))
+                }
+                .buttonStyle(.plain)
+                Button { observer.dismissError() } label: {
+                    Text("common.dismiss")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .frame(minHeight: 44)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(32)
+        }
     }
 
     // MARK: - Layout

--- a/iosApp/ListenUp/Features/Player/MiniPlayerBar.swift
+++ b/iosApp/ListenUp/Features/Player/MiniPlayerBar.swift
@@ -54,25 +54,68 @@ struct MiniPlayerBar: View {
 
     // MARK: - Content
 
+    @ViewBuilder
     private var contentRow: some View {
-        HStack(spacing: 12) {
-            cover
+        if observer.isErrored {
+            errorRow
+        } else {
+            HStack(spacing: 12) {
+                cover
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(observer.bookTitle)
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(observer.bookTitle)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 12)
+
+                playPauseButton
             }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+    }
+
+    /// Never-stranded failure surface: instead of the player vanishing on `.error`, the bar shows
+    /// the failure message and a Retry that re-drives the errored book (`togglePlayback` → replay).
+    private var errorRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title3)
+                .foregroundStyle(Color.listenUpOrange)
+                .frame(width: 40, height: 40)
+
+            Text(observer.errorMessage ?? String(localized: "common.something_went_wrong"))
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+                .lineLimit(2)
 
             Spacer(minLength: 12)
 
-            playPauseButton
+            Button { observer.togglePlayback() } label: {
+                Text("book.detail_retry")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.listenUpOrange)
+                    .frame(minHeight: 44)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "book.detail_retry"))
+
+            Button { observer.dismissError() } label: {
+                Image(systemName: "xmark")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "common.dismiss"))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
+++ b/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
@@ -76,11 +76,12 @@ final class PlayerCoordinator: RemoteCommandHandler {
 
     // MARK: - Preserved UI surface — visibility & playback flags (derived from phase)
 
-    /// A book is loaded — drives the mini player's visibility.
+    /// A book is loaded (or a load failed) — drives the mini player's visibility. `.error` stays
+    /// visible so the inline error+retry is reachable (never stranded); only `.idle` hides it.
     var isVisible: Bool {
         switch phase {
-        case .idle, .error: return false
-        case .preparing, .playing, .paused, .buffering: return true
+        case .idle: return false
+        case .preparing, .playing, .paused, .buffering, .error: return true
         }
     }
 
@@ -89,6 +90,19 @@ final class PlayerCoordinator: RemoteCommandHandler {
     var isBuffering: Bool {
         if case .buffering = phase { return true }
         return false
+    }
+
+    /// True when playback failed to start/continue — drives the inline error+retry surface so the
+    /// user is never stranded on a vanished player.
+    var isErrored: Bool {
+        if case .error = phase { return true }
+        return false
+    }
+
+    /// The user-facing failure message when `isErrored`, else nil.
+    var errorMessage: String? {
+        if case .error(let state) = phase { return state.message }
+        return nil
     }
 
     /// Playback intent is "advancing": the audio is playing OR buffering toward playing.
@@ -459,6 +473,14 @@ final class PlayerCoordinator: RemoteCommandHandler {
         updateNowPlaying()
     }
 
+    /// Dismiss an errored player back to `.idle` — the user's escape so a failed load (e.g. offline)
+    /// doesn't leave an undismissable error bar reserving space over every tab. No-op unless errored.
+    func dismissError() {
+        guard isErrored else { return }
+        phase = .idle
+        updateNowPlaying()
+    }
+
     /// Seek to a whole-book position in milliseconds.
     func seekTo(positionMs: Int64) {
         Task { await engine.seek(toMs: positionMs) }
@@ -746,7 +768,9 @@ final class PlayerCoordinator: RemoteCommandHandler {
     // MARK: - System integration
 
     private func updateNowPlaying() {
-        guard isVisible else {
+        // `.error` keeps the in-app player visible (for the inline retry) but has no now-playing
+        // content — clear the lock-screen controls; the retry lives in the app.
+        guard isVisible, !isErrored else {
             system.clear()
             return
         }

--- a/iosApp/ListenUp/Features/Search/SearchView.swift
+++ b/iosApp/ListenUp/Features/Search/SearchView.swift
@@ -43,6 +43,7 @@ struct SearchView: View {
                 Color.luSurface
             }
         }
+        .offlineTopBanner()
         .navigationTitle(String(localized: "common.search"))
         .navigationBarTitleDisplayMode(.large)
         .onAppear {

--- a/iosApp/ListenUp/ListenUpApp.swift
+++ b/iosApp/ListenUp/ListenUpApp.swift
@@ -41,6 +41,8 @@ private struct RootView: View {
             .environment(currentUser)
             .environment(hapticsSettings)
             .environment(deepLinkRouter)
+            // App-wide server-reachability signal (offline indicators + Retry across screens).
+            .environment(dependencies.serverReachabilityObserver)
             // Universal links: `.onOpenURL` is the reliable SwiftUI App-lifecycle delivery path
             // (cold launch *and* while running). `.onContinueUserActivity(NSUserActivityTypeBrowsingWeb)`
             // does not fire for universal links under the SwiftUI lifecycle — kept only as a

--- a/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
+++ b/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
@@ -134,6 +134,38 @@ struct PlayerSwitchPathTests {
         }
     }
 
+    /// Never stranded: a load failure keeps the player VISIBLE with the error message, so the
+    /// existing `.error`-retry (`togglePlayback`) is actually reachable rather than hidden behind
+    /// a vanished player.
+    @Test func errorStateKeepsPlayerVisibleWithMessage() async {
+        let (coordinator, engine, _) = makeCoordinator()
+        await engine.setLoadShouldFail(true)
+        coordinator.play(bookId: "book1")
+        await awaitUntil { if case .error = coordinator.phase { return true }; return false }
+
+        #expect(coordinator.isVisible)
+        #expect(coordinator.isErrored)
+        #expect(coordinator.errorMessage != nil)
+    }
+
+    /// The user can DISMISS an errored player back to idle (hidden) — otherwise a failed offline
+    /// load would leave an undismissable error bar reserving space over every tab.
+    @Test func dismissErrorReturnsToIdleAndHides() async {
+        let (coordinator, engine, _) = makeCoordinator()
+        await engine.setLoadShouldFail(true)
+        coordinator.play(bookId: "book1")
+        await awaitUntil { if case .error = coordinator.phase { return true }; return false }
+        #expect(coordinator.isVisible)   // errored → still visible (for the inline retry)
+
+        coordinator.dismissError()
+        #expect(!coordinator.isVisible)  // dismissed → hidden
+        #expect(!coordinator.isErrored)
+        guard case .idle = coordinator.phase else {
+            Issue.record("expected .idle after dismissError, got \(coordinator.phase)")
+            return
+        }
+    }
+
     /// RC-5: a load failure surfaces `.error`; toggling the errored book retries it rather than
     /// no-oping, so the user is never stranded on a dead player.
     @Test func errorStateIsRecoverableByToggle() async {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -326,6 +326,16 @@ class PlaybackPreparer internal constructor(
             if (localPaths.values.all { it != null }) {
                 emptyMap() // fully downloaded — never touch the server (offline-first)
             } else {
+                // Diagnostic for the "downloaded but won't play offline" corruption edge: if SOME
+                // files are local but not all, a book the UI shows as downloaded still falls to the
+                // streaming path here and fails when offline. Surface it so it isn't a silent mystery.
+                if (localPaths.values.any { it != null }) {
+                    val missing = localPaths.values.count { it == null }
+                    logger.warn {
+                        "Book ${bookId.value}: $missing of ${localPaths.size} audio file(s) have no local path " +
+                            "despite others being downloaded — using streaming (will fail offline). Possible partial/corrupt download."
+                    }
+                }
                 // Routed through the bounded, self-healing engine so a dead-socket transport throw
                 // becomes a typed, time-bounded AppResult.Failure instead of an unguarded exception
                 // crossing the Swift Export seam as an opaque KotlinError.

--- a/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
+++ b/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
@@ -26,6 +26,7 @@ import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.data.repository.DeepLinkManager
 import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.domain.repository.ServerReachability
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserProfileRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
@@ -307,6 +308,8 @@ object KoinHelper {
     fun getSleepTimerManager(): SleepTimerManager = resolve(SleepTimerManager::class)
 
     fun getPlaybackPreparer(): PlaybackPreparer = resolve(PlaybackPreparer::class)
+
+    fun getServerReachability(): ServerReachability = resolve(ServerReachability::class)
 
     fun getPlaybackPreferences(): PlaybackPreferences = resolve(PlaybackPreferences::class)
 }


### PR DESCRIPTION
## Why

When the server is unreachable, iOS silently stranded the user: tapping Play on a not-yet-downloaded book made the mini-player **vanish** (the failed-load `.error` state hid it, and its retry was unreachable); Book Detail's Play/Download failed with no explanation; and the browse screens gave no sign the server was unreachable. Meanwhile a **fully-downloaded book already plays offline** (verified — `PlaybackPreparer.buildTimeline` short-circuits to local paths when all files are downloaded), so the gaps were purely UX. This is the "never stranded" charter, made real on iOS.

## What

Every surface now surfaces unreachability with a way forward, off the **shared** `ServerReachability` signal (same source of truth as Android):

- **Player** — `.error` stays visible with an inline **message + Retry + Dismiss** (mini bar and full player). Retry re-drives the errored book; Dismiss returns to idle so a failed offline load can't leave a stuck bar.
- **Book Detail** — a "Server offline" banner + Retry; Play relabels to "Unavailable offline" and Download disables when unreachable (both read `canPlay`/`canDownload`/`showServerWarning`, already computed by the shared `BookDetailViewModel`). Downloaded books are unaffected — still playable, no banner.
- **Browse screens** (Home / Library / Search / Discover) — a thin "Server offline" top bar with Retry when unreachable, so a silently-no-op pull-to-refresh has a visible explanation. Lists still render from the local store.
- **Global signal** — a native `ServerReachabilityObserver` (`@Observable`) over the shared `ServerReachability.state`, injected app-wide; a new `getServerReachability()` Koin accessor (both types already in the Swift-Export baseline).
- **Defensive** — a warn in `PlaybackPreparer` for the "downloaded but a file's local path is missing" corruption edge that silently forces the offline-failing streaming path.

## Adversarial review (run before this PR opened)

A reviewer stress-tested the diff and found real defects, all fixed here:
- **BLOCKER** — three new localization keys were being stripped by xcodebuild (committed keys survive, freshly-added ones don't), so Retry/banner would render raw identifiers. Fixed by reusing existing committed keys.
- **MAJOR** — undismissable error bar (added Dismiss); the PDF reader's now-playing strip rendered a blank card on `.error` (now hides); Home/Library SwiftUI previews crashed on the non-optional environment lookup (now optional).
- Removed dead `isWaitingForWifi` state; added the banner to Discover.

## Tests

New Swift Testing coverage: `.error` keeps the player visible with a message; `dismissError()` returns to idle/hidden. Full iOS suite green (487). Kotlin lane (spotless + detekt + `PlaybackPreparerTest`) green. Device-verified on hardware with the server stopped: player error+retry+dismiss, book-detail banner + disabled actions, browse banners, reader strip hides, and full recovery when the server returns.
