### PR TITLE
♻️ refactor(shared): route Genre RPC through bounded callResult + drift ratchet

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/GenreRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/GenreRpcFactory.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.api.GenreService
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import kotlinx.rpc.krpc.ktor.client.rpc
 import kotlinx.rpc.withService
@@ -17,8 +18,13 @@ import kotlinx.rpc.withService
  * [KtorGenreRpcFactory] is the production implementation over WebSocket RPC.
  */
 internal interface GenreRpcFactory {
-    /** Returns the cached [GenreService] proxy, connecting on first use. */
-    suspend fun genreService(): GenreService
+    /**
+     * Dispatch [block] against the cached [GenreService] through the bounded, self-healing
+     * [RpcProxyCache.rpcCall] engine: transport deaths heal invisibly (one bounded reconnect +
+     * retry), a surviving fault surfaces as a typed [AppResult.Failure], and a business failure
+     * returned by the service passes through untouched.
+     */
+    suspend fun <T> callResult(block: suspend (GenreService) -> AppResult<T>): AppResult<T>
 
     /** Drop the cached proxy and the RPC-flavored HttpClient. */
     suspend fun invalidate()
@@ -39,7 +45,8 @@ internal class KtorGenreRpcFactory(
             client.rpc("$baseUrl/api/rpc/authed").withService<GenreService>()
         }
 
-    override suspend fun genreService(): GenreService = cache.get()
+    override suspend fun <T> callResult(block: suspend (GenreService) -> AppResult<T>): AppResult<T> =
+        cache.rpcCall(block = block)
 
     override suspend fun invalidate() = cache.invalidate()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/GenreRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/GenreRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.api.dto.GenreUpdate
-import com.calypsan.listenup.api.result.AppResult as WireAppResult
 import com.calypsan.listenup.client.data.local.db.GenreDao
 import com.calypsan.listenup.client.data.local.db.GenreEntity
 import com.calypsan.listenup.client.data.local.db.GenreWithBookCount
@@ -11,13 +10,8 @@ import com.calypsan.listenup.client.domain.repository.GenreRepository
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.GenreId
-import com.calypsan.listenup.client.core.error.ErrorMapper
-import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-
-private val logger = KotlinLogging.logger {}
 
 /**
  * Genre repository — Room-backed reads, RPC-dispatched mutations.
@@ -64,53 +58,30 @@ internal class GenreRepositoryImpl(
         name: String,
         parentId: GenreId?,
         sortOrder: Int,
-    ): AppResult<GenreId> = rpcCall { rpcFactory.genreService().createGenre(parentId, name, sortOrder) }
+    ): AppResult<GenreId> = rpcFactory.callResult { it.createGenre(parentId, name, sortOrder) }
 
     override suspend fun updateGenre(
         id: GenreId,
         patch: GenreUpdate,
-    ): AppResult<Unit> = rpcCallUnit { rpcFactory.genreService().updateGenre(id, patch) }
+    ): AppResult<Unit> = rpcFactory.callResult { it.updateGenre(id, patch) }
 
-    override suspend fun deleteGenre(id: GenreId): AppResult<Unit> =
-        rpcCallUnit { rpcFactory.genreService().deleteGenre(id) }
+    override suspend fun deleteGenre(id: GenreId): AppResult<Unit> = rpcFactory.callResult { it.deleteGenre(id) }
 
     override suspend fun moveGenre(
         id: GenreId,
         newParentId: GenreId?,
-    ): AppResult<Unit> = rpcCallUnit { rpcFactory.genreService().moveGenre(id, newParentId) }
+    ): AppResult<Unit> = rpcFactory.callResult { it.moveGenre(id, newParentId) }
 
     override suspend fun mergeGenres(
         source: GenreId,
         target: GenreId,
-    ): AppResult<Unit> = rpcCallUnit { rpcFactory.genreService().mergeGenres(source, target) }
+    ): AppResult<Unit> = rpcFactory.callResult { it.mergeGenres(source, target) }
 
     override suspend fun browseBooks(
         genreId: GenreId,
         includeDescendants: Boolean,
         limit: Int,
-    ): AppResult<List<BookId>> = rpcCall { rpcFactory.genreService().browseBooks(genreId, includeDescendants, limit) }
-
-    // ── Plumbing ─────────────────────────────────────────────────────────────
-
-    /**
-     * Run an RPC call that returns a value, converting [WireAppResult] →
-     * [AppResult]. Re-throws [CancellationException]; all other throwables
-     * become [AppResult.Failure] via [ErrorMapper].
-     */
-    private suspend fun <T> rpcCall(block: suspend () -> WireAppResult<T>): AppResult<T> =
-        try {
-            when (val result = block()) {
-                is WireAppResult.Success -> AppResult.Success(result.data)
-                is WireAppResult.Failure -> AppResult.Failure(result.error)
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            logger.warn(e) { "Genre RPC failed" }
-            AppResult.Failure(ErrorMapper.map(e))
-        }
-
-    private suspend fun rpcCallUnit(block: suspend () -> WireAppResult<Unit>): AppResult<Unit> = rpcCall(block)
+    ): AppResult<List<BookId>> = rpcFactory.callResult { it.browseBooks(genreId, includeDescendants, limit) }
 }
 
 private fun GenreEntity.toDomain(bookCount: Int): Genre =

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/GenreRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/GenreRepositoryImplTest.kt
@@ -1,0 +1,133 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.GenreService
+import com.calypsan.listenup.api.error.GenreError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.AppResult as WireAppResult
+import com.calypsan.listenup.client.data.local.db.GenreDao
+import com.calypsan.listenup.client.data.remote.GenreRpcFactory
+import com.calypsan.listenup.client.data.remote.catchingRpcResult
+import com.calypsan.listenup.api.dto.GenreUpdate
+import com.calypsan.listenup.core.GenreId
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Fake [GenreRpcFactory] routing [callResult] through the REAL boundary [catchingRpcResult],
+ * so repository tests exercise the same throw→Failure / business-Failure-passthrough semantics the
+ * production [com.calypsan.listenup.client.data.remote.RpcProxyCache] engine provides — without a
+ * live socket. Mirrors `FakeCollectionRpcFactory` / `FakeShelfRpcFactory`.
+ */
+private class FakeGenreRpcFactory(
+    private val service: GenreService,
+) : GenreRpcFactory {
+    override suspend fun <T> callResult(block: suspend (GenreService) -> AppResult<T>): AppResult<T> = catchingRpcResult { block(service) }
+
+    override suspend fun invalidate() {}
+}
+
+/**
+ * Unit tests for [GenreRepositoryImpl] — the curator-mutation surface now routes through the bounded,
+ * self-healing `callResult` boundary instead of a hand-rolled `try/catch`. These pin the three
+ * outcomes of that boundary: a value returns, a business `AppResult.Failure` passes straight through,
+ * and a thrown transport fault becomes a typed `AppResult.Failure`.
+ */
+class GenreRepositoryImplTest :
+    FunSpec({
+
+        fun repo(
+            dao: GenreDao = mock(MockMode.autofill),
+            service: GenreService = mock(),
+        ): GenreRepositoryImpl = GenreRepositoryImpl(dao = dao, rpcFactory = FakeGenreRpcFactory(service))
+
+        test("createGenre dispatches to the service and returns the new id") {
+            runTest {
+                val service = mock<GenreService>()
+                everySuspend { service.createGenre(null, "Sci-Fi", 0) } returns
+                    WireAppResult.Success(GenreId("g-new"))
+
+                val result = repo(service = service).createGenre(name = "Sci-Fi", parentId = null, sortOrder = 0)
+
+                val success = result.shouldBeInstanceOf<AppResult.Success<GenreId>>()
+                success.data shouldBe GenreId("g-new")
+            }
+        }
+
+        test("createGenre propagates a business failure straight through (no reconnect)") {
+            runTest {
+                val service = mock<GenreService>()
+                everySuspend { service.createGenre(null, "Dup", 0) } returns
+                    WireAppResult.Failure(GenreError.SlugConflict())
+
+                val result = repo(service = service).createGenre(name = "Dup", parentId = null, sortOrder = 0)
+
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<GenreError.SlugConflict>()
+            }
+        }
+
+        test("createGenre maps a thrown transport fault to a typed AppResult.Failure") {
+            runTest {
+                val service = mock<GenreService>()
+                everySuspend { service.createGenre(null, "Boom", 0) } throws RuntimeException("socket died")
+
+                val result = repo(service = service).createGenre(name = "Boom", parentId = null, sortOrder = 0)
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+            }
+        }
+
+        test("deleteGenre dispatches to the service") {
+            runTest {
+                val service = mock<GenreService>()
+                everySuspend { service.deleteGenre(GenreId("g1")) } returns WireAppResult.Success(Unit)
+
+                repo(service = service).deleteGenre(GenreId("g1")).shouldBeInstanceOf<AppResult.Success<*>>()
+
+                verifySuspend(VerifyMode.exactly(1)) { service.deleteGenre(GenreId("g1")) }
+            }
+        }
+
+        test("updateGenre dispatches the patch to the service") {
+            runTest {
+                val service = mock<GenreService>()
+                val patch = GenreUpdate(name = "Renamed")
+                everySuspend { service.updateGenre(GenreId("g1"), patch) } returns WireAppResult.Success(Unit)
+
+                repo(service = service).updateGenre(GenreId("g1"), patch).shouldBeInstanceOf<AppResult.Success<*>>()
+
+                verifySuspend(VerifyMode.exactly(1)) { service.updateGenre(GenreId("g1"), patch) }
+            }
+        }
+
+        test("moveGenre dispatches to the service") {
+            runTest {
+                val service = mock<GenreService>()
+                everySuspend { service.moveGenre(GenreId("g1"), GenreId("g2")) } returns WireAppResult.Success(Unit)
+
+                repo(service = service).moveGenre(GenreId("g1"), GenreId("g2")).shouldBeInstanceOf<AppResult.Success<*>>()
+
+                verifySuspend(VerifyMode.exactly(1)) { service.moveGenre(GenreId("g1"), GenreId("g2")) }
+            }
+        }
+
+        test("mergeGenres dispatches to the service") {
+            runTest {
+                val service = mock<GenreService>()
+                everySuspend { service.mergeGenres(GenreId("src"), GenreId("dst")) } returns WireAppResult.Success(Unit)
+
+                repo(service = service).mergeGenres(GenreId("src"), GenreId("dst")).shouldBeInstanceOf<AppResult.Success<*>>()
+
+                verifySuspend(VerifyMode.exactly(1)) { service.mergeGenres(GenreId("src"), GenreId("dst")) }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/RpcCallsRouteThroughCallResultRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/RpcCallsRouteThroughCallResultRule.kt
@@ -1,0 +1,71 @@
+package com.calypsan.listenup.konsist
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Repository RPC calls route through the factory's bounded, self-healing `callResult`
+ * (which delegates to [com.calypsan.listenup.client.data.remote.RpcProxyCache.rpcCall]) — never a
+ * hand-rolled `try/catch` that folds a raw `service.method()` result itself.
+ *
+ * The bounded engine is the whole point of the seam: a transport death heals invisibly (one bounded
+ * reconnect + retry), a surviving fault surfaces as a typed `AppResult.Failure`, a `TransportError.
+ * Timeout` bounds a hung frame, and a lost-response frame becomes an honest timeout rather than a
+ * silent hang. A repository that instead opens the raw proxy (`factory.fooService()`) and wraps it
+ * in its own `when (result) { Success/Failure }` fold gets none of that — it is a "never stranded"
+ * gap hiding behind a green compile.
+ *
+ * **The tell.** Every hand-rolled repo aliases the contract result type as
+ * `import com.calypsan.listenup.api.result.AppResult as WireAppResult` so it can spell out the
+ * `WireAppResult.Success`/`WireAppResult.Failure` fold by hand. Canonical repos
+ * ([com.calypsan.listenup.client.data.repository.ShelfRepositoryImpl],
+ * [com.calypsan.listenup.client.data.repository.CollectionRepositoryImpl], and now
+ * `GenreRepositoryImpl`) carry no such alias — they call `factory.callResult { it.method() }` and
+ * let the boundary fold the outcome. So the alias is a precise, uniform proxy for the drift.
+ *
+ * This rule is a ratchet: it locks the migrated surface and blocks NEW hand-rolled repos. The
+ * [RESIDUAL_HANDROLLED_RPC_ALLOWLIST] holds the repos still awaiting migration — the project is
+ * rewritten in place, so each entry drops off the list the day its `callResult` migration ships
+ * (as `GenreRepositoryImpl` just did). Removing a file from the set is the explicit signal that one
+ * of those re-touches has landed; adding one should never be necessary.
+ */
+class RpcCallsRouteThroughCallResultRule :
+    FunSpec({
+        test("data/repository/*Impl files fold RPC through callResult, not a hand-rolled WireAppResult alias") {
+            val offenders =
+                productionScope()
+                    .files
+                    .filter { it.path.contains("/data/repository/") && it.path.endsWith("Impl.kt") }
+                    .filter { f -> RESIDUAL_HANDROLLED_RPC_ALLOWLIST.none { allowed -> f.path.endsWith(allowed) } }
+                    .filter { file -> file.imports.any { it.alias?.name == "WireAppResult" } }
+                    .map { it.path }
+
+            offenders shouldBe emptyList()
+        }
+    })
+
+/**
+ * Repository impls that still hand-roll the `WireAppResult` fold instead of routing through the
+ * factory's `callResult`. Each migrates when its domain is re-touched; removing a file from this set
+ * is the explicit signal that its migration has shipped. Adding a new entry should never be
+ * necessary — new repos call `factory.callResult { it.method() }` from day one.
+ *
+ * Legitimately-excluded shapes stay here on purpose, not as debt:
+ * - **Long-running RPCs** (`BackupRepositoryImpl`, `ImportRepositoryImpl`) — backup/restore/import
+ *   run far past `callResult`'s 15s bound; they need bespoke timeouts, so they own their fold.
+ * - **`BookRepositoryImpl` / `MetadataRepositoryImpl`** — mixed read/write surfaces whose fold is
+ *   entangled with cover/metadata handling; migrate as a deliberate slice, not a mechanical swap.
+ */
+private val RESIDUAL_HANDROLLED_RPC_ALLOWLIST: Set<String> =
+    setOf(
+        "/data/repository/BackupRepositoryImpl.kt",
+        "/data/repository/BookEditRepositoryImpl.kt",
+        "/data/repository/BookRepositoryImpl.kt",
+        "/data/repository/ContributorEditRepositoryImpl.kt",
+        "/data/repository/ImportRepositoryImpl.kt",
+        "/data/repository/MetadataRepositoryImpl.kt",
+        "/data/repository/MoodRepositoryImpl.kt",
+        "/data/repository/ProfileEditRepositoryImpl.kt",
+        "/data/repository/SeriesEditRepositoryImpl.kt",
+        "/data/repository/TagRepositoryImpl.kt",
+    )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.SeriesService
 import com.calypsan.listenup.api.UserPreferencesService
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.catchingRpcResult
 import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
@@ -1027,14 +1028,17 @@ internal class TestGenreRpcFactory(
     private val mutex = Mutex()
     private var cachedService: GenreService? = null
 
-    override suspend fun genreService(): GenreService =
-        mutex.withLock {
-            cachedService ?: connect().also { cachedService = it }
-        }
+    override suspend fun <T> callResult(block: suspend (GenreService) -> AppResult<T>): AppResult<T> =
+        catchingRpcResult { block(genreService()) }
 
     override suspend fun invalidate() {
         mutex.withLock { cachedService = null }
     }
+
+    private suspend fun genreService(): GenreService =
+        mutex.withLock {
+            cachedService ?: connect().also { cachedService = it }
+        }
 
     private suspend fun connect(): GenreService =
         httpClient


### PR DESCRIPTION
## What

Step 3 of the RPC-call consolidation. Migrates `GenreRepository`'s RPC dispatch off a hand-rolled `try/catch` fold onto the factory's bounded, self-healing `callResult` seam — the same shape `ShelfRepositoryImpl`/`CollectionRepositoryImpl` already use — and adds a Konsist ratchet so no new repo can reintroduce the hand-rolled pattern.

### The drift being eliminated
Divergent repos opened the raw RPC proxy (`factory.genreService()`) and wrapped it in a private `rpcCall`/`rpcCallUnit` helper that spelled out the `when (result) { Success/Failure }` fold by hand. That fold has **no timeout, no single-flight, no self-healing reconnect** — a "never stranded" gap hiding behind a green compile. `callResult` delegates to `RpcProxyCache.rpcCall` (15s bound, single-flight, pre-delivery retry-once, typed-timeout on lost frames).

## Changes
- **`GenreRpcFactory`** — replaced the raw `genreService()` getter with `callResult { }` delegating to `cache.rpcCall`.
- **`GenreRepositoryImpl`** — all 6 curator mutations route through `callResult`; deleted the private `rpcCall`/`rpcCallUnit` fold and its now-dead imports.
- **`TestGenreRpcFactory`** (integration double) — converted to `callResult` through the real `catchingRpcResult` boundary.
- **`GenreRepositoryImplTest`** (new) — pins the three boundary outcomes: value returns, business `AppResult.Failure` passes through, thrown fault → typed `AppResult.Failure`.
- **`RpcCallsRouteThroughCallResultRule`** (new Konsist rule) — bans the `WireAppResult`-alias drift tell in `data/repository/*Impl.kt`, with a documented allowlist of the 10 repos still awaiting migration. A ratchet: each entry drops off the day its migration ships.

## Safety
`RpcProxyCache.call` retries **only on provably pre-delivery failures**, so non-idempotent mutations (`createGenre`, `mergeGenres`) can't double-apply — the documented load-bearing invariant, already shipping for `createCollection`.

## Verification
- TDD: RED (`callResult` overrides nothing) → GREEN.
- `:sharedLogic:jvmTest` full suite green, incl. all genre e2e suites (real in-process server via `callResult`).
- Konsist rule teeth-verified: fires when a drift file is un-allowlisted.
- `spotlessCheck` + `detekt` clean.
- Adversarial review: no shippable bugs.