### PR TITLE
✨ feat(shared): playback preempts downloads — yield bandwidth while a stream buffers

### DIFF
--- a/iosApp/ListenUp/Core/Dependencies.swift
+++ b/iosApp/ListenUp/Core/Dependencies.swift
@@ -62,6 +62,9 @@ final class Dependencies {
     var userProfileRepository: UserProfileRepository { resolve { KoinHelper.shared.getUserProfileRepository() } }
     var downloadService: DownloadService { resolve { KoinHelper.shared.getDownloadService() } }
     var serverReachability: ServerReachability { resolve { KoinHelper.shared.getServerReachability() } }
+    var playbackBandwidthCoordinator: PlaybackBandwidthCoordinator {
+        resolve { KoinHelper.shared.getPlaybackBandwidthCoordinator() }
+    }
 
     // MARK: - Player coordinator (app-wide Swift singleton)
 

--- a/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
+++ b/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
@@ -7,61 +7,8 @@ import AVFoundation
 typealias PlaybackManagerChapterInfo =
     _ExportedKotlinPackages_com_calypsan_listenup_client_playback_PlaybackManager_ChapterInfo
 
-/// Pure decision for an audio-session interruption — testable without notifications.
-enum InterruptionPolicy {
-    enum Action: Equatable { case pause, resume, none }
-    static func action(type: AVAudioSession.InterruptionType, shouldResume: Bool) -> Action {
-        switch type {
-        case .began: return .pause
-        case .ended: return shouldResume ? .resume : .none
-        @unknown default: return .none
-        }
-    }
-}
-
-/// Pure decision for an audio-route change — testable without notifications.
-enum RouteChangePolicy {
-    /// Pause only when the previous output device went away (headphones/AirPods
-    /// unplugged) — otherwise audio would blast out of the speaker (charter rule 13).
-    static func shouldPause(reason: AVAudioSession.RouteChangeReason) -> Bool {
-        reason == .oldDeviceUnavailable
-    }
-}
-
-/// Pure decision: should backgrounding to `newPhase` trigger a position save?
-/// Only the genuine `.background` transition should — `.inactive` fires constantly
-/// (Control Center, banners, app switcher) and would redundantly re-save (charter rule 13).
-enum ScenePhasePolicy {
-    static func shouldSavePosition(on newPhase: ScenePhase) -> Bool {
-        newPhase == .background
-    }
-}
-
-/// Pure predicate for the load-generation guard — a book-switch epoch check, testable
-/// without a coordinator. Each `play(bookId:)` bumps the coordinator's generation; an
-/// in-flight prepare captures the generation it started under and bails after every
-/// `await` if a newer switch has superseded it, so a slow prepare for book A can never
-/// stomp the state of a book B the user has since switched to (RC-4).
-enum LoadGeneration {
-    static func isSuperseded(taskGeneration: Int, current: Int) -> Bool {
-        taskGeneration != current
-    }
-}
-
-/// Pure chapter math — resolves a whole-book position to a chapter index.
-/// Split out so it is testable without a coordinator.
-enum ChapterMath {
-    /// The index of the chapter containing `positionMs`, or `nil` for an empty
-    /// list. A position past the last chapter clamps to the last index.
-    static func index(forPositionMs positionMs: Int64, in chapters: [Chapter]) -> Int? {
-        guard !chapters.isEmpty else { return nil }
-        for (index, chapter) in chapters.enumerated()
-        where positionMs < chapter.startTime + chapter.duration {
-            return index
-        }
-        return chapters.count - 1
-    }
-}
+// The pure decision helpers (InterruptionPolicy, RouteChangePolicy, ScenePhasePolicy,
+// LoadGeneration, ChapterMath) live in PlayerPolicies.swift.
 
 /// The iOS player orchestrator (Option B). Owns `PlayerPhase` and the player-core
 /// components, maps the KMP seam, and exposes the flat `@Observable` surface the
@@ -72,7 +19,9 @@ final class PlayerCoordinator: RemoteCommandHandler {
 
     // MARK: - Runtime phase
 
-    private(set) var phase: PlayerPhase = .idle
+    private(set) var phase: PlayerPhase = .idle {
+        didSet { updateBandwidthSignal() }
+    }
 
     // MARK: - Preserved UI surface — visibility & playback flags (derived from phase)
 
@@ -247,6 +196,12 @@ final class PlayerCoordinator: RemoteCommandHandler {
     /// never overridden (Apple's "was playing when interrupted" contract).
     private var pausedByInterruption = false
     private static let positionReportIntervalMs: Int64 = 5000
+    /// Feeds the shared "playback preempts downloads" signal. Optional so unit tests can construct
+    /// the coordinator without a Kotlin coordinator.
+    private let bandwidthCoordinator: PlaybackBandwidthCoordinator?
+    /// Whether the currently-loaded book streams (has a non-local file) — gates the yield signal so
+    /// a fully-downloaded book (no bandwidth contention) never asks downloads to back off.
+    private var isCurrentBookStreaming = false
 
     // MARK: - Init
 
@@ -258,7 +213,8 @@ final class PlayerCoordinator: RemoteCommandHandler {
         coverProvider: BookCoverProviding,
         documentProvider: BookDocumentProviding = NoDocumentProviding(),
         skipIntervals: SkipIntervalProviding? = nil,
-        fadeStepDelay: Duration = .milliseconds(250)
+        fadeStepDelay: Duration = .milliseconds(250),
+        bandwidthCoordinator: PlaybackBandwidthCoordinator? = nil
     ) {
         self.preparer = preparer
         self.progress = progress
@@ -268,6 +224,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
         self.documentProvider = documentProvider
         self.skipIntervals = skipIntervals
         self.fadeStepDelay = fadeStepDelay
+        self.bandwidthCoordinator = bandwidthCoordinator
         system.attach(handler: self)
         system.updateSkipIntervals(forwardSeconds: skipForwardSec, backwardSeconds: skipBackwardSec)
         bridge.bind(engine.events) { [weak self] in self?.handleEngineEvent($0) }
@@ -289,7 +246,8 @@ final class PlayerCoordinator: RemoteCommandHandler {
             engine: AudioEngine(),
             coverProvider: KotlinBookCoverProviding(repository: deps.bookRepository),
             documentProvider: KotlinBookDocumentProviding(repository: deps.documentRepository),
-            skipIntervals: KotlinSkipIntervalProviding(preferences: deps.playbackPreferences)
+            skipIntervals: KotlinSkipIntervalProviding(preferences: deps.playbackPreferences),
+            bandwidthCoordinator: deps.playbackBandwidthCoordinator
         )
     }
 
@@ -406,6 +364,9 @@ final class PlayerCoordinator: RemoteCommandHandler {
         let generation = loadGeneration
         // Gate engine events for the whole switch→load window (see `isEngineLoading`).
         isEngineLoading = true
+        // Not known to stream until prepare resolves the timeline — conservative so a switch never
+        // asks downloads to yield for a book that turns out to be fully local.
+        isCurrentBookStreaming = false
 
         // Save the outgoing book's place before we retarget — a switch must not lose it.
         // Only silence the engine when there *was* an outgoing loaded book: an unconditional
@@ -562,6 +523,10 @@ final class PlayerCoordinator: RemoteCommandHandler {
         prepareTask?.cancel()
         loadGeneration &+= 1
         isEngineLoading = false
+        // Return to idle so the `phase` didSet releases the download-yield signal — otherwise a
+        // stop while `.buffering` would leave a streaming book "buffering" forever and pin
+        // `shouldYield` true, suspending iOS downloads indefinitely.
+        phase = .idle
         bridge.cancelAll()
         positionTracker.reset()
         await engine.deactivateSession()
@@ -616,6 +581,9 @@ final class PlayerCoordinator: RemoteCommandHandler {
         // load, so this early `.buffering` never absorbs the outgoing book's or the muted preroll's
         // events. The first real `timeControlStatus == .playing` (after the gate lifts) promotes it
         // to `.playing`.
+        // A book streams if any file has no local path — set BEFORE the phase change so the
+        // `phase` didSet's bandwidth signal sees the right streaming-ness for this book.
+        isCurrentBookStreaming = prepared.timeline.files.contains { $0.localPath == nil }
         phase = .buffering(PlayingState(bookId: bookId, durationMs: prepared.timeline.totalDurationMs))
         lastSyncedChapterIndex = chapterIndex
         updateNowPlaying()
@@ -763,6 +731,20 @@ final class PlayerCoordinator: RemoteCommandHandler {
             sleepTimerMode = isEndOfChapter ? "endOfChapter" : "duration"
             sleepTimerLabel = label
         }
+    }
+
+    // MARK: - Playback-preempts-downloads signal
+
+    /// Tell the shared coordinator whether a STREAMING book is currently buffering, so background
+    /// downloads yield only during the stalls that matter (a local book never asks them to). Driven
+    /// by the `phase` didSet — `.preparing`/`.buffering` mean "loading/stalled".
+    private func updateBandwidthSignal() {
+        let buffering: Bool
+        switch phase {
+        case .preparing, .buffering: buffering = true
+        case .idle, .playing, .paused, .error: buffering = false
+        }
+        bandwidthCoordinator?.setStreamingBuffering(active: buffering && isCurrentBookStreaming)
     }
 
     // MARK: - System integration

--- a/iosApp/ListenUp/Features/Player/PlayerPolicies.swift
+++ b/iosApp/ListenUp/Features/Player/PlayerPolicies.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import AVFoundation
+@preconcurrency import Shared
+
+// Pure, coordinator-free decision helpers for the player — split out of `PlayerCoordinator` so each
+// is unit-testable in isolation (and to keep the coordinator file focused).
+
+/// Pure decision for an audio-session interruption — testable without notifications.
+enum InterruptionPolicy {
+    enum Action: Equatable { case pause, resume, none }
+    static func action(type: AVAudioSession.InterruptionType, shouldResume: Bool) -> Action {
+        switch type {
+        case .began: return .pause
+        case .ended: return shouldResume ? .resume : .none
+        @unknown default: return .none
+        }
+    }
+}
+
+/// Pure decision for an audio-route change — testable without notifications.
+enum RouteChangePolicy {
+    /// Pause only when the previous output device went away (headphones/AirPods
+    /// unplugged) — otherwise audio would blast out of the speaker (charter rule 13).
+    static func shouldPause(reason: AVAudioSession.RouteChangeReason) -> Bool {
+        reason == .oldDeviceUnavailable
+    }
+}
+
+/// Pure decision: should backgrounding to `newPhase` trigger a position save?
+/// Only the genuine `.background` transition should — `.inactive` fires constantly
+/// (Control Center, banners, app switcher) and would redundantly re-save (charter rule 13).
+enum ScenePhasePolicy {
+    static func shouldSavePosition(on newPhase: ScenePhase) -> Bool {
+        newPhase == .background
+    }
+}
+
+/// Pure predicate for the load-generation guard — a book-switch epoch check, testable
+/// without a coordinator. Each `play(bookId:)` bumps the coordinator's generation; an
+/// in-flight prepare captures the generation it started under and bails after every
+/// `await` if a newer switch has superseded it, so a slow prepare for book A can never
+/// stomp the state of a book B the user has since switched to (RC-4).
+enum LoadGeneration {
+    static func isSuperseded(taskGeneration: Int, current: Int) -> Bool {
+        taskGeneration != current
+    }
+}
+
+/// Pure chapter math — resolves a whole-book position to a chapter index.
+/// Split out so it is testable without a coordinator.
+enum ChapterMath {
+    /// The index of the chapter containing `positionMs`, or `nil` for an empty
+    /// list. A position past the last chapter clamps to the last index.
+    static func index(forPositionMs positionMs: Int64, in chapters: [Chapter]) -> Int? {
+        guard !chapters.isEmpty else { return nil }
+        for (index, chapter) in chapters.enumerated()
+        where positionMs < chapter.startTime + chapter.duration {
+            return index
+        }
+        return chapters.count - 1
+    }
+}

--- a/scripts/export-surface-baseline.txt
+++ b/scripts/export-surface-baseline.txt
@@ -332,6 +332,7 @@ PendingOperationStatus
 PendingOperationType
 PendingOperationUi
 PendingRegistration
+PlaybackBandwidthCoordinator
 PlaybackController
 PlaybackDynamics
 PlaybackManager

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.android.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.android.kt
@@ -46,6 +46,7 @@ val androidPlaybackModule: Module =
                 bookRpcFactory = get(),
                 scope = get(),
                 bookSyncDomainHandler = get<SyncDomainHandler<BookSyncPayload>>(named(SyncDomains.BOOKS.name)),
+                playbackBandwidthCoordinator = get(),
             )
         }
     }

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -18,6 +18,7 @@ import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.playback.AudioTokenProvider
+import com.calypsan.listenup.client.playback.PlaybackBandwidthCoordinator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
@@ -92,12 +93,21 @@ class AppleDownloadService internal constructor(
     private val fileManager: DownloadFileManager,
     private val playbackRpcFactory: PlaybackRpcFactory,
     private val scope: CoroutineScope,
+    private val playbackBandwidthCoordinator: PlaybackBandwidthCoordinator,
 ) : DownloadService {
     /**
      * Delegate handles download progress and completion.
      * Must be held as a strong reference (ObjC weak delegate pattern).
      */
     private val sessionDelegate = DownloadSessionDelegate(downloadDao, scope)
+
+    init {
+        // "Playback preempts downloads": while a stream is buffering, suspend in-flight download
+        // tasks so the stream gets the bandwidth; resume them when playback is flowing again.
+        scope.launch {
+            playbackBandwidthCoordinator.shouldYield.collect { sessionDelegate.setYielding(it) }
+        }
+    }
 
     private val urlSession: NSURLSession =
         run {
@@ -278,10 +288,11 @@ class AppleDownloadService internal constructor(
                 task.taskDescription = "$bookId|$audioFileId|$filename|$destPath"
 
                 // Register continuation so delegate can resume it
-                sessionDelegate.registerDownload(task, continuation, destPath.toString(), bookId)
-
                 continuation.invokeOnCancellation { task.cancel() }
-                task.resume()
+                // registerDownload also STARTS the task (or leaves it suspended if playback is
+                // currently yielding-bound) atomically under the delegate's lock — so a task can't
+                // slip past a concurrent setYielding(true) and run at full bandwidth mid-buffer.
+                sessionDelegate.registerDownload(task, continuation, destPath.toString(), bookId)
             }
 
         if (result) {
@@ -461,6 +472,13 @@ private class DownloadSessionDelegate(
     /** Maps taskIdentifier to its live download task so cancellation can stop it directly */
     private val taskById = mutableMapOf<ULong, NSURLSessionDownloadTask>()
 
+    /**
+     * Register and START the task atomically w.r.t. [setYielding]. Under the lock we decide to
+     * `resume()` (start) only if not currently yielding — otherwise the task stays in its initial
+     * suspended state and [setYielding]`(false)` starts it later. Doing the start inside the lock
+     * closes the race where a task registered-and-resumed *after* a concurrent `setYielding(true)`
+     * would run at full bandwidth for the whole buffer window.
+     */
     fun registerDownload(
         task: NSURLSessionDownloadTask,
         continuation: CancellableContinuation<Boolean>,
@@ -474,6 +492,7 @@ private class DownloadSessionDelegate(
             if (bookId != null) {
                 taskToBookId[taskId] = bookId
             }
+            if (!yielding) task.resume()
         }
     }
 
@@ -494,6 +513,23 @@ private class DownloadSessionDelegate(
             }
         tasks.forEach { it.cancel() }
         return tasks.size
+    }
+
+    /** True while playback is buffering a stream — new tasks start suspended (see [registerDownload]). */
+    private var yielding = false
+
+    /**
+     * The "playback preempts downloads" yield. Uses `NSURLSessionTask.suspend`/`resume` — which
+     * hold the connection + partial data (no re-download, unlike cancel) — across every in-flight
+     * task. Done under [lock] so it can't interleave with [registerDownload]'s start decision (that
+     * race would let a task escape the yield). Idempotent: suspending an already-suspended (or
+     * not-yet-started) task, or resuming a completed/removed one, is a documented no-op.
+     */
+    fun setYielding(active: Boolean) {
+        lock.withLock {
+            yielding = active
+            taskById.values.forEach { if (active) it.suspend() else it.resume() }
+        }
     }
 
     private fun removePending(taskId: ULong): PendingDownload? =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/MediaModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/MediaModule.kt
@@ -95,6 +95,15 @@ internal val mediaModule: Module =
                 repository = get(),
                 fileManager = get(),
                 playbackRpcFactory = get(),
+                playbackBandwidthCoordinator = get(),
+            )
+        }
+
+        // PlaybackBandwidthCoordinator — the "playback preempts downloads" signal. The active
+        // player feeds streaming-buffering state; the download paths observe `shouldYield`.
+        single<com.calypsan.listenup.client.playback.PlaybackBandwidthCoordinator> {
+            com.calypsan.listenup.client.playback.DefaultPlaybackBandwidthCoordinator(
+                scope = get(qualifier = named(APP_SCOPE)),
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/AudioFileDownloaderImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/AudioFileDownloaderImpl.kt
@@ -4,6 +4,11 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.playback.PlaybackBandwidthCoordinator
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Default [AudioFileDownloader] backed by the authenticated [ApiClientFactory] client.
@@ -11,12 +16,18 @@ import com.calypsan.listenup.client.domain.repository.DownloadRepository
  * Lives in `:sharedLogic` so it can call [ApiClientFactory.getClient] internally — keeping the Ktor
  * `HttpClient` off every cross-module surface. Delegates the actual streaming to [downloadAudioFile],
  * which carries the resume/progress/cancellation logic.
+ *
+ * Also drives the "playback preempts downloads" yield: between chunks it consults
+ * [playbackBandwidthCoordinator] and soft-pauses while a stream is buffering — bounded by [maxYield]
+ * so a sustained stall can't starve the download indefinitely (or trip WorkManager's run limit).
  */
 internal class AudioFileDownloaderImpl(
     private val apiClientFactory: ApiClientFactory,
     private val repository: DownloadRepository,
     private val fileManager: DownloadFileManager,
     private val playbackRpcFactory: PlaybackRpcFactory,
+    private val playbackBandwidthCoordinator: PlaybackBandwidthCoordinator,
+    private val maxYield: Duration = 30.seconds,
 ) : AudioFileDownloader {
     override suspend fun download(
         audioFileId: String,
@@ -37,5 +48,19 @@ internal class AudioFileDownloaderImpl(
             playbackRpcFactory = playbackRpcFactory,
             isStopped = isStopped,
             setProgress = setProgress,
+            yieldToPlayback = ::yieldToPlayback,
         )
+
+    /**
+     * Suspend while playback is buffering a stream, up to [maxYield]. Returns immediately when not
+     * yielding (the common case). The cap guarantees the download eventually makes progress even
+     * during a long stall, so background downloads are throttled — never permanently starved.
+     */
+    private suspend fun yieldToPlayback() {
+        if (playbackBandwidthCoordinator.shouldYield.value) {
+            withTimeoutOrNull(maxYield) {
+                playbackBandwidthCoordinator.shouldYield.first { !it }
+            }
+        }
+    }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
@@ -69,6 +69,7 @@ internal suspend fun downloadAudioFile(
     playbackRpcFactory: PlaybackRpcFactory,
     isStopped: () -> Boolean = { false },
     setProgress: suspend (downloadedBytes: Long, totalBytes: Long) -> Unit = { _, _ -> },
+    yieldToPlayback: suspend () -> Unit = {},
 ): AppResult<Unit> =
     suspendRunCatching {
         withContext(IODispatcher) {
@@ -132,6 +133,10 @@ internal suspend fun downloadAudioFile(
                             if (isStopped()) {
                                 throw CancellationException("Download stopped")
                             }
+                            // Soft-pause between chunks while playback is buffering a stream, so the
+                            // stream gets the bandwidth. Keeps the connection + partial file warm
+                            // (no cancel). The caller bounds how long this can suspend.
+                            yieldToPlayback()
 
                             val read = channel.readAvailable(buffer, 0, buffer.size)
                             if (read <= 0) continue

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackBandwidthCoordinator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackBandwidthCoordinator.kt
@@ -1,0 +1,75 @@
+package com.calypsan.listenup.client.playback
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.transformLatest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Cross-platform "playback preempts downloads" signal. The active player reports when a
+ * **streaming** (not-fully-downloaded) book is actively buffering; background downloads observe
+ * [shouldYield] and back off so the stall clears fast — then resume once playback is flowing.
+ *
+ * The yield is tied to *buffering*, not merely *playing*: downloads get out of the way during the
+ * stalls that actually matter and make progress the rest of the time, so they're never starved
+ * (and the streamed book's own auto-download eventually completes → future playback is local).
+ *
+ * A single commonMain `single`; both the iOS [com.calypsan.listenup.client] native `PlayerCoordinator`
+ * (via Swift Export) and the Android/Desktop `PlaybackManager` feed it, and both download paths
+ * (the shared byte pump on Android, `NSURLSession` task suspension on iOS) obey it.
+ */
+interface PlaybackBandwidthCoordinator {
+    /** True while a not-fully-downloaded book is buffering — background downloads should yield. */
+    val shouldYield: StateFlow<Boolean>
+
+    /** Called by the active player when its streaming-buffering state changes. Idempotent. */
+    fun setStreamingBuffering(active: Boolean)
+}
+
+/**
+ * Default [PlaybackBandwidthCoordinator] with **instant acquire, delayed release** hysteresis and a
+ * hard **[maxYield] cap**:
+ * - yielding turns on the instant buffering starts (playback needs bandwidth *now*);
+ * - it turns off after [releaseDelay] of non-buffering — so a stream that flickers
+ *   buffering→playing→buffering doesn't thrash downloads' connections;
+ * - it turns off unconditionally after [maxYield] of *continuous* buffering, so a stuck/dead stream
+ *   (or a producer that never leaves `.buffering`) can never starve downloads.
+ *
+ * All timing lives in a **single** collector on [scope] (`transformLatest` cancels the prior branch
+ * on each new value), so `setStreamingBuffering` only writes a `StateFlow` — there is no cross-thread
+ * mutation to race, and acquire deterministically wins over an in-flight release. This is the fix for
+ * the lock-free release race the naive `launch`/`cancel` version had.
+ *
+ * [scope] should be app-lifetime (the download/playback scope).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class DefaultPlaybackBandwidthCoordinator(
+    scope: CoroutineScope,
+    releaseDelay: Duration = 2.seconds,
+    maxYield: Duration = 60.seconds,
+) : PlaybackBandwidthCoordinator {
+    private val buffering = MutableStateFlow(false)
+
+    override val shouldYield: StateFlow<Boolean> =
+        buffering
+            .transformLatest { active ->
+                if (active) {
+                    emit(true) // instant acquire
+                    delay(maxYield) // cap: never starve downloads on a stuck/endless buffer
+                    emit(false)
+                } else {
+                    delay(releaseDelay) // delayed release; a re-buffer cancels this branch
+                    emit(false)
+                }
+            }.stateIn(scope, SharingStarted.Eagerly, false)
+
+    override fun setStreamingBuffering(active: Boolean) {
+        buffering.value = active
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
@@ -59,6 +59,7 @@ internal class PlaybackManagerImpl(
     private val bookRpcFactory: BookRpcFactory,
     private val scope: CoroutineScope,
     private val bookSyncDomainHandler: SyncDomainHandler<BookSyncPayload>,
+    private val playbackBandwidthCoordinator: PlaybackBandwidthCoordinator,
 ) : PlaybackManager {
     private val preparer =
         PlaybackPreparer(
@@ -296,6 +297,10 @@ internal class PlaybackManagerImpl(
      */
     override fun setBuffering(buffering: Boolean) {
         isBuffering.value = buffering
+        // Feed the "playback preempts downloads" signal: yield bandwidth only when a
+        // NOT-fully-downloaded book is buffering — a local book needs no help, a stream does.
+        val streaming = currentTimeline.value?.isFullyDownloaded != true
+        playbackBandwidthCoordinator.setStreamingBuffering(buffering && streaming)
     }
 
     /**
@@ -403,6 +408,10 @@ internal class PlaybackManagerImpl(
         playbackSpeed.value = 1.0f
         playbackError.value = null
         isBuffering.value = false
+        // Release the download-yield signal on teardown too — this path clears `isBuffering`
+        // directly (not via `setBuffering`), so tell the coordinator explicitly or a clear while
+        // buffering could leave downloads yielded until some later state change.
+        playbackBandwidthCoordinator.setStreamingBuffering(false)
         playbackState.value = PlaybackState.Idle
     }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/PlaybackBandwidthCoordinatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/PlaybackBandwidthCoordinatorTest.kt
@@ -1,0 +1,83 @@
+package com.calypsan.listenup.client.playback
+
+import app.cash.turbine.test
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaybackBandwidthCoordinatorTest :
+    FunSpec({
+
+        test("does not yield until a stream buffers") {
+            runTest {
+                val coordinator = DefaultPlaybackBandwidthCoordinator(backgroundScope, releaseDelay = 2.seconds)
+                coordinator.shouldYield.value shouldBe false
+            }
+        }
+
+        test("buffering a stream yields bandwidth immediately") {
+            runTest {
+                val coordinator = DefaultPlaybackBandwidthCoordinator(backgroundScope, releaseDelay = 2.seconds)
+                coordinator.shouldYield.test {
+                    awaitItem() shouldBe false
+                    coordinator.setStreamingBuffering(true)
+                    awaitItem() shouldBe true
+                }
+            }
+        }
+
+        test("release is delayed by releaseDelay so downloads don't thrash") {
+            runTest {
+                val coordinator = DefaultPlaybackBandwidthCoordinator(backgroundScope, releaseDelay = 2.seconds)
+                coordinator.shouldYield.test {
+                    awaitItem() shouldBe false
+                    coordinator.setStreamingBuffering(true)
+                    awaitItem() shouldBe true
+                    coordinator.setStreamingBuffering(false)
+                    runCurrent()
+                    expectNoEvents() // still yielding within the release window
+                    advanceTimeBy(2.seconds)
+                    runCurrent()
+                    awaitItem() shouldBe false // released after the window
+                }
+            }
+        }
+
+        test("a re-buffer within the release window keeps yielding (no flap)") {
+            runTest {
+                val coordinator = DefaultPlaybackBandwidthCoordinator(backgroundScope, releaseDelay = 2.seconds)
+                coordinator.shouldYield.test {
+                    awaitItem() shouldBe false
+                    coordinator.setStreamingBuffering(true)
+                    awaitItem() shouldBe true
+                    coordinator.setStreamingBuffering(false)
+                    advanceTimeBy(1.seconds) // partway through the window
+                    runCurrent()
+                    coordinator.setStreamingBuffering(true) // re-buffer cancels the pending release
+                    advanceTimeBy(5.seconds) // well past the original window
+                    runCurrent()
+                    expectNoEvents() // never flapped to false
+                }
+            }
+        }
+
+        test("yield is capped at maxYield so a stuck buffer never starves downloads") {
+            runTest {
+                val coordinator =
+                    DefaultPlaybackBandwidthCoordinator(backgroundScope, releaseDelay = 2.seconds, maxYield = 60.seconds)
+                coordinator.shouldYield.test {
+                    awaitItem() shouldBe false
+                    coordinator.setStreamingBuffering(true) // buffering, and it never clears
+                    awaitItem() shouldBe true
+                    advanceTimeBy(60.seconds)
+                    runCurrent()
+                    awaitItem() shouldBe false // cap released despite still "buffering"
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
+++ b/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
@@ -12,6 +12,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 import org.koin.mp.KoinPlatform
 import com.calypsan.listenup.client.download.DownloadService
+import com.calypsan.listenup.client.playback.PlaybackBandwidthCoordinator
 import com.calypsan.listenup.client.playback.PlaybackPreparer
 import com.calypsan.listenup.client.playback.PlaybackProgressReporter
 import com.calypsan.listenup.client.playback.SleepTimerManager
@@ -310,6 +311,8 @@ object KoinHelper {
     fun getPlaybackPreparer(): PlaybackPreparer = resolve(PlaybackPreparer::class)
 
     fun getServerReachability(): ServerReachability = resolve(ServerReachability::class)
+
+    fun getPlaybackBandwidthCoordinator(): PlaybackBandwidthCoordinator = resolve(PlaybackBandwidthCoordinator::class)
 
     fun getPlaybackPreferences(): PlaybackPreferences = resolve(PlaybackPreferences::class)
 }

--- a/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -83,6 +83,7 @@ internal val iosPlaybackModule: Module =
                 fileManager = get(),
                 playbackRpcFactory = get(),
                 scope = get(qualifier = named(PLAYBACK_SCOPE)),
+                playbackBandwidthCoordinator = get(),
             )
         }
 

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.jvm.kt
@@ -45,6 +45,7 @@ val desktopPlaybackModule: Module =
                 bookRpcFactory = get(),
                 scope = get(qualifier = named("playbackScope")),
                 bookSyncDomainHandler = get<SyncDomainHandler<BookSyncPayload>>(named(SyncDomains.BOOKS.name)),
+                playbackBandwidthCoordinator = get(),
             )
         }
     }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -51,6 +51,7 @@ class PlaybackManagerBufferingStateTest :
             db: ListenUpDatabase,
             scope: CoroutineScope = CoroutineScope(Job()),
             progressTracker: ProgressTracker = buildProgressTracker(scope = scope),
+            bandwidthCoordinator: PlaybackBandwidthCoordinator = DefaultPlaybackBandwidthCoordinator(scope),
         ): PlaybackManager {
             val tokenProvider: AudioTokenProvider = mock()
             everySuspend { tokenProvider.prepareForPlayback() } returns Unit
@@ -85,6 +86,7 @@ class PlaybackManagerBufferingStateTest :
                 bookRpcFactory = mock<BookRpcFactory>(),
                 scope = scope,
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                playbackBandwidthCoordinator = bandwidthCoordinator,
             )
         }
 
@@ -140,6 +142,26 @@ class PlaybackManagerBufferingStateTest :
 
                     sut.setBuffering(false)
                     sut.isBuffering.value shouldBe false
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("setBuffering forwards streaming-buffering to the bandwidth coordinator") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val recorder = RecordingBandwidthCoordinator()
+                    val sut = createPlaybackManager(db, bandwidthCoordinator = recorder)
+
+                    // No fully-downloaded timeline in scope → a buffering book is treated as a
+                    // stream, so downloads are asked to yield; clearing buffering releases them.
+                    sut.setBuffering(true)
+                    recorder.calls.last() shouldBe true
+
+                    sut.setBuffering(false)
+                    recorder.calls.last() shouldBe false
                 }
             } finally {
                 db.close()
@@ -451,3 +473,14 @@ class PlaybackManagerBufferingStateTest :
             }
         }
     })
+
+/** Records every `setStreamingBuffering` value so a test can assert the producer wiring. */
+private class RecordingBandwidthCoordinator : PlaybackBandwidthCoordinator {
+    val calls = mutableListOf<Boolean>()
+    override val shouldYield = kotlinx.coroutines.flow.MutableStateFlow(false)
+
+    override fun setStreamingBuffering(active: Boolean) {
+        calls += active
+        shouldYield.value = active
+    }
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -162,6 +162,7 @@ class PlaybackManagerFallbackFetchTest :
                 bookRpcFactory = bookRpcFactory,
                 scope = CoroutineScope(Job()),
                 bookSyncDomainHandler = bookSyncDomainHandler,
+                playbackBandwidthCoordinator = DefaultPlaybackBandwidthCoordinator(scope),
             )
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -117,6 +117,7 @@ class PlaybackManagerPrepareTest :
                 bookRpcFactory = mock<BookRpcFactory>(),
                 scope = CoroutineScope(Job()),
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                playbackBandwidthCoordinator = DefaultPlaybackBandwidthCoordinator(scope),
             )
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -102,6 +102,7 @@ class PlaybackManagerSpeedTest :
                 bookRpcFactory = mock<BookRpcFactory>(),
                 scope = scope,
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                playbackBandwidthCoordinator = DefaultPlaybackBandwidthCoordinator(scope),
             )
         }
 


### PR DESCRIPTION
## Why

Streaming a not-yet-downloaded book while other downloads were in flight took ~30s to buffer and start — the stream and the downloads fought for the same bandwidth (and the streamed book **auto-downloads itself**, so the contention was partly self-inflicted). This makes background downloads yield to a buffering stream so playback starts fast, then resume once it's flowing.

## What — one shared mechanism, both platforms

- **`PlaybackBandwidthCoordinator`** (commonMain `single`) holds `shouldYield: StateFlow<Boolean>`. Policy: **instant acquire** (yield the moment buffering starts), **2s-delayed release** (so buffering↔playing flicker doesn't thrash download connections), and a **60s max-yield cap** (a stuck/endless buffer can never starve downloads). All timing lives in a single `transformLatest` collector, so `setStreamingBuffering` only writes a `StateFlow` — no cross-thread state to race.
- **Producers** feed `buffering && !fullyDownloaded` (only a *stream* stall asks downloads to back off; a local book needs no help): iOS `PlayerCoordinator` (via a `phase` didSet), Android/Desktop `PlaybackManager.setBuffering`.
- **Consumers** obey `shouldYield`: Android's download byte-pump soft-pauses between chunks (bounded 30s/chunk, keeps the `.tmp` + connection warm — no re-download); iOS suspends/resumes the `NSURLSession` tasks (connection stays warm — iOS has no resume-data, so cancel would re-download from scratch).

## Adversarial review (run before this PR opened)

A reviewer found three real concurrency/starvation bugs the green tests couldn't catch (`runTest` collapses threads onto one dispatcher). All fixed:
- **Release race** — the naive lock-free `launch`/`cancel` release could leave downloads *not* yielding during a live buffer. Rewrote to the single-collector `transformLatest` model (acquire deterministically wins).
- **iOS task-start race** — a download starting mid-buffer could slip past the suspend and run full-bandwidth all window. Register + start is now **atomic under the delegate lock**.
- **iOS starvation leak** — a stuck `.buffering` (or `stop()` mid-buffer) pinned downloads suspended forever. Added the **max-yield cap** (both platforms) and `stop()` returns to `.idle`; Android `clearPlayback` now routes through the coordinator.

## Tests

`PlaybackBandwidthCoordinatorTest` (Kotest): instant-acquire, delayed-release, no-flap on re-buffer, and the max-yield cap. `PlaybackManagerBufferingStateTest` gains a producer-wiring assertion (streaming-buffering forwards to the coordinator). Full iOS suite (487), Android app build, Kotlin lint, export-baseline all green. (`:server:jvmTest` + `verifyLicenses` are the documented Mac-environmental flakes; CI-Linux canonical.)
