### PR TITLE
✅ test(iosApp): fix flaky freshLoadEntersBufferingThenPlaying (deterministic pumpUntil) — #1077

### DIFF
--- a/iosApp/ListenUpTests/PlayerCoordinatorTests.swift
+++ b/iosApp/ListenUpTests/PlayerCoordinatorTests.swift
@@ -32,6 +32,24 @@ func awaitUntil(
     }
 }
 
+/// Deterministically advance the main actor until `condition` holds (or `maxHops` is reached), by
+/// yielding cooperatively instead of sleeping on the wall clock. The player's state transitions are
+/// all delivered on the main actor — the `play(bookId:)` prepare task and the `FlowBridge`
+/// engine-event collector — so pumping the actor drives them with **no real-time dependency**.
+///
+/// Prefer this over `awaitUntil` for waits on main-actor-delivered coordinator state: under a
+/// starved CI executor `awaitUntil`'s real-time poll can miss its window and hang to a 25s kill
+/// (issue #1077), whereas this returns as soon as the work drains — and if the transition never
+/// happens it fails fast (the caller's `#expect`) instead of hanging.
+@MainActor
+func pumpUntil(maxHops: Int = 5000, _ condition: () -> Bool) async {
+    var hops = 0
+    while !condition(), hops < maxHops {
+        await Task.yield()
+        hops += 1
+    }
+}
+
 @Suite("ChapterMath")
 struct PlayerCoordinatorTests {
     private func chapter(_ id: String, start: Int64, duration: Int64) -> Chapter {

--- a/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
+++ b/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
@@ -109,7 +109,7 @@ struct PlayerSwitchPathTests {
         #expect(!coordinator.isPlaying)
 
         engine.emit(.statusChanged(.ready))   // the first real "playing" event
-        await awaitUntil { coordinator.isPlaying }
+        await pumpUntil { coordinator.isPlaying }
         #expect(coordinator.isPlaying)
         #expect(!coordinator.isBuffering)
     }
@@ -141,7 +141,7 @@ struct PlayerSwitchPathTests {
         let (coordinator, engine, _) = makeCoordinator()
         await engine.setLoadShouldFail(true)
         coordinator.play(bookId: "book1")
-        await awaitUntil { if case .error = coordinator.phase { return true }; return false }
+        await pumpUntil { if case .error = coordinator.phase { return true }; return false }
 
         #expect(coordinator.isVisible)
         #expect(coordinator.isErrored)
@@ -154,7 +154,7 @@ struct PlayerSwitchPathTests {
         let (coordinator, engine, _) = makeCoordinator()
         await engine.setLoadShouldFail(true)
         coordinator.play(bookId: "book1")
-        await awaitUntil { if case .error = coordinator.phase { return true }; return false }
+        await pumpUntil { if case .error = coordinator.phase { return true }; return false }
         #expect(coordinator.isVisible)   // errored → still visible (for the inline retry)
 
         coordinator.dismissError()
@@ -173,7 +173,7 @@ struct PlayerSwitchPathTests {
         await engine.setLoadShouldFail(true)
 
         coordinator.play(bookId: "book1")
-        await awaitUntil {
+        await pumpUntil {
             if case .error = coordinator.phase { return true }
             return false
         }
@@ -185,7 +185,7 @@ struct PlayerSwitchPathTests {
         await engine.setLoadShouldFail(false)
         coordinator.togglePlayback()   // retry
         await progress.waitForStarted(bookId: "book1")
-        await awaitUntil { coordinator.isPlaying }
+        await pumpUntil { coordinator.isPlaying }
         #expect(coordinator.isPlaying)
     }
 }


### PR DESCRIPTION
Fixes #1077.

## Why

`PlayerSwitchPathTests/freshLoadEntersBufferingThenPlaying` hung ~25s on a loaded CI simulator clone (no assertion failure recorded — a timeout kill, not a wrong value). The test drives a `buffering→playing` transition by emitting `.ready` and then **polling `coordinator.isPlaying` on a real-time clock** (`awaitUntil`, `Task.sleep(20ms)`). The transition is delivered on the main actor (the `play(bookId:)` prepare task + the `FlowBridge` engine-event collector); under a starved CI executor the real-time poll can miss its window, so the test hangs instead of catching the change.

Could not reproduce locally even under 4× CPU contention (360 runs green), consistent with a rare loaded-VM artifact.

## What

Add a `pumpUntil(_:)` test helper that advances the main actor with cooperative `Task.yield()` until the condition holds (bounded by `maxHops`) — **no wall-clock dependency**. Since the coordinator's state transitions are all main-actor-delivered, pumping the actor drains them deterministically. Swap the five `awaitUntil` waits in `PlayerSwitchPathTests` (all synchronous coordinator-state reads) to `pumpUntil`.

Bonus: if a transition genuinely never happens, the test now fails **fast and clearly** (the caller's `#expect`) instead of hanging to a 25s kill — better CI signal either way.

## Tests

Full iOS suite green (487). Stress: `PlayerSwitchPathTests` ×40 under 4× CPU contention passes in 0.4s (vs 1.0s with the real-time poll) — deterministic and faster.
