### PR TITLE
✨ feat(sharedUI): Android push client — FCM wiring, registrar, receive path (#604)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.androidx.baselineprofile)
+    alias(libs.plugins.googleServices)
 }
 
 android {

--- a/androidApp/google-services.json
+++ b/androidApp/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "464100124865",
+    "project_id": "listenup-b087e",
+    "storage_bucket": "listenup-b087e.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:464100124865:android:67fd018ec9838c5d74cc40",
+        "android_client_info": {
+          "package_name": "com.calypsan.listenup.client"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBbiJ2h0bPrj_xQfAs5Ly0DuDVuRKqTHAc"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.androidx.baselineprofile) apply false
     alias(libs.plugins.aboutlibraries) apply false
+    alias(libs.plugins.googleServices) apply false
 
     // Quality Tools
     alias(libs.plugins.detekt)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,12 +45,14 @@ slf4j = "2.0.18"
 room = "2.8.4"
 room-sqlite = "2.7.0"
 androidx-work = "2.11.2"
+androidx-lifecycle-process = "2.11.0"
 coil = "3.5.0"
 media3 = "1.10.1"
 concurrent-futures = "1.3.0"
 markdown-renderer = "0.43.0"
 aboutlibraries = "15.0.3"
-
+google-services = "4.5.0"
+firebase-messaging = "25.1.1"
 
 # Desktop
 logback = "1.5.38"
@@ -216,6 +218,10 @@ androidx-sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", 
 # WorkManager
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }
 androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "androidx-work" }
+# Lifecycle Process (ProcessLifecycleOwner — foreground/background app-lifecycle observation)
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle-process" }
+# Firebase Cloud Messaging (push notifications)
+firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebase-messaging" }
 # Coil (Image Loading)
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
@@ -276,3 +282,5 @@ kotlinxRpc = { id = "org.jetbrains.kotlinx.rpc.plugin", version.ref = "kotlinx-r
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 # AboutLibraries
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
+# Firebase (google-services.json → BuildConfig resource injection)
+googleServices = { id = "com.google.gms.google-services", version.ref = "google-services" }

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -12011,6 +12011,76 @@
         }
       }
     },
+    "push.campfire_invite_body": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@"
+          }
+        }
+      }
+    },
+    "push.campfire_invite_title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ invited you to listen together"
+          }
+        }
+      }
+    },
+    "push.campfire_invite_title_unknown": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have an invite to listen together"
+          }
+        }
+      }
+    },
+    "push.generic_body": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something happened on your server."
+          }
+        }
+      }
+    },
+    "push.generic_title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ListenUp"
+          }
+        }
+      }
+    },
+    "push.test_body": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push notifications are working."
+          }
+        }
+      }
+    },
+    "push.test_title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test notification"
+          }
+        }
+      }
+    },
     "scan.building_subtitle": {
       "localizations": {
         "en": {

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -13061,26 +13061,6 @@
         }
       }
     },
-    "settings.send_test_notification": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send test notification"
-          }
-        }
-      }
-    },
-    "settings.send_test_notification_subtitle": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arrives when the app is in the background."
-          }
-        }
-      }
-    },
     "settings.server_version": {
       "localizations": {
         "en": {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/push/RelayPushNotifier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/push/RelayPushNotifier.kt
@@ -41,7 +41,8 @@ class RelayPushNotifier(
                 db.pushTokensQueries.selectLiveForUser(userId, clock.now().toEpochMilliseconds()).executeAsList()
             }
         if (rows.isEmpty()) return
-        val tokens = rows.map { PushRelayClient.RelayToken(platform = it.platform, token = it.token) }
+        // Rows store the PushPlatform enum name ("ANDROID"); the relay protocol speaks lowercase.
+        val tokens = rows.map { PushRelayClient.RelayToken(platform = it.platform.lowercase(), token = it.token) }
         val payloadJson = contractJson.encodeToJsonElement(PushPayload.serializer(), payload)
         val collapseKey = collapseKeyFor(payload)
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/push/RelayPushNotifierTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/push/RelayPushNotifierTest.kt
@@ -173,7 +173,9 @@ class RelayPushNotifierTest :
                             it.jsonObject["token"]!!.jsonPrimitive.content to
                                 it.jsonObject["platform"]!!.jsonPrimitive.content
                         }.toSet()
-                sentTokens shouldBe setOf("token-android" to "ANDROID", "token-ios" to "IOS")
+                // The relay wire protocol speaks lowercase platform tags (validate.ts:
+                // "platform must be android|ios"); rows store the PushPlatform enum name.
+                sentTokens shouldBe setOf("token-android" to "android", "token-ios" to "ios")
                 body["payload"] shouldBe contractJson.encodeToJsonElement(PushPayload.serializer(), payload)
             }
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/push/PushRegistrar.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/push/PushRegistrar.kt
@@ -1,0 +1,54 @@
+package com.calypsan.listenup.client.data.push
+
+import com.calypsan.listenup.api.result.onFailure
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.domain.repository.PushRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Orchestrates push-token registration against the user's server: post-auth,
+ * on platform token rotation, and whenever `ServerInfo.pushEnabled` changes
+ * (the admin toggle flips → `ServerInfoChanged` → forced refetch → this runs
+ * again). Best-effort — failures log and defer to the next trigger (Never
+ * Stranded: push is an accelerant, SSE carries every event regardless).
+ *
+ * [tokenProvider] is nullable: absence means this build has no platform push
+ * hook (desktop, or an Android build without Play services) — every method is
+ * then a silent no-op. We never unregister on toggle-disable: the server just
+ * stops sending, and the token dies with the session (logout/session eviction
+ * is the existing cleanup path).
+ */
+class PushRegistrar(
+    private val instanceRepository: InstanceRepository,
+    private val pushRepository: PushRepository,
+    private val tokenProvider: PushTokenProvider?,
+) {
+    /**
+     * Registers this device's current push token with the server, if push is
+     * enabled there. Call after authentication and after any forced
+     * `ServerInfo` refetch.
+     */
+    suspend fun syncRegistration() {
+        val provider = tokenProvider ?: return
+        val info = instanceRepository.getServerInfoOrNull() ?: return
+        if (!info.pushEnabled) return
+        val token = provider.currentToken() ?: return
+        pushRepository
+            .registerToken(token)
+            .onFailure { logger.warn { "push token registration failed: ${it.code}" } }
+    }
+
+    /**
+     * Re-registers [newToken] after the platform SDK rotates it (e.g. FCM's
+     * `onNewToken`). No-ops if the server has push disabled.
+     */
+    suspend fun onTokenRotated(newToken: String) {
+        val info = instanceRepository.getServerInfoOrNull() ?: return
+        if (!info.pushEnabled) return
+        pushRepository
+            .registerToken(newToken)
+            .onFailure { logger.warn { "push token rotation registration failed: ${it.code}" } }
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/push/PushTokenProvider.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/push/PushTokenProvider.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.client.data.push
+
+/**
+ * Platform hook returning this device's push token, or `null` when push isn't
+ * available here (no Play services, desktop). Bound only where a real provider
+ * exists (the Android platform module); consumers inject it nullable — the
+ * absence of a binding on a platform (desktop) is the intended "push doesn't
+ * exist here" signal, not a wiring bug.
+ */
+interface PushTokenProvider {
+    /**
+     * Returns the current platform push token, or `null` if unavailable
+     * (missing Play services, registration in progress, or any lookup failure).
+     */
+    suspend fun currentToken(): String?
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PushRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PushRepositoryImpl.kt
@@ -24,7 +24,10 @@ internal class PushRepositoryImpl(
     override suspend fun registerToken(token: String): AppResult<Unit> =
         rpcFactory.callResult { it.registerToken(token, platform) }
 
-    override suspend fun unregisterToken(token: String): AppResult<Unit> = rpcFactory.callResult { it.unregisterToken(token) }
+    override suspend fun unregisterToken(token: String): AppResult<Unit> =
+        rpcFactory.callResult {
+            it.unregisterToken(token)
+        }
 
     override suspend fun sendTestNotification(): AppResult<Unit> = rpcFactory.callResult { it.sendTestNotification() }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.sync.SyncDomainKey
 import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.BookEntityMapper
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.push.PushRegistrar
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.data.remote.BookRpcFactory
 import com.calypsan.listenup.client.data.remote.ContributorRpcFactory
@@ -232,7 +233,14 @@ internal val clientSyncModule =
                 // write-through side effects. These are the sole home of this wiring now — the
                 // dispatcher routes refresh controls via RefreshedDomainRouter.
                 pingPresence = { get<PresenceRefreshSignal>().ping() },
-                refetchServerInfo = { val _ = get<InstanceRepository>().getServerInfo(forceRefresh = true) },
+                refetchServerInfo = {
+                    val _ = get<InstanceRepository>().getServerInfo(forceRefresh = true)
+                    // The admin push toggle rides this same refetch: toggle flips → ServerInfoChanged →
+                    // this forced refetch → PushRegistrar re-evaluates pushEnabled and (re)registers. We
+                    // never unregister on disable — the server stops sending, and the token dies with the
+                    // session (logout/session eviction is the existing cleanup path).
+                    get<PushRegistrar>().syncRegistration()
+                },
                 refetchPreferences = { val _ = get<UserPreferencesRepository>().getPreferences() },
                 documentStorage = get(),
             )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -526,8 +526,6 @@ internal val settingsPresentationModule =
                 authSession = get(),
                 syncRepository = get(),
                 rpcCacheInvalidator = get(),
-                pushRepository = get(),
-                errorBus = get(),
             )
         }
         // DevicesViewModel for the Devices (active sessions) screen

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PushClientModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PushClientModule.kt
@@ -1,6 +1,8 @@
 package com.calypsan.listenup.client.di
 
 import com.calypsan.listenup.api.push.PushPlatform
+import com.calypsan.listenup.client.data.push.PushRegistrar
+import com.calypsan.listenup.client.data.push.PushTokenProvider
 import com.calypsan.listenup.client.data.remote.KtorPushRpcFactory
 import com.calypsan.listenup.client.data.remote.PushRpcFactory
 import com.calypsan.listenup.client.data.remote.RemoteCache
@@ -11,19 +13,21 @@ import org.koin.dsl.binds
 import org.koin.dsl.module
 
 /**
- * Push aggregate Koin wiring — RPC proxy and repository for device push-token
- * registration.
+ * Push aggregate Koin wiring — RPC proxy, repository, and registrar for device
+ * push-token registration.
  *
  * External dependencies (owned by other modules):
  *  - [com.calypsan.listenup.client.data.remote.ApiClientFactory] — `networkModule`
  *  - [com.calypsan.listenup.client.domain.repository.ServerConfig] — `settingsModule`
  *  - [com.calypsan.listenup.client.data.remote.RpcAuthRecovery] — `networkModule`
- *
- * The [PushPlatform] binding below is a **stopgap**: it hardcodes `ANDROID` here
- * because this task (client RPC plumbing, C2) only touches commonMain. The
- * per-platform value belongs in the platform entry point once it exists — C3/C4
- * move this binding to `androidMain` (and add the iOS `IOS` equivalent) as part
- * of wiring up the real FCM token provider.
+ *  - [com.calypsan.listenup.client.domain.repository.InstanceRepository] — `settingsModule`
+ *  - [PushPlatform] — bound `ANDROID` in the Android platform module
+ *    (`androidModule` in `ListenUp.kt`); the iOS `IOS` binding lands with the
+ *    iOS push work.
+ *  - [PushTokenProvider] — bound only where a real platform hook exists (the
+ *    Android platform module binds `FcmTokenProvider`); resolved here via
+ *    `getOrNull()` so its absence (desktop, or an Android build without Play
+ *    services) is a normal, non-crashing case.
  */
 internal val pushClientModule: Module =
     module {
@@ -36,14 +40,22 @@ internal val pushClientModule: Module =
             )
         } binds arrayOf(RemoteCache::class)
 
-        // TODO(C3/C4): relocate to a platform module once FcmTokenProvider exists; bind IOS on Apple targets.
-        single<PushPlatform> { PushPlatform.ANDROID }
-
         // PushRepository — device push-token registration (SOLID: interface in domain, impl in data)
         single<PushRepository> {
             PushRepositoryImpl(
                 rpcFactory = get(),
                 platform = get(),
+            )
+        }
+
+        // PushRegistrar — orchestrates registration post-auth, on rotation, and on toggle
+        // change. `tokenProvider` is nullable by design: no binding means no platform push
+        // hook on this build.
+        single {
+            PushRegistrar(
+                instanceRepository = get(),
+                pushRepository = get(),
+                tokenProvider = getOrNull(),
             )
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminSettingsViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminSettingsViewModel.kt
@@ -142,7 +142,11 @@ class AdminSettingsViewModel(
                     logger.error { "Failed to save push notifications setting: ${result.error}" }
                     // Revert the optimistic flip to the last server-confirmed value.
                     updateReady {
-                        it.copy(pushNotificationsEnabled = savedPushNotificationsEnabled, error = result.error).withDirty()
+                        it
+                            .copy(
+                                pushNotificationsEnabled = savedPushNotificationsEnabled,
+                                error = result.error,
+                            ).withDirty()
                     }
                 }
             }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/settings/SettingsViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/settings/SettingsViewModel.kt
@@ -8,7 +8,6 @@ import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.domain.model.ThemeMode
 import com.calypsan.listenup.client.data.remote.RpcCacheInvalidator
 import com.calypsan.listenup.client.domain.repository.AuthSession
-import com.calypsan.listenup.client.domain.repository.PushRepository
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.LibraryPreferences
@@ -16,7 +15,6 @@ import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.domain.repository.UserPreferencesRepository
-import com.calypsan.listenup.core.error.ErrorBus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -71,7 +69,6 @@ data class SettingsUiState(
     // Server info (read-only)
     val serverUrl: String? = null,
     val serverVersion: String? = null,
-    val pushEnabled: Boolean = false,
 )
 
 /**
@@ -94,8 +91,6 @@ class SettingsViewModel(
     private val authSession: AuthSession,
     private val syncRepository: SyncRepository,
     private val rpcCacheInvalidator: RpcCacheInvalidator,
-    private val pushRepository: PushRepository,
-    private val errorBus: ErrorBus,
 ) : ViewModel() {
     // Internal mutable state for settings that aren't reactive StateFlows
     private val internalState = MutableStateFlow(SettingsUiState())
@@ -186,7 +181,7 @@ class SettingsViewModel(
         when (val result = instanceRepository.getServerInfo()) {
             is AppResult.Success -> {
                 internalState.update {
-                    it.copy(serverVersion = result.data.version, pushEnabled = result.data.pushEnabled)
+                    it.copy(serverVersion = result.data.version)
                 }
             }
 
@@ -402,16 +397,4 @@ class SettingsViewModel(
     }
 
     // endregion
-
-    /**
-     * Sends a test push notification to this user's own registered devices. Success has no UI
-     * feedback — the arriving notification IS the feedback (and only shows while the app is
-     * backgrounded, since foreground pushes are suppressed in favor of the live SSE surface).
-     * Failure routes through the global error bus.
-     */
-    fun sendTestNotification() {
-        viewModelScope.launch {
-            pushRepository.sendTestNotification().onFailure { errorBus.emit(it) }
-        }
-    }
 }

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -1441,5 +1441,14 @@
     "version_prefix": "v%1$s",
     "not_found": "Library not found.",
     "view_project": "View project"
+  },
+  "push": {
+    "test_title": "Test notification",
+    "test_body": "Push notifications are working.",
+    "campfire_invite_title": "%1$s invited you to listen together",
+    "campfire_invite_title_unknown": "You have an invite to listen together",
+    "campfire_invite_body": "%1$s",
+    "generic_title": "ListenUp",
+    "generic_body": "Something happened on your server."
   }
 }

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -854,8 +854,6 @@
     "open_source_licenses": "Open Source Licenses",
     "playback": "Playback",
     "rewind_a_few_seconds_when": "Rewind a few seconds when resuming playback",
-    "send_test_notification": "Send test notification",
-    "send_test_notification_subtitle": "Arrives when the app is in the background.",
     "server_version": "Server version",
     "shake_to_reset_timer": "Shake to Reset Timer",
     "sign_out_confirm_title": "Sign Out",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/push/PushRegistrarTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/push/PushRegistrarTest.kt
@@ -1,0 +1,134 @@
+package com.calypsan.listenup.client.data.push
+
+import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
+import com.calypsan.listenup.api.error.PushError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.domain.repository.PushRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.test.runTest
+
+/** Fake [PushTokenProvider] returning a fixed [token] (or `null` to simulate "no token yet"). */
+private class FakePushTokenProvider(
+    private val token: String?,
+) : PushTokenProvider {
+    override suspend fun currentToken(): String? = token
+}
+
+private fun serverInfo(pushEnabled: Boolean): ServerInfo =
+    ServerInfo(
+        name = "ListenUp",
+        version = "1.0.0",
+        apiVersion = "v1",
+        setupRequired = false,
+        registrationPolicy = RegistrationPolicy.CLOSED,
+        pushEnabled = pushEnabled,
+        instanceId = "instance-1",
+    )
+
+class PushRegistrarTest :
+    FunSpec({
+
+        test("registers the current token when pushEnabled") {
+            runTest {
+                val instanceRepository =
+                    mock<InstanceRepository> {
+                        everySuspend { getServerInfoOrNull() } returns serverInfo(pushEnabled = true)
+                    }
+                val pushRepository =
+                    mock<PushRepository> {
+                        everySuspend { registerToken(any()) } returns AppResult.Success(Unit)
+                    }
+                val registrar = PushRegistrar(instanceRepository, pushRepository, FakePushTokenProvider("token-1"))
+
+                registrar.syncRegistration()
+
+                verifySuspend { pushRepository.registerToken("token-1") }
+            }
+        }
+
+        test("no-ops when ServerInfo.pushEnabled is false") {
+            runTest {
+                val instanceRepository =
+                    mock<InstanceRepository> {
+                        everySuspend { getServerInfoOrNull() } returns serverInfo(pushEnabled = false)
+                    }
+                val pushRepository = mock<PushRepository>()
+                val registrar = PushRegistrar(instanceRepository, pushRepository, FakePushTokenProvider("token-1"))
+
+                registrar.syncRegistration()
+
+                verifySuspend(exactly(0)) { pushRepository.registerToken(any()) }
+            }
+        }
+
+        test("no-ops when no token provider is bound (desktop/de-googled)") {
+            runTest {
+                val instanceRepository = mock<InstanceRepository>()
+                val pushRepository = mock<PushRepository>()
+                val registrar = PushRegistrar(instanceRepository, pushRepository, tokenProvider = null)
+
+                registrar.syncRegistration()
+
+                verifySuspend(exactly(0)) { instanceRepository.getServerInfoOrNull() }
+                verifySuspend(exactly(0)) { pushRepository.registerToken(any()) }
+            }
+        }
+
+        test("no-ops when provider returns null (no Play services)") {
+            runTest {
+                val instanceRepository =
+                    mock<InstanceRepository> {
+                        everySuspend { getServerInfoOrNull() } returns serverInfo(pushEnabled = true)
+                    }
+                val pushRepository = mock<PushRepository>()
+                val registrar = PushRegistrar(instanceRepository, pushRepository, FakePushTokenProvider(null))
+
+                registrar.syncRegistration()
+
+                verifySuspend(exactly(0)) { pushRepository.registerToken(any()) }
+            }
+        }
+
+        test("onTokenRotated re-registers with the new token") {
+            runTest {
+                val instanceRepository =
+                    mock<InstanceRepository> {
+                        everySuspend { getServerInfoOrNull() } returns serverInfo(pushEnabled = true)
+                    }
+                val pushRepository =
+                    mock<PushRepository> {
+                        everySuspend { registerToken(any()) } returns AppResult.Success(Unit)
+                    }
+                val registrar = PushRegistrar(instanceRepository, pushRepository, FakePushTokenProvider("stale"))
+
+                registrar.onTokenRotated("rotated-token")
+
+                verifySuspend { pushRepository.registerToken("rotated-token") }
+            }
+        }
+
+        test("registration failure is swallowed after logging (never throws)") {
+            runTest {
+                val instanceRepository =
+                    mock<InstanceRepository> {
+                        everySuspend { getServerInfoOrNull() } returns serverInfo(pushEnabled = true)
+                    }
+                val pushRepository =
+                    mock<PushRepository> {
+                        everySuspend { registerToken(any()) } returns AppResult.Failure(PushError.PushDisabled())
+                    }
+                val registrar = PushRegistrar(instanceRepository, pushRepository, FakePushTokenProvider("token-1"))
+
+                // Must not throw.
+                registrar.syncRegistration()
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PushRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PushRepositoryImplTest.kt
@@ -27,8 +27,7 @@ private class FakePushRpcFactory(
 ) : PushRpcFactory {
     override suspend fun get(): PushService = provide()
 
-    override suspend fun <T> callResult(block: suspend (PushService) -> AppResult<T>): AppResult<T> =
-        catchingRpcResult { block(provide()) }
+    override suspend fun <T> callResult(block: suspend (PushService) -> AppResult<T>): AppResult<T> = catchingRpcResult { block(provide()) }
 
     override suspend fun invalidate() {}
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ClientSyncModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ClientSyncModuleVerifyTest.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.local.documents.DocumentStorage
 import com.calypsan.listenup.client.data.connection.ConnectionCoordinator
 import com.calypsan.listenup.client.data.connection.ConnectionIssueReporter
+import com.calypsan.listenup.client.data.push.PushRegistrar
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.data.sync.domains.MirroredDomain
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -53,6 +54,9 @@ import org.koin.test.verify.verify
  *    `mirrored: List<MirroredDomain<*>>` is populated by literal `listOf(...)` construction
  *    inside the module, not by individual `single<MirroredDomain<*>>` bindings, so the
  *    element type is declared here instead.
+ *  - [PushRegistrar] — owned by `pushClientModule`; the catalog's `refetchServerInfo`
+ *    refresh strategy re-runs registration after every forced `ServerInfo` refetch, which
+ *    is how the admin push toggle takes effect live.
  */
 @OptIn(KoinExperimentalAPI::class)
 class ClientSyncModuleVerifyTest :
@@ -81,6 +85,7 @@ class ClientSyncModuleVerifyTest :
                         DocumentStorage::class,
                         MirroredDomain::class,
                         com.calypsan.listenup.client.data.remote.RpcAuthRecovery::class,
+                        PushRegistrar::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/PushClientModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/PushClientModuleVerifyTest.kt
@@ -1,7 +1,10 @@
 package com.calypsan.listenup.client.di
 
+import com.calypsan.listenup.api.push.PushPlatform
+import com.calypsan.listenup.client.data.push.PushTokenProvider
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.data.remote.RpcAuthRecovery
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import io.kotest.core.spec.style.FunSpec
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -15,6 +18,13 @@ import org.koin.test.verify.verify
  *  - [ApiClientFactory] — owned by `networkModule`.
  *  - [ServerConfig] — owned by `settingsModule`.
  *  - [RpcAuthRecovery] — owned by `networkModule`.
+ *  - [InstanceRepository] — owned by `settingsModule`.
+ *  - [PushPlatform] — owned by the Android platform module (`androidModule`).
+ *  - [PushTokenProvider] — owned by the Android platform module. Resolved
+ *    nullable in [pushClientModule] via `getOrNull()`, but still declared here
+ *    because `verify()`'s static analysis needs every referenced type
+ *    resolvable, nullable or not — the nullability is a runtime distinction,
+ *    not a static-graph one.
  */
 @OptIn(KoinExperimentalAPI::class)
 class PushClientModuleVerifyTest :
@@ -27,6 +37,9 @@ class PushClientModuleVerifyTest :
                         ApiClientFactory::class,
                         ServerConfig::class,
                         RpcAuthRecovery::class,
+                        InstanceRepository::class,
+                        PushPlatform::class,
+                        PushTokenProvider::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/settings/SettingsViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/settings/SettingsViewModelTest.kt
@@ -1,8 +1,5 @@
 package com.calypsan.listenup.client.presentation.settings
 
-import app.cash.turbine.test
-import com.calypsan.listenup.api.dto.ServerInfo
-import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.ThemeMode
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -11,12 +8,10 @@ import com.calypsan.listenup.client.domain.repository.LibraryPreferences
 import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.data.remote.RpcCacheInvalidator
-import com.calypsan.listenup.client.domain.repository.PushRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserPreferences
 import com.calypsan.listenup.client.domain.repository.UserPreferencesRepository
-import com.calypsan.listenup.core.error.ErrorBus
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -62,8 +57,6 @@ class SettingsViewModelTest :
             val authSession: AuthSession = mock()
             val syncRepository: SyncRepository = mock()
             val rpcCacheInvalidator: RpcCacheInvalidator = mock()
-            val pushRepository: PushRepository = mock()
-            val errorBus: ErrorBus = ErrorBus()
 
             // StateFlows for local preferences (mocked as MutableStateFlow)
             val themeModeFlow = MutableStateFlow(ThemeMode.SYSTEM)
@@ -97,8 +90,6 @@ class SettingsViewModelTest :
                     authSession = authSession,
                     syncRepository = syncRepository,
                     rpcCacheInvalidator = rpcCacheInvalidator,
-                    pushRepository = pushRepository,
-                    errorBus = errorBus,
                 )
         }
 
@@ -151,7 +142,6 @@ class SettingsViewModelTest :
             everySuspend { fixture.authSession.clearAuthTokens() } returns Unit
             everySuspend { fixture.syncRepository.disconnect() } returns Unit
             everySuspend { fixture.rpcCacheInvalidator.invalidateAll() } returns Unit
-            everySuspend { fixture.pushRepository.sendTestNotification() } returns AppResult.Success(Unit)
 
             return fixture
         }
@@ -349,62 +339,6 @@ class SettingsViewModelTest :
 
                 // Then
                 viewModel.state.value.hideSingleBookSeries shouldBe true
-            }
-        }
-
-        // ========== Push Notifications ==========
-
-        test("loads pushEnabled from server info") {
-            runTest {
-                val fixture = createFixture()
-                everySuspend { fixture.instanceRepository.getServerInfo() } returns
-                    AppResult.Success(
-                        ServerInfo(
-                            name = "ListenUp",
-                            version = "1.0.0",
-                            apiVersion = "v1",
-                            setupRequired = false,
-                            registrationPolicy = RegistrationPolicy.CLOSED,
-                            pushEnabled = true,
-                            instanceId = "instance-1",
-                        ),
-                    )
-
-                val viewModel = fixture.build()
-                advanceUntilIdle()
-
-                viewModel.state.value.pushEnabled shouldBe true
-            }
-        }
-
-        test("sendTestNotification delegates to PushRepository") {
-            runTest {
-                val fixture = createFixture()
-                val viewModel = fixture.build()
-                advanceUntilIdle()
-
-                viewModel.sendTestNotification()
-                advanceUntilIdle()
-
-                verifySuspend { fixture.pushRepository.sendTestNotification() }
-            }
-        }
-
-        test("sendTestNotification failure emits to the error bus") {
-            runTest {
-                val fixture = createFixture()
-                val error =
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Push notifications are not enabled on this server.")
-                everySuspend { fixture.pushRepository.sendTestNotification() } returns AppResult.Failure(error)
-                val viewModel = fixture.build()
-                advanceUntilIdle()
-
-                fixture.errorBus.errors.test {
-                    viewModel.sendTestNotification()
-                    advanceUntilIdle()
-                    awaitItem() shouldBe error
-                }
             }
         }
 

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -179,6 +179,11 @@ kotlin {
 
             // kotlinx-io: wrap a SAF OutputStream as a RawSink to stream backup downloads to disk
             implementation(libs.kotlinx.io.core)
+
+            // Firebase Cloud Messaging (push notifications) + ProcessLifecycleOwner
+            // (foreground/background observation for registration timing)
+            implementation(libs.firebase.messaging)
+            implementation(libs.androidx.lifecycle.process)
         }
         commonMain.dependencies {
             implementation(libs.compose.runtime)

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/notifications/NotificationChannelsTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/notifications/NotificationChannelsTest.kt
@@ -26,7 +26,12 @@ class NotificationChannelsTest :
             NotificationChannels.DOWNLOAD shouldBe "listenup_download"
         }
 
-        test("allIds returns all three channel ids in order") {
-            NotificationChannels.allIds() shouldBe listOf("listenup_playback", "listenup_sync", "listenup_download")
+        test("SOCIAL channel id is listenup_social") {
+            NotificationChannels.SOCIAL shouldBe "listenup_social"
+        }
+
+        test("allIds returns all four channel ids in order") {
+            NotificationChannels.allIds() shouldBe
+                listOf("listenup_playback", "listenup_sync", "listenup_download", "listenup_social")
         }
     })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/push/PushNotificationRendererTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/push/PushNotificationRendererTest.kt
@@ -1,0 +1,120 @@
+package com.calypsan.listenup.client.push
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.calypsan.listenup.api.push.PushPayload
+import com.calypsan.listenup.client.notifications.NotificationChannels
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [PushNotificationRenderer]'s decode → enrich → notify pipeline and for the
+ * [NotificationChannels.SOCIAL] channel it posts to.
+ *
+ * [android.app.NotificationManager] and [android.content.Intent] resolution require a real
+ * Android resource/service environment, so this uses [RobolectricTestRunner] + JUnit4
+ * (consistent with [com.calypsan.listenup.client.playback.AudiobookNotificationProviderTest] and
+ * [com.calypsan.listenup.client.presentation.error.AppErrorLocalizationTest]); the
+ * `junit-vintage-engine` on the classpath keeps these discoverable alongside Kotest specs.
+ *
+ * Posted notifications are inspected via Robolectric's `ShadowNotificationManager` rather than by
+ * recomputing the renderer's private notification-id scheme.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class PushNotificationRendererTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val notificationManager = context.getSystemService(NotificationManager::class.java)
+
+    private fun renderer(
+        bookTitleLookup: suspend (String) -> String? = { null },
+        inviterNameLookup: suspend (String) -> String? = { null },
+    ) = PushNotificationRenderer(context, bookTitleLookup, inviterNameLookup)
+
+    private fun onlyPosted(): Notification = Shadows.shadowOf(notificationManager).allNotifications.single()
+
+    @Test
+    fun `social channel is registered`() {
+        NotificationChannels.registerAll(context)
+
+        val channel = notificationManager.getNotificationChannel(NotificationChannels.SOCIAL)
+
+        channel shouldNotBe null
+        channel.importance shouldBe NotificationManager.IMPORTANCE_HIGH
+    }
+
+    @Test
+    fun `test payload renders title+body on social channel`() =
+        runTest {
+            NotificationChannels.registerAll(context)
+
+            renderer().render(PushPayload.TestNotification(sentAtMs = 0L))
+
+            val posted = onlyPosted()
+            posted.extras.getString(Notification.EXTRA_TITLE) shouldBe "Test notification"
+            posted.extras.getString(Notification.EXTRA_TEXT) shouldBe "Push notifications are working."
+            posted.channelId shouldBe NotificationChannels.SOCIAL
+        }
+
+    @Test
+    fun `campfire invite enriches inviter name from lookup`() =
+        runTest {
+            NotificationChannels.registerAll(context)
+            val payload = PushPayload.CampfireInvite(campfireId = "camp1", bookId = "book1", inviterUserId = "user1")
+
+            renderer(
+                bookTitleLookup = { id -> "The Way of Kings".takeIf { id == "book1" } },
+                inviterNameLookup = { id -> "Alice".takeIf { id == "user1" } },
+            ).render(payload)
+
+            val posted = onlyPosted()
+            posted.extras.getString(Notification.EXTRA_TITLE) shouldBe "Alice invited you to listen together"
+            posted.extras.getString(Notification.EXTRA_TEXT) shouldBe "The Way of Kings"
+        }
+
+    @Test
+    fun `campfire invite falls back to unknown-inviter title when lookups fail`() =
+        runTest {
+            NotificationChannels.registerAll(context)
+            val payload = PushPayload.CampfireInvite(campfireId = "camp2", bookId = "book2", inviterUserId = "user2")
+
+            renderer(
+                bookTitleLookup = { error("book lookup failed") },
+                inviterNameLookup = { error("inviter lookup failed") },
+            ).render(payload)
+
+            val posted = onlyPosted()
+            posted.extras.getString(Notification.EXTRA_TITLE) shouldBe "You have an invite to listen together"
+            posted.extras.getString(Notification.EXTRA_TEXT) shouldBe ""
+        }
+
+    @Test
+    fun `null payload renders the generic notification`() =
+        runTest {
+            NotificationChannels.registerAll(context)
+
+            renderer().render(null)
+
+            val posted = onlyPosted()
+            posted.extras.getString(Notification.EXTRA_TITLE) shouldBe "ListenUp"
+            posted.extras.getString(Notification.EXTRA_TEXT) shouldBe "Something happened on your server."
+        }
+
+    @Test
+    fun `notification carries a content intent`() =
+        runTest {
+            NotificationChannels.registerAll(context)
+
+            renderer().render(PushPayload.TestNotification(sentAtMs = 0L))
+
+            onlyPosted().contentIntent shouldNotBe null
+        }
+}

--- a/sharedUI/src/androidMain/AndroidManifest.xml
+++ b/sharedUI/src/androidMain/AndroidManifest.xml
@@ -86,6 +86,14 @@
             </intent-filter>
         </service>
 
+        <service
+            android:name="com.calypsan.listenup.client.push.ListenUpMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <!-- Android Auto support -->
         <meta-data
             android:name="com.google.android.gms.car.application"

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -43,9 +43,12 @@ import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
 import com.calypsan.listenup.client.playback.cast.CastPreparer
 import com.calypsan.listenup.client.push.FcmTokenProvider
+import com.calypsan.listenup.client.push.PushNotificationRenderer
 import com.calypsan.listenup.api.push.PushPlatform
 import com.calypsan.listenup.client.data.push.PushRegistrar
 import com.calypsan.listenup.client.data.push.PushTokenProvider
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.UserProfileRepository
 import com.calypsan.listenup.client.sync.AndroidBackgroundSyncScheduler
 import com.calypsan.listenup.client.sync.BackgroundSyncScheduler
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -132,6 +135,18 @@ val androidModule =
         // see that module's KDoc for the full external-dependency contract.
         single<PushPlatform> { PushPlatform.ANDROID }
         single<PushTokenProvider> { FcmTokenProvider() }
+
+        // Receive-path renderer: enrichment lookups are best-effort local-first reads
+        // (Room-backed repositories) resolved once at DI time, invoked per notification.
+        single {
+            val bookRepository = get<BookRepository>()
+            val userProfileRepository = get<UserProfileRepository>()
+            PushNotificationRenderer(
+                context = androidContext(),
+                bookTitleLookup = { id -> bookRepository.getBookListItem(id)?.title },
+                inviterNameLookup = { id -> userProfileRepository.getById(id)?.displayName },
+            )
+        }
 
         // App shortcuts manager - handles dynamic shortcuts for recent books
         single {

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -42,6 +42,10 @@ import com.calypsan.listenup.client.playback.PlaybackStateWriter
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
 import com.calypsan.listenup.client.playback.cast.CastPreparer
+import com.calypsan.listenup.client.push.FcmTokenProvider
+import com.calypsan.listenup.api.push.PushPlatform
+import com.calypsan.listenup.client.data.push.PushRegistrar
+import com.calypsan.listenup.client.data.push.PushTokenProvider
 import com.calypsan.listenup.client.sync.AndroidBackgroundSyncScheduler
 import com.calypsan.listenup.client.sync.BackgroundSyncScheduler
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -122,6 +126,12 @@ val androidModule =
     module {
         // Background sync scheduler
         single<BackgroundSyncScheduler> { AndroidBackgroundSyncScheduler(androidContext()) }
+
+        // Push: this build's platform fact + the real FCM token hook. Both are
+        // platform-specific facts that don't belong in commonMain's pushClientModule —
+        // see that module's KDoc for the full external-dependency contract.
+        single<PushPlatform> { PushPlatform.ANDROID }
+        single<PushTokenProvider> { FcmTokenProvider() }
 
         // App shortcuts manager - handles dynamic shortcuts for recent books
         single {
@@ -344,6 +354,7 @@ class ListenUp :
             com.calypsan.listenup.client.data.remote
                 .warmUpApiClient()
             get<BackgroundSyncScheduler>().schedule()
+            get<PushRegistrar>().syncRegistration()
         }
     }
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/notifications/NotificationChannels.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/notifications/NotificationChannels.kt
@@ -13,6 +13,7 @@ import android.content.Context
  * - [PLAYBACK]: audiobook playback controls (IMPORTANCE_LOW, no badge).
  * - [SYNC]: background sync activity (IMPORTANCE_LOW, silent, no badge).
  * - [DOWNLOAD]: download progress (IMPORTANCE_LOW, silent, no badge).
+ * - [SOCIAL]: push-delivered invites and social activity (IMPORTANCE_HIGH, badge, default sound).
  *
  * Call [registerAll] from `Application.onCreate`. It is idempotent — Android ignores
  * `createNotificationChannel` calls for channels that already exist with the same id.
@@ -21,6 +22,7 @@ object NotificationChannels {
     const val PLAYBACK = "listenup_playback"
     const val SYNC = "listenup_sync"
     const val DOWNLOAD = "listenup_download"
+    const val SOCIAL = "listenup_social"
 
     /**
      * User-visible name for the [PLAYBACK] channel.
@@ -32,7 +34,7 @@ object NotificationChannels {
     const val PLAYBACK_NAME = "Playback"
 
     /** Returns all channel ids in registration order. */
-    fun allIds(): List<String> = listOf(PLAYBACK, SYNC, DOWNLOAD)
+    fun allIds(): List<String> = listOf(PLAYBACK, SYNC, DOWNLOAD, SOCIAL)
 
     /** Register every channel. Idempotent — safe to call from `Application.onCreate`. */
     fun registerAll(context: Context) {
@@ -57,6 +59,12 @@ object NotificationChannels {
                 setShowBadge(false)
                 setSound(null, null)
                 enableVibration(false)
+            },
+        )
+        notificationManager.createNotificationChannel(
+            NotificationChannel(SOCIAL, "Social", NotificationManager.IMPORTANCE_HIGH).apply {
+                description = "Invites and social activity"
+                setShowBadge(true)
             },
         )
     }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/FcmTokenProvider.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/FcmTokenProvider.kt
@@ -20,7 +20,7 @@ class FcmTokenProvider : PushTokenProvider {
             }
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Exception) {
+        } catch (ignored: Exception) {
             null // No Play services / Firebase not initialized: SSE-only, by design.
         }
 }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/FcmTokenProvider.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/FcmTokenProvider.kt
@@ -1,0 +1,26 @@
+package com.calypsan.listenup.client.push
+
+import com.calypsan.listenup.client.data.push.PushTokenProvider
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Android [PushTokenProvider] backed by Firebase Cloud Messaging. Wraps the
+ * SDK's `Task`-based API in [suspendCancellableCoroutine] rather than pulling
+ * in `kotlinx-coroutines-play-services` for a single call site.
+ */
+class FcmTokenProvider : PushTokenProvider {
+    override suspend fun currentToken(): String? =
+        try {
+            suspendCancellableCoroutine { cont ->
+                FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+                    cont.resumeWith(Result.success(if (task.isSuccessful) task.result else null))
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            null // No Play services / Firebase not initialized: SSE-only, by design.
+        }
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/ListenUpMessagingService.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/ListenUpMessagingService.kt
@@ -1,0 +1,11 @@
+package com.calypsan.listenup.client.push
+
+import com.google.firebase.messaging.FirebaseMessagingService
+
+/**
+ * Receives FCM token refreshes and incoming data messages for push notifications.
+ *
+ * Compile-safe skeleton only — [onNewToken] and [onMessageReceived] are wired up in Task C4
+ * (token registration + decode → enrich → notify rendering pipeline).
+ */
+class ListenUpMessagingService : FirebaseMessagingService()

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/ListenUpMessagingService.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/ListenUpMessagingService.kt
@@ -1,11 +1,52 @@
 package com.calypsan.listenup.client.push
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.push.PushPayload
+import com.calypsan.listenup.client.data.push.PushRegistrar
 import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.runBlocking
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 /**
  * Receives FCM token refreshes and incoming data messages for push notifications.
  *
- * Compile-safe skeleton only — [onNewToken] and [onMessageReceived] are wired up in Task C4
- * (token registration + decode → enrich → notify rendering pipeline).
+ * [onMessageReceived] and [onNewToken] both bridge into suspend functions with [runBlocking].
+ * This is acceptable here — unlike the ban on `runBlocking` in the rest of the production
+ * codebase — because both callbacks already run on FCM's own background executor (never the
+ * main thread) and are budgeted by the platform for roughly 10 seconds of synchronous work; there
+ * is no UI thread to block and no caller expecting a faster return. This is the same "bridge a
+ * synchronous platform callback into a suspend call" idiom as
+ * [com.calypsan.listenup.client.playback.AudioTokenAuthenticator].
  */
-class ListenUpMessagingService : FirebaseMessagingService()
+class ListenUpMessagingService :
+    FirebaseMessagingService(),
+    KoinComponent {
+    private val renderer: PushNotificationRenderer by inject()
+    private val registrar: PushRegistrar by inject()
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        // Foreground suppression: the in-app SSE-fed surface already shows live events, so a
+        // foregrounded app skips the local notification entirely.
+        val foreground =
+            ProcessLifecycleOwner
+                .get()
+                .lifecycle.currentState
+                .isAtLeast(Lifecycle.State.STARTED)
+        if (foreground) return
+
+        val payload =
+            message.data["payload"]?.let { raw ->
+                runCatching { contractJson.decodeFromString(PushPayload.serializer(), raw) }.getOrNull()
+            } // null (absent OR unknown discriminator) → generic notification, never a crash
+
+        runBlocking { renderer.render(payload) }
+    }
+
+    override fun onNewToken(token: String) {
+        runBlocking { registrar.onTokenRotated(token) }
+    }
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/PushNotificationRenderer.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/push/PushNotificationRenderer.kt
@@ -1,0 +1,121 @@
+package com.calypsan.listenup.client.push
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.calypsan.listenup.api.push.PushPayload
+import com.calypsan.listenup.client.MainActivity
+import com.calypsan.listenup.client.notifications.NotificationChannels
+import listenup.composeapp.generated.resources.Res
+import listenup.composeapp.generated.resources.push_campfire_invite_body
+import listenup.composeapp.generated.resources.push_campfire_invite_title
+import listenup.composeapp.generated.resources.push_campfire_invite_title_unknown
+import listenup.composeapp.generated.resources.push_generic_body
+import listenup.composeapp.generated.resources.push_generic_title
+import listenup.composeapp.generated.resources.push_test_body
+import listenup.composeapp.generated.resources.push_test_title
+import org.jetbrains.compose.resources.getString
+
+private const val RES_TYPE_DRAWABLE = "drawable"
+private const val EXTRA_PUSH_TYPE = "push_type"
+
+/** Title + body of a rendered local notification, pre-enrichment. */
+private data class NotificationContent(
+    val title: String,
+    val body: String,
+)
+
+/**
+ * Decodes a [PushPayload] into an enriched, localized local notification and posts it on the
+ * [NotificationChannels.SOCIAL] channel.
+ *
+ * Push payloads carry IDs only (never names or titles — see [PushPayload]'s KDoc), so enrichment
+ * resolves display data locally: [bookTitleLookup] and [inviterNameLookup] are best-effort suspend
+ * lookups wired at the DI site to the client's own repositories (local Room first, the
+ * repository's own server fallback second). Both lookups are `runCatching`-wrapped here — any
+ * failure degrades to the generic/unknown-inviter copy rather than losing the notification.
+ */
+class PushNotificationRenderer(
+    private val context: Context,
+    private val bookTitleLookup: suspend (String) -> String?,
+    private val inviterNameLookup: suspend (String) -> String?,
+) {
+    private val smallIcon: Int by lazy {
+        context.resources
+            .getIdentifier("ic_notification", RES_TYPE_DRAWABLE, context.packageName)
+            .takeIf { it != 0 }
+            ?: android.R.drawable.ic_dialog_info
+    }
+
+    /** Decodes, enriches, and posts a local notification for [payload]. `null` renders generic copy. */
+    suspend fun render(payload: PushPayload?) {
+        val content =
+            when (payload) {
+                is PushPayload.TestNotification -> {
+                    NotificationContent(
+                        title = getString(Res.string.push_test_title),
+                        body = getString(Res.string.push_test_body),
+                    )
+                }
+
+                is PushPayload.CampfireInvite -> {
+                    val inviter = runCatching { inviterNameLookup(payload.inviterUserId) }.getOrNull()
+                    val book = runCatching { bookTitleLookup(payload.bookId) }.getOrNull()
+                    NotificationContent(
+                        title =
+                            inviter?.let { getString(Res.string.push_campfire_invite_title, it) }
+                                ?: getString(Res.string.push_campfire_invite_title_unknown),
+                        body = book?.let { getString(Res.string.push_campfire_invite_body, it) } ?: "",
+                    )
+                }
+
+                null -> {
+                    NotificationContent(
+                        title = getString(Res.string.push_generic_title),
+                        body = getString(Res.string.push_generic_body),
+                    )
+                }
+            }
+
+        val tapIntent =
+            PendingIntent.getActivity(
+                context,
+                payload.hashCode(),
+                Intent(context, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    payload?.let { putExtra(EXTRA_PUSH_TYPE, it::class.simpleName) }
+                    // Campfire deep-link target lands with the Campfire arc; the single seam
+                    // for per-type actions/routing is actionsFor() + this intent.
+                },
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+
+        val notification =
+            NotificationCompat
+                .Builder(context, NotificationChannels.SOCIAL)
+                .setSmallIcon(smallIcon)
+                .setContentTitle(content.title)
+                .setContentText(content.body)
+                .setAutoCancel(true)
+                .setContentIntent(tapIntent)
+                .apply { actionsFor(payload).forEach(::addAction) }
+                .build()
+
+        // POST_NOTIFICATIONS may be denied (Android 13+): notify() is then a silent no-op — acceptable,
+        // the in-app SSE-fed surface still carries the same event.
+        NotificationManagerCompat.from(context).notify(notificationId(payload), notification)
+    }
+
+    /**
+     * THE per-type action seam. v1 always returns an empty list — no notification carries action
+     * buttons yet. The Campfire arc adds a "Join" action (deep-link); registration approvals add
+     * "Approve"/"Deny" (background API calls via WorkManager). New actions are added here, not
+     * scattered across call sites — [ignored] is the future dispatch key.
+     */
+    private fun actionsFor(ignored: PushPayload?): List<NotificationCompat.Action> = emptyList()
+
+    private fun notificationId(payload: PushPayload?): Int =
+        if (payload is PushPayload.CampfireInvite) payload.campfireId.hashCode() else payload.hashCode()
+}

--- a/sharedUI/src/commonMain/composeResources/files/aboutlibraries.json
+++ b/sharedUI/src/commonMain/composeResources/files/aboutlibraries.json
@@ -1118,6 +1118,181 @@
             ]
         },
         {
+            "uniqueId": "androidx.datastore:datastore-android",
+            "artifactVersion": "1.1.7",
+            "name": "DataStore",
+            "description": "Android DataStore - contains the underlying store used by each serialization method along with components that require an Android dependency",
+            "website": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            },
+            "scm": {
+                "connection": "scm:git:https://android.googlesource.com/platform/frameworks/support",
+                "url": "https://cs.android.com/androidx/platform/frameworks/support"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "androidx.datastore:datastore-core-android",
+            "artifactVersion": "1.1.7",
+            "name": "DataStore Core",
+            "description": "Android DataStore Core - contains the underlying store used by each serialization method",
+            "website": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            },
+            "scm": {
+                "connection": "scm:git:https://android.googlesource.com/platform/frameworks/support",
+                "url": "https://cs.android.com/androidx/platform/frameworks/support"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "androidx.datastore:datastore-core-okio-jvm",
+            "artifactVersion": "1.1.7",
+            "name": "DataStore Core Okio",
+            "description": "Android DataStore Core Okio- contains APIs to use datastore-core in multiplatform via okio",
+            "website": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            },
+            "scm": {
+                "connection": "scm:git:https://android.googlesource.com/platform/frameworks/support",
+                "url": "https://cs.android.com/androidx/platform/frameworks/support"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "androidx.datastore:datastore-preferences-android",
+            "artifactVersion": "1.1.7",
+            "name": "Preferences DataStore",
+            "description": "Android Preferences DataStore",
+            "website": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            },
+            "scm": {
+                "connection": "scm:git:https://android.googlesource.com/platform/frameworks/support",
+                "url": "https://cs.android.com/androidx/platform/frameworks/support"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "androidx.datastore:datastore-preferences-core-android",
+            "artifactVersion": "1.1.7",
+            "name": "Preferences DataStore Core",
+            "description": "Android Preferences DataStore without the Android Dependencies",
+            "website": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            },
+            "scm": {
+                "connection": "scm:git:https://android.googlesource.com/platform/frameworks/support",
+                "url": "https://cs.android.com/androidx/platform/frameworks/support"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "androidx.datastore:datastore-preferences-external-protobuf",
+            "artifactVersion": "1.1.7",
+            "name": "Preferences External Protobuf",
+            "description": "Repackaged proto-lite dependency for use by datastore preferences",
+            "website": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            },
+            "scm": {
+                "connection": "scm:git:https://android.googlesource.com/platform/frameworks/support",
+                "url": "https://cs.android.com/androidx/platform/frameworks/support"
+            },
+            "licenses": [
+                "BSD-3-Clause"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "androidx.datastore:datastore-preferences-proto",
+            "artifactVersion": "1.1.7",
+            "name": "Preferences DataStore Proto",
+            "description": "Jarjar the generated proto for use by datastore-preferences.",
+            "website": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            },
+            "scm": {
+                "connection": "scm:git:https://android.googlesource.com/platform/frameworks/support",
+                "url": "https://cs.android.com/androidx/platform/frameworks/support"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
             "uniqueId": "androidx.documentfile:documentfile",
             "artifactVersion": "1.0.0",
             "name": "Support Document File",
@@ -2958,12 +3133,16 @@
         },
         {
             "uniqueId": "com.google.android.datatransport:transport-backend-cct",
-            "artifactVersion": "3.1.3",
-            "name": "transport-backend-cct",
+            "artifactVersion": "3.1.9",
+            "name": "com.google.android.datatransport:transport-backend-cct",
             "description": "",
             "developers": [
                 
             ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
             "licenses": [
                 "Apache-2.0"
             ],
@@ -2973,12 +3152,16 @@
         },
         {
             "uniqueId": "com.google.android.datatransport:transport-runtime",
-            "artifactVersion": "3.1.3",
-            "name": "transport-runtime",
+            "artifactVersion": "3.1.9",
+            "name": "com.google.android.datatransport:transport-runtime",
             "description": "",
             "developers": [
                 
             ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
             "licenses": [
                 "Apache-2.0"
             ],
@@ -3003,7 +3186,7 @@
         },
         {
             "uniqueId": "com.google.android.gms:play-services-basement",
-            "artifactVersion": "18.5.0",
+            "artifactVersion": "18.8.0",
             "name": "play-services-basement",
             "description": "",
             "developers": [
@@ -3047,6 +3230,21 @@
             ]
         },
         {
+            "uniqueId": "com.google.android.gms:play-services-cloud-messaging",
+            "artifactVersion": "17.4.0",
+            "name": "play-services-cloud-messaging",
+            "description": "",
+            "developers": [
+                
+            ],
+            "licenses": [
+                "ASDKL"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
             "uniqueId": "com.google.android.gms:play-services-flags",
             "artifactVersion": "18.1.0",
             "name": "play-services-flags",
@@ -3062,8 +3260,23 @@
             ]
         },
         {
+            "uniqueId": "com.google.android.gms:play-services-stats",
+            "artifactVersion": "17.0.2",
+            "name": "play-services-stats",
+            "description": "",
+            "developers": [
+                
+            ],
+            "licenses": [
+                "ASDKL"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
             "uniqueId": "com.google.android.gms:play-services-tasks",
-            "artifactVersion": "18.2.0",
+            "artifactVersion": "18.4.0",
             "name": "play-services-tasks",
             "description": "",
             "developers": [
@@ -3071,6 +3284,109 @@
             ],
             "licenses": [
                 "ASDKL"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.errorprone:error_prone_annotations",
+            "artifactVersion": "2.26.0",
+            "name": "error-prone annotations",
+            "description": "Error Prone is a static analysis tool for Java that catches common programming mistakes at compile-time.",
+            "website": "https://errorprone.info/error_prone_annotations",
+            "developers": [
+                {
+                    "name": "Eddie Aftandilian"
+                }
+            ],
+            "organization": {
+                "name": "Google LLC",
+                "url": "http://www.google.com"
+            },
+            "scm": {
+                "connection": "scm:git:https://github.com/google/error-prone.git/error_prone_annotations",
+                "developerConnection": "scm:git:git@github.com:google/error-prone.git/error_prone_annotations",
+                "url": "https://github.com/google/error-prone/error_prone_annotations"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-annotations",
+            "artifactVersion": "17.0.0",
+            "name": "com.google.firebase:firebase-annotations",
+            "description": "",
+            "developers": [
+                
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-common",
+            "artifactVersion": "22.0.1",
+            "name": "com.google.firebase:firebase-common",
+            "description": "",
+            "developers": [
+                
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-components",
+            "artifactVersion": "19.0.0",
+            "name": "com.google.firebase:firebase-components",
+            "description": "",
+            "developers": [
+                
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-datatransport",
+            "artifactVersion": "18.2.0",
+            "name": "com.google.firebase:firebase-datatransport",
+            "description": "",
+            "developers": [
+                
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
+            "licenses": [
+                "Apache-2.0"
             ],
             "funding": [
                 
@@ -3114,6 +3430,93 @@
             "developers": [
                 
             ],
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-iid-interop",
+            "artifactVersion": "17.1.0",
+            "name": "firebase-iid-interop",
+            "description": "",
+            "developers": [
+                
+            ],
+            "licenses": [
+                "ASDKL"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-installations",
+            "artifactVersion": "19.1.1",
+            "name": "com.google.firebase:firebase-installations",
+            "description": "",
+            "developers": [
+                
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-installations-interop",
+            "artifactVersion": "17.3.0",
+            "name": "com.google.firebase:firebase-installations-interop",
+            "description": "",
+            "developers": [
+                
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-measurement-connector",
+            "artifactVersion": "19.0.0",
+            "name": "firebase-measurement-connector",
+            "description": "",
+            "developers": [
+                
+            ],
+            "licenses": [
+                "ASDKL"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.google.firebase:firebase-messaging",
+            "artifactVersion": "25.1.1",
+            "name": "com.google.firebase:firebase-messaging",
+            "description": "",
+            "developers": [
+                
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/firebase/firebase-android-sdk.git",
+                "url": "https://github.com/firebase/firebase-android-sdk"
+            },
             "licenses": [
                 "Apache-2.0"
             ],
@@ -5393,6 +5796,30 @@
             ]
         },
         {
+            "uniqueId": "org.jetbrains.kotlin:kotlin-android-extensions-runtime",
+            "artifactVersion": "1.9.22",
+            "name": "Kotlin Android Extensions Runtime",
+            "description": "Kotlin Android Extensions Runtime",
+            "website": "https://kotlinlang.org/",
+            "developers": [
+                {
+                    "name": "Kotlin Team",
+                    "organisationUrl": "https://www.jetbrains.com"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/JetBrains/kotlin.git",
+                "developerConnection": "scm:git:https://github.com/JetBrains/kotlin.git",
+                "url": "https://github.com/JetBrains/kotlin"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
             "uniqueId": "org.jetbrains.kotlin:kotlin-bom",
             "artifactVersion": "1.8.0",
             "name": "Kotlin Libraries bill-of-materials",
@@ -5401,6 +5828,30 @@
             "developers": [
                 {
                     "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/JetBrains/kotlin.git",
+                "developerConnection": "scm:git:https://github.com/JetBrains/kotlin.git",
+                "url": "https://github.com/JetBrains/kotlin"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "org.jetbrains.kotlin:kotlin-parcelize-runtime",
+            "artifactVersion": "1.9.22",
+            "name": "Parcelize Runtime",
+            "description": "Runtime library for the Parcelize compiler plugin",
+            "website": "https://kotlinlang.org/",
+            "developers": [
+                {
+                    "name": "Kotlin Team",
                     "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
@@ -5650,6 +6101,28 @@
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
             "artifactVersion": "1.11.0",
             "name": "kotlinx-coroutines-core",
+            "description": "Coroutines support libraries for Kotlin",
+            "website": "https://github.com/Kotlin/kotlinx.coroutines",
+            "developers": [
+                {
+                    "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
+                }
+            ],
+            "scm": {
+                "url": "https://github.com/Kotlin/kotlinx.coroutines"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "org.jetbrains.kotlinx:kotlinx-coroutines-play-services",
+            "artifactVersion": "1.11.0",
+            "name": "kotlinx-coroutines-play-services",
             "description": "Coroutines support libraries for Kotlin",
             "website": "https://github.com/Kotlin/kotlinx.coroutines",
             "developers": [
@@ -6482,6 +6955,14 @@
             "internalHash": "Apache-2.0",
             "spdxId": "Apache-2.0",
             "hash": "Apache-2.0"
+        },
+        "BSD-3-Clause": {
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html",
+            "content": "Copyright (c) <<var;name=copyright;original= <year> <owner>;match=.+>>. All rights reserved. \n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \n\n3. Neither the name of <<var;name=organizationClause3;original=the copyright holder;match=.+>> nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY <<var;name=copyrightHolderAsIs;original=THE COPYRIGHT HOLDERS AND CONTRIBUTORS;match=.+>> \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <<var;name=copyrightHolderLiability;original=THE COPYRIGHT HOLDER OR CONTRIBUTORS;match=.+>> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ",
+            "internalHash": "BSD-3-Clause",
+            "spdxId": "BSD-3-Clause",
+            "hash": "BSD-3-Clause"
         },
         "MIT": {
             "name": "MIT License",

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -1307,8 +1307,6 @@ One beautiful library.</string>
     <string name="settings_open_source_licenses">Open Source Licenses</string>
     <string name="settings_playback">Playback</string>
     <string name="settings_rewind_a_few_seconds_when">Rewind a few seconds when resuming playback</string>
-    <string name="settings_send_test_notification">Send test notification</string>
-    <string name="settings_send_test_notification_subtitle">Arrives when the app is in the background.</string>
     <string name="settings_server_version">Server version</string>
     <string name="settings_shake_to_reset_timer">Shake to Reset Timer</string>
     <string name="settings_sign_out_confirm_title">Sign Out</string>

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -1202,6 +1202,13 @@ One beautiful library.</string>
     <string name="profile_tagline_description">A short bio that appears on your profile</string>
     <string name="profile_tagline_placeholder">What are you listening to?</string>
     <string name="profile_upload_photo">Upload Photo</string>
+    <string name="push_campfire_invite_body">%1$s</string>
+    <string name="push_campfire_invite_title">%1$s invited you to listen together</string>
+    <string name="push_campfire_invite_title_unknown">You have an invite to listen together</string>
+    <string name="push_generic_body">Something happened on your server.</string>
+    <string name="push_generic_title">ListenUp</string>
+    <string name="push_test_body">Push notifications are working.</string>
+    <string name="push_test_title">Test notification</string>
     <string name="scan_building_subtitle">Building your library.</string>
     <string name="scan_files_total">/ %1$d files</string>
     <string name="scan_recently_matched">Recently matched</string>

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/settings/SettingsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/settings/SettingsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
-import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PersonOutline
 import androidx.compose.material.icons.filled.PlayCircle
@@ -98,8 +97,6 @@ import listenup.composeapp.generated.resources.settings_ignore_articles_when_sor
 import listenup.composeapp.generated.resources.settings_manage_storage
 import listenup.composeapp.generated.resources.settings_open_source_licenses
 import listenup.composeapp.generated.resources.settings_rewind_a_few_seconds_when
-import listenup.composeapp.generated.resources.settings_send_test_notification
-import listenup.composeapp.generated.resources.settings_send_test_notification_subtitle
 import listenup.composeapp.generated.resources.settings_server_version
 import listenup.composeapp.generated.resources.settings_skip_backward
 import listenup.composeapp.generated.resources.settings_skip_forward
@@ -284,7 +281,6 @@ fun SettingsScreen(
                     state = state,
                     onNavigateToDevices = onNavigateToDevices,
                     onSignOutClick = { showSignOutDialog = true },
-                    onSendTestNotificationClick = viewModel::sendTestNotification,
                 )
 
                 if (onNavigateToStorage != null) {
@@ -463,7 +459,6 @@ private fun AccountSection(
     state: SettingsUiState,
     onNavigateToDevices: (() -> Unit)?,
     onSignOutClick: () -> Unit,
-    onSendTestNotificationClick: () -> Unit,
 ) {
     val accent = MaterialTheme.colorScheme.primary
     SectionGroup(
@@ -488,18 +483,6 @@ private fun AccountSection(
                 subtitle = stringResource(Res.string.devices_manage_active_sessions),
                 onClick = onNavigateToDevices,
                 showDivider = hasServerRow,
-            )
-        }
-        // Server advertises push (admin toggle AND relay configured) — the arriving notification
-        // is the only feedback, so this row carries no result state of its own.
-        if (state.pushEnabled) {
-            SettingRow(
-                icon = Icons.Default.Notifications,
-                accent = accent,
-                title = stringResource(Res.string.settings_send_test_notification),
-                subtitle = stringResource(Res.string.settings_send_test_notification_subtitle),
-                showDivider = hasServerRow || onNavigateToDevices != null,
-                onClick = onSendTestNotificationClick,
             )
         }
     }


### PR DESCRIPTION
Completes the Android client half of push notifications (#604) — stacks on the merged server bedrock (#1075). Targets `next` per the release-train plan.

## What's here

- **C1 — Firebase wiring**: google-services 4.5.0, firebase-messaging 25.1.1, lifecycle-process 2.11.0 (all resolved live against Google's Maven); `google-services.json` committed (not a secret); manifest service declaration + license inventory regen.
- **C3 — `PushRegistrar` + token lifecycle**: post-auth registration, FCM rotation re-registration, and toggle-change re-registration via the `refetchServerInfo` hook (admin toggle flips → ServerInfoChanged → refetch → re-register). Never unregisters on disable by design — the server stops sending and the token dies with the session. `FcmTokenProvider` wraps the FCM Task API; desktop/de-googled devices get a null provider and stay SSE-only (Never Stranded).
- **C4 — receive path**: `listenup_social` notification channel (IMPORTANCE_HIGH); `PushNotificationRenderer` decodes the IDs-only payload and enriches locally (book title via `BookRepository`, inviter name via `UserProfileRepository`, Room-first, generic-text floor); foreground suppression via ProcessLifecycleOwner (in-app SSE surface already shows live events); `actionsFor()` action seam empty in v1 (Campfire adds Join; approvals add Approve/Deny).

## Notes for review

- `runBlocking` in `ListenUpMessagingService` is intentional (FMS background executor, ~10s budget) — KDoc'd, follows the `AudioTokenAuthenticator` precedent.
- One new string reworded to dodge the pre-existing app-wide apostrophe-escaping bug (#1079).
- Relay is deployed with the FCM service-account secret; `/healthz` green. Custom domain `push.listenup.audio` attach pending.
- Device E2E (register → test notification → toggle-off PUSH_DISABLED) still to run on hardware — will report results here.

Gates at HEAD (post-rebase onto next): `verifyLocal` + `:androidApp:assembleDebug` BUILD SUCCESSFUL; server untouched by these commits.