### PR TITLE
🐛 fix(shared): retry outbox ops that throw a transport fault instead of losing them

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -184,9 +184,11 @@ internal class PendingOperationQueue(
      * are disjoint (`failureCount > maxAttempts` vs `<=`), so GC never races dispatch.
      *
      * A [PendingOperationSender] that throws instead of returning
-     * [AppResult.Failure] is a bug in that sender, not a reason to abort the
-     * wave — the op is flagged terminally failed (past [MAX_RETRYABLE_ATTEMPTS])
-     * and the loop continues to the next op.
+     * [AppResult.Failure] is treated as a transient (retryable) failure — never a
+     * reason to abort the wave, and never an instant dead-letter. A raw-proxy
+     * transport fault escapes as an untyped throwable; terminally quarantining it
+     * on the first throw would permanently lose a queued offline write. The op is
+     * retried (bounded by [MAX_RETRYABLE_ATTEMPTS]) and the loop continues.
      */
     suspend fun drain(): DrainOutcome {
         dao.gcDeadLetters(cutoffMillis = nowMillis() - DEAD_LETTER_RETENTION_MILLIS)
@@ -202,15 +204,24 @@ internal class PendingOperationQueue(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    logger.error(e) { "Sender threw for op ${op.clientOpId} (${op.domainName}); flagging terminal" }
+                    // A thrown sender exception is a TRANSIENT (retryable) failure, never an instant
+                    // terminal dead-letter. A raw-proxy transport fault — a dead RpcClient after the
+                    // self-hosted server restarts, a dropped WebSocket — escapes as an untyped throwable
+                    // that ErrorMapper misclassifies as non-retryable, permanently losing a queued
+                    // position/edit on the first blip (a "never lose the user's position" violation).
+                    // Treating a throw as retryable keeps the op queued to retry once the connection
+                    // heals (the firehose reconnect invalidates the dead proxy); a genuinely buggy sender
+                    // burns the bounded retry budget and then dead-letters — the same bounded-waste
+                    // tradeoff a permanently-corrupt payload already accepts.
+                    logger.warn(e) { "Sender threw for op ${op.clientOpId} (${op.domainName}); retrying as transient" }
                     dao.update(
                         entity.copy(
-                            failureCount = MAX_RETRYABLE_ATTEMPTS + 1,
+                            failureCount = entity.failureCount + 1,
                             lastAttemptAt = nowMillis(),
                             lastError = e::class.simpleName ?: "SenderException",
                         ),
                     )
-                    terminalFailures++
+                    retryableFailures++
                     continue
                 }
             when (result) {

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -208,27 +208,78 @@ class PendingOperationQueueTest :
             }
         }
 
-        test("a sender that throws is flagged terminally failed and the wave continues") {
+        test("a sender that throws a transient transport fault is retried, not terminally dead-lettered") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                // The dead-proxy fault a raw RPC push throws when the self-hosted server restarts —
+                // kotlinx.rpc surfaces it as IllegalStateException("RpcClient was cancelled"), which
+                // ErrorMapper would misclassify non-retryable. The queue must NOT lose the op.
+                val sender = PendingOperationSender { error("RpcClient was cancelled") }
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = sender,
+                        nowMillis = { 1_000L },
+                    )
+                val opId = queue.enqueue(upsertOnlyChannel, "flaky", OpKind.Upsert, "{}", "u1")
+                val outcome = queue.drain()
+                // Treated as a transient (retryable) failure — one attempt burned, op survives.
+                outcome.retryableFailures shouldBe 1
+                outcome.terminalFailures shouldBe 0
+                val stored = db.pendingOperationV2Dao().get(opId)
+                stored?.failureCount shouldBe 1
+                // Still dispatchable — it retries once the connection heals (firehose reconnect drops
+                // the dead proxy), instead of being permanently dead-lettered on the first blip.
+                db.pendingOperationV2Dao().nextDispatchable().map { it.clientOpId } shouldContainExactly listOf(opId)
+                db.close()
+            }
+        }
+
+        test("a sender that throws every wave eventually dead-letters after the bounded retry budget") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val sender = PendingOperationSender { error("persistent sender bug") }
+                var clock = 0L
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = sender,
+                        nowMillis = { clock++ },
+                    )
+                val opId = queue.enqueue(upsertOnlyChannel, "buggy", OpKind.Upsert, "{}", "u1")
+                // Bounded waste: a genuinely broken sender burns MAX_RETRYABLE_ATTEMPTS then quarantines,
+                // the same tradeoff a permanently-corrupt payload already accepts.
+                repeat(MAX_RETRYABLE_ATTEMPTS + 1) { queue.drain() }
+                val stored = db.pendingOperationV2Dao().get(opId)
+                stored shouldNotBe null
+                ((stored?.failureCount ?: 0) > MAX_RETRYABLE_ATTEMPTS) shouldBe true
+                db.pendingOperationV2Dao().nextDispatchable().map { it.clientOpId } shouldContainExactly emptyList()
+                db.close()
+            }
+        }
+
+        test("a sender that throws is retried as transient and the wave continues past it") {
             runTest {
                 val db = createInMemoryTestDatabase()
                 val sent = mutableListOf<String>()
                 val sender =
                     PendingOperationSender { op ->
-                        if (op.entityId == "poison") error("sender blew up")
+                        if (op.entityId == "flaky") error("sender blew up")
                         sent += op.clientOpId
                         AppResult.Success(Unit)
                     }
                 var clock = 0L
                 val queue = PendingOperationQueue(dao = db.pendingOperationV2Dao(), sender = sender, nowMillis = { clock++ })
-                val poison = queue.enqueue(upsertOnlyChannel, "poison", OpKind.Upsert, "{}", "u1")
+                val flaky = queue.enqueue(upsertOnlyChannel, "flaky", OpKind.Upsert, "{}", "u1")
                 val healthy = queue.enqueue(upsertOnlyChannel, "healthy", OpKind.Upsert, "{}", "u1")
                 val outcome = queue.drain()
+                // The throw doesn't abort the wave — the healthy op still sends.
                 sent shouldContainExactly listOf(healthy)
                 outcome.sent shouldBe 1
-                outcome.terminalFailures shouldBe 1
-                val stored = db.pendingOperationV2Dao().get(poison)
-                stored shouldNotBe null
-                ((stored?.failureCount ?: 0) > 5) shouldBe true
+                // …and the thrower is retried, not terminally dead-lettered.
+                outcome.retryableFailures shouldBe 1
+                outcome.terminalFailures shouldBe 0
+                db.pendingOperationV2Dao().get(flaky)?.failureCount shouldBe 1
                 db.close()
             }
         }


### PR DESCRIPTION
## The bug (data loss — verified end-to-end)

An offline write — a **playback position** or a queued book/series/contributor/preferences/profile edit — could be **permanently dropped on the first transient transport fault**, violating "never lose the user's position."

The chain:
1. Every outbox binding dispatches through a **raw kotlinx.rpc proxy** (`ClientSyncModule.kt:118-138`) — no bounded/self-healing engine.
2. `OutboxOpSender.send()` calls `push()` **outside** its try/catch (`OutboxOpSender.kt:37`), so a transport throw propagates.
3. `PendingOperationQueue.drain()` flagged the op **terminal on the first throw** (`failureCount = MAX + 1` — *"never picks it up again"*). The design assumed "a sender that throws is a bug."

But the raw-proxy wiring **does** throw on exactly the transient faults offline sync exists to survive: a dead `RpcClient` after the self-hosted server restarts (`IllegalStateException("RpcClient was cancelled")`), a dropped `WebSocketException`, a connect timeout. First blip → op gone.

### Why the obvious fix is insufficient
Wrapping the push in `catchingRpcResult` alone would **not** fix it: `ErrorMapper` maps the dead-proxy ISE (and a non-401 WS drop) via its `else` branch → `InternalError(isRetryable=false)` → still terminal. Only `RpcProxyCache.call`'s `RpcFailureClassifier` recognizes those as pre-delivery-recoverable — so the durable fix is at the drain.

## The fix

`drain()` now treats a **thrown** sender exception as a **transient (retryable) failure** — `failureCount + 1`, bounded by `MAX_RETRYABLE_ATTEMPTS`, never an instant dead-letter. The op survives to retry once the connection heals (the firehose reconnect invalidates the dead proxy). A genuinely buggy sender burns the bounded budget then dead-letters — the same tradeoff a corrupt payload already accepts.

## Why it's safe
- Drain is **connectivity-gated** (`SyncEngine:836` — `isOnline() && Authenticated`), so no offline budget-burn.
- `runDrain` now schedules a **backoff re-drain** for the transient failure instead of counting it as progress (no tight-loop).
- `CancellationException` is still re-raised (unchanged).
- Strict improvement in every case — the old behavior was 1 attempt then permanent loss.

## Tests (TDD, red→green)
- `a sender that throws a transient transport fault is retried, not terminally dead-lettered` (the fix — was red)
- `a sender that throws every wave eventually dead-letters after the bounded retry budget` (bounded-waste guarantee)
- updated `…retried as transient and the wave continues past it` (the old terminal-behavior test, re-pinned to the new contract)

Full `:sharedLogic:jvmTest` green; spotless + detekt clean.

> Context: first of the Phase-0 correctness fixes from a two-part RPC/transport audit. Root-cause elimination (routing outbox binds through the engine) lands with the `RpcChannel<S>` consolidation; this drain-level fix remains as permanent defense-in-depth.