### PR TITLE
✅ test(shared): fix hanging JVM suite from #1078 (fake bandwidth coordinator in tests)

### DIFF
--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackBandwidthCoordinator.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackBandwidthCoordinator.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.client.test.fake
+
+import com.calypsan.listenup.client.playback.PlaybackBandwidthCoordinator
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * In-memory [PlaybackBandwidthCoordinator] for tests: records every `setStreamingBuffering` value
+ * and reflects it straight into [shouldYield]. Unlike the real `DefaultPlaybackBandwidthCoordinator`
+ * it starts no `stateIn` collector and uses no real-time `delay`s, so it neither leaks a coroutine
+ * onto an uncancelled test scope nor hangs `runTest`.
+ */
+class FakePlaybackBandwidthCoordinator : PlaybackBandwidthCoordinator {
+    val calls = mutableListOf<Boolean>()
+
+    private val yielding = MutableStateFlow(false)
+    override val shouldYield: StateFlow<Boolean> = yielding.asStateFlow()
+
+    override fun setStreamingBuffering(active: Boolean) {
+        calls += active
+        yielding.value = active
+    }
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -19,6 +19,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
 import com.calypsan.listenup.client.test.fake.FakePlayer
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -51,7 +52,7 @@ class PlaybackManagerBufferingStateTest :
             db: ListenUpDatabase,
             scope: CoroutineScope = CoroutineScope(Job()),
             progressTracker: ProgressTracker = buildProgressTracker(scope = scope),
-            bandwidthCoordinator: PlaybackBandwidthCoordinator = DefaultPlaybackBandwidthCoordinator(scope),
+            bandwidthCoordinator: PlaybackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
         ): PlaybackManager {
             val tokenProvider: AudioTokenProvider = mock()
             everySuspend { tokenProvider.prepareForPlayback() } returns Unit
@@ -152,7 +153,7 @@ class PlaybackManagerBufferingStateTest :
             val db = createInMemoryTestDatabase()
             try {
                 runTest {
-                    val recorder = RecordingBandwidthCoordinator()
+                    val recorder = FakePlaybackBandwidthCoordinator()
                     val sut = createPlaybackManager(db, bandwidthCoordinator = recorder)
 
                     // No fully-downloaded timeline in scope → a buffering book is treated as a
@@ -473,14 +474,3 @@ class PlaybackManagerBufferingStateTest :
             }
         }
     })
-
-/** Records every `setStreamingBuffering` value so a test can assert the producer wiring. */
-private class RecordingBandwidthCoordinator : PlaybackBandwidthCoordinator {
-    val calls = mutableListOf<Boolean>()
-    override val shouldYield = kotlinx.coroutines.flow.MutableStateFlow(false)
-
-    override fun setStreamingBuffering(active: Boolean) {
-        calls += active
-        shouldYield.value = active
-    }
-}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -25,6 +25,7 @@ import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
 import com.calypsan.listenup.client.test.stubImageStorage
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -162,7 +163,7 @@ class PlaybackManagerFallbackFetchTest :
                 bookRpcFactory = bookRpcFactory,
                 scope = CoroutineScope(Job()),
                 bookSyncDomainHandler = bookSyncDomainHandler,
-                playbackBandwidthCoordinator = DefaultPlaybackBandwidthCoordinator(scope),
+                playbackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
             )
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
@@ -117,7 +118,7 @@ class PlaybackManagerPrepareTest :
                 bookRpcFactory = mock<BookRpcFactory>(),
                 scope = CoroutineScope(Job()),
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
-                playbackBandwidthCoordinator = DefaultPlaybackBandwidthCoordinator(scope),
+                playbackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
             )
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -102,7 +103,7 @@ class PlaybackManagerSpeedTest :
                 bookRpcFactory = mock<BookRpcFactory>(),
                 scope = scope,
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
-                playbackBandwidthCoordinator = DefaultPlaybackBandwidthCoordinator(scope),
+                playbackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
             )
         }
 


### PR DESCRIPTION
## Why

#1078 merged before its `Test (JVM)` job finished — and that job was **hanging**, not slow: the `PlaybackManager` test helpers construct the real `DefaultPlaybackBandwidthCoordinator`, whose `stateIn(SharingStarted.Eagerly)` launches a collector with real-time `delay`s on an **uncancelled** `CoroutineScope(Job())`. Inside `runTest` that never settles, so the suite hangs (`PlaybackManagerPrepareTest`/`SpeedTest`/`FallbackFetchTest` each hang alone; confirmed via `jstack` — the test worker parked in `runBlocking.joinBlocking`). So `main`'s `Test (JVM)` is currently red/hanging.

Production is unaffected — the coordinator runs on the app-lifetime scope where an always-on collector is intended.

## What

Add `FakePlaybackBandwidthCoordinator` (commonTest) — an in-memory coordinator with no `stateIn`/`delay` — and use it in the `PlaybackManager` test helpers instead of the real one. Also replaces the now-redundant private `RecordingBandwidthCoordinator` in `PlaybackManagerBufferingStateTest` with the shared fake. `PlaybackBandwidthCoordinatorTest` keeps exercising the *real* coordinator (correctly, via `backgroundScope` + virtual time).

## Tests

Full `:sharedLogic:jvmTest` now completes in ~1m (was hanging 45min+ → cancelled on CI). Spotless + detekt green.
