### PR TITLE
✨ feat(iosApp): connection-health banner — Offline + Update-available on iOS

### DIFF
--- a/iosApp/ListenUp/Core/ConnectionHealthObserver.swift
+++ b/iosApp/ListenUp/Core/ConnectionHealthObserver.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+@preconcurrency import Shared
+
+/// Observes the shared `ConnectionHealthViewModel` and exposes its state as SwiftUI-native state.
+/// Drives the connection-health banner (Offline / Update-available) while the shell is mounted —
+/// the iOS counterpart to the Compose `ConnectionHealthBanner`. `AuthState.sessionLapsed` keeps its
+/// own dedicated banner (`SessionLapsedBanner`, via `AuthStateObserver`); this covers the two states
+/// that occur *while authenticated*: unreachable server and a meaningful client/server version skew.
+///
+/// Mirrors `AuthStateObserver`: bind the KMP flow once, map to a native value enum at the boundary
+/// so SwiftUI never diffs a bridged Kotlin object.
+@Observable
+@MainActor
+final class ConnectionHealthObserver {
+
+    // MARK: - State
+
+    private(set) var kind: ConnectionHealthKind = .hidden
+
+    // MARK: - Dependencies
+
+    private let viewModel: ConnectionHealthViewModel
+    private let bridge = FlowBridge()
+
+    // MARK: - Init
+
+    init(viewModel: ConnectionHealthViewModel = KoinHelper.shared.getConnectionHealthViewModel()) {
+        self.viewModel = viewModel
+        bridge.bind(viewModel.state) { [weak self] ui in
+            self?.apply(ui)
+        }
+    }
+
+    deinit { bridge.cancelAll() }   // cancelAll() is nonisolated-safe; see FlowBridge.
+
+    // MARK: - Actions
+
+    /// Force a fresh reachability check (the Offline banner's Retry action).
+    func retry() { viewModel.retry() }
+
+    /// Dismiss the current Update-available hint — persisted per (client, server) pair.
+    func dismiss() { viewModel.dismiss() }
+
+    // MARK: - Mapping
+
+    private func apply(_ ui: ConnectionHealthUi) {
+        switch onEnum(of: ui) {
+        case .hidden:
+            kind = .hidden
+        case .unreachable:
+            kind = .unreachable
+        case .sessionExpired:
+            kind = .sessionExpired
+        case .outdated(let outdated):
+            kind = .outdated(clientVersion: outdated.clientVersion, serverVersion: outdated.serverVersion)
+        case .unknown:
+            Log.error("Unexpected ConnectionHealthUi case")
+            kind = .hidden
+        }
+    }
+}
+
+/// Flattened connection-health state for SwiftUI `switch` — a native value type off the Kotlin diff path.
+enum ConnectionHealthKind: Equatable {
+    case hidden
+    /// Server unreachable for a sustained window. Local content works; sync auto-heals on reconnect.
+    case unreachable
+    /// Session credentials dead — surfaced by `SessionLapsedBanner` via `AuthStateObserver`, not here.
+    case sessionExpired
+    /// A meaningful client/server version skew. Non-blocking "Update available" hint.
+    case outdated(clientVersion: String, serverVersion: String)
+}

--- a/iosApp/ListenUp/DesignSystem/Components/ConnectionHealthBanner.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/ConnectionHealthBanner.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+/// Non-blocking connection-health banner for the mounted shell: "Offline" (server unreachable,
+/// auto-reconnecting, with a manual Retry) and "Update available" (a meaningful client/server
+/// version skew, with Dismiss). Never modal — browsing and downloaded playback stay fully usable
+/// underneath (Never Stranded). A Liquid-Glass card matching `SessionLapsedBanner`.
+///
+/// `sessionExpired` is intentionally NOT rendered here — it has its own `SessionLapsedBanner` driven
+/// by `AuthStateObserver`, shown in the app root's `.sessionLapsed` branch.
+struct ConnectionHealthBanner: View {
+    let kind: ConnectionHealthKind
+    var onRetry: () -> Void
+    var onDismiss: () -> Void
+
+    /// UI-local dismissal of the Offline banner; resets when the state next changes.
+    @State private var offlineDismissed = false
+
+    var body: some View {
+        switch kind {
+        case .unreachable:
+            if !offlineDismissed {
+                card(
+                    icon: "wifi.slash",
+                    title: Text("shell.offline_title"),
+                    message: Text("shell.offline_body"),
+                    actionLabel: Text("common.retry"),
+                    onAction: onRetry,
+                    onClose: { offlineDismissed = true }
+                )
+            }
+        case .outdated(let clientVersion, let serverVersion):
+            card(
+                icon: "arrow.down.circle",
+                title: Text("shell.update_available_title"),
+                message: Text(updateBody(clientVersion, serverVersion)),
+                actionLabel: Text("common.dismiss"),
+                onAction: onDismiss,
+                onClose: nil
+            )
+        case .hidden, .sessionExpired:
+            EmptyView()
+        }
+    }
+
+    private func updateBody(_ client: String, _ server: String) -> String {
+        String(format: String(localized: "shell.update_available_body"), client, server)
+    }
+
+    @ViewBuilder
+    private func card(
+        icon: String,
+        title: Text,
+        message: Text,
+        actionLabel: Text,
+        onAction: @escaping () -> Void,
+        onClose: (() -> Void)?
+    ) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(Color.listenUpOrange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                title
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                message
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            Button(action: onAction) {
+                actionLabel
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.listenUpOrange)
+                    .frame(minHeight: 44)
+            }
+            .buttonStyle(.plain)
+
+            if let onClose {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.secondary)
+                        .frame(minWidth: 44, minHeight: 44)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "common.dismiss"))
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassControl(in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .padding(.horizontal, 16)
+    }
+}

--- a/iosApp/ListenUp/ListenUpApp.swift
+++ b/iosApp/ListenUp/ListenUpApp.swift
@@ -27,6 +27,7 @@ struct ListenUpApp: App {
 /// Root view — created after `App.init()` so observers resolve Koin safely.
 private struct RootView: View {
     @State private var auth = AuthStateObserver()
+    @State private var connectionHealth = ConnectionHealthObserver()
     @State private var currentUser = CurrentUserObserver()
     @State private var readiness = LibraryReadinessObserver()
     @State private var hapticsSettings = HapticsSettings()
@@ -160,7 +161,17 @@ private struct RootView: View {
                     AuthFlowCoordinator(openRegistration: false)
                 }
         case .authenticated:
+            // Shell mounted and healthy — overlay a non-blocking banner if the server goes
+            // unreachable (Offline + Retry) or a version skew is detected (Update available).
+            // `sessionExpired` never surfaces here; it has the `.sessionLapsed` branch above.
             authenticatedContent
+                .safeAreaInset(edge: .top) {
+                    ConnectionHealthBanner(
+                        kind: connectionHealth.kind,
+                        onRetry: { connectionHealth.retry() },
+                        onDismiss: { connectionHealth.dismiss() }
+                    )
+                }
         }
     }
 

--- a/iosApp/ListenUp/ListenUpApp.swift
+++ b/iosApp/ListenUp/ListenUpApp.swift
@@ -27,7 +27,9 @@ struct ListenUpApp: App {
 /// Root view — created after `App.init()` so observers resolve Koin safely.
 private struct RootView: View {
     @State private var auth = AuthStateObserver()
-    @State private var connectionHealth = ConnectionHealthObserver()
+    /// Resolved lazily on first authentication (see `.authenticated`) — never at launch, so the
+    /// shared ConnectionHealthViewModel graph doesn't touch the keychain before the session exists.
+    @State private var connectionHealth: ConnectionHealthObserver?
     @State private var currentUser = CurrentUserObserver()
     @State private var readiness = LibraryReadinessObserver()
     @State private var hapticsSettings = HapticsSettings()
@@ -161,16 +163,25 @@ private struct RootView: View {
                     AuthFlowCoordinator(openRegistration: false)
                 }
         case .authenticated:
-            // Shell mounted and healthy — overlay a non-blocking banner if the server goes
-            // unreachable (Offline + Retry) or a version skew is detected (Update available).
-            // `sessionExpired` never surfaces here; it has the `.sessionLapsed` branch above.
+            // Overlay a non-blocking banner if the server goes unreachable (Offline + Retry) or a
+            // version skew is detected (Update available). `sessionExpired` never surfaces here — it
+            // has the `.sessionLapsed` branch above. The observer is created lazily on first appear
+            // (not at RootView root), so the shared ConnectionHealthViewModel graph is only resolved
+            // once the user is authenticated.
             authenticatedContent
                 .safeAreaInset(edge: .top) {
-                    ConnectionHealthBanner(
-                        kind: connectionHealth.kind,
-                        onRetry: { connectionHealth.retry() },
-                        onDismiss: { connectionHealth.dismiss() }
-                    )
+                    if let connectionHealth {
+                        ConnectionHealthBanner(
+                            kind: connectionHealth.kind,
+                            onRetry: { connectionHealth.retry() },
+                            onDismiss: { connectionHealth.dismiss() }
+                        )
+                    }
+                }
+                .onAppear {
+                    if connectionHealth == nil {
+                        connectionHealth = ConnectionHealthObserver()
+                    }
                 }
         }
     }

--- a/iosApp/ListenUpTests/ConnectionHealthObserverTests.swift
+++ b/iosApp/ListenUpTests/ConnectionHealthObserverTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import ListenUp
+
+@Suite("ConnectionHealthKind")
+struct ConnectionHealthKindTests {
+    // ConnectionHealthObserver itself needs a live KMP ConnectionHealthViewModel; its construction
+    // and `onEnum` mapping are reviewed against the contract. ConnectionHealthKind — the flattened
+    // enum the banner switches on — is pure and verified here.
+
+    @Test func valuelessCasesAreDistinct() {
+        #expect(ConnectionHealthKind.hidden != .unreachable)
+        #expect(ConnectionHealthKind.unreachable != .sessionExpired)
+        #expect(ConnectionHealthKind.sessionExpired != .hidden)
+    }
+
+    @Test func outdatedCarriesVersionsAndEquatesByValue() {
+        let a = ConnectionHealthKind.outdated(clientVersion: "0.6.0", serverVersion: "0.7.0")
+        let b = ConnectionHealthKind.outdated(clientVersion: "0.6.0", serverVersion: "0.7.0")
+        let differentServer = ConnectionHealthKind.outdated(clientVersion: "0.6.0", serverVersion: "0.8.0")
+
+        #expect(a == b)
+        #expect(a != differentServer)
+        #expect(ConnectionHealthKind.hidden != a)
+
+        guard case let .outdated(client, server) = a else {
+            Issue.record("expected .outdated")
+            return
+        }
+        #expect(client == "0.6.0")
+        #expect(server == "0.7.0")
+    }
+}

--- a/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
+++ b/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.core.configureLogging
 import com.calypsan.listenup.client.data.discovery.AppleDiscoveryService
 import com.calypsan.listenup.client.data.discovery.ServerDiscoveryService
 import com.calypsan.listenup.client.domain.usecase.GetInstanceUseCase
+import com.calypsan.listenup.client.presentation.connection.ConnectionHealthViewModel
 import com.calypsan.listenup.client.presentation.contributordetail.ContributorDetailViewModel
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
@@ -187,6 +188,8 @@ object KoinHelper {
     fun getAppStartupViewModel(): AppStartupViewModel = resolve(AppStartupViewModel::class)
 
     fun getAuthSession(): AuthSession = resolve(AuthSession::class)
+
+    fun getConnectionHealthViewModel(): ConnectionHealthViewModel = resolve(ConnectionHealthViewModel::class)
 
     fun getServerConfig(): ServerConfig = resolve(ServerConfig::class)
 


### PR DESCRIPTION
## iOS parity for the connection-health banner (Task 13)

Renders the **Offline** (server unreachable → Retry) and **Update available** (version skew → Dismiss) states on iOS, matching the Compose banner shipped in 2a/2b. Session-lapse keeps its existing dedicated `SessionLapsedBanner` (auth-driven); this covers the two states that occur *while authenticated*.

### What's here
- **`KoinHelper.getConnectionHealthViewModel()`** — DI accessor for the already-exported ViewModel (no new export-surface types; `ConnectionHealthViewModel`/`ConnectionHealthUi` were already baselined in 2a).
- **`ConnectionHealthObserver`** — `@Observable @MainActor`, binds `ConnectionHealthViewModel.state` via `FlowBridge`, maps `ConnectionHealthUi` → a native `ConnectionHealthKind` value enum at the boundary (per the rule against feeding bridged Kotlin objects to SwiftUI). Resolved **lazily on first authentication**, never at launch.
- **`ConnectionHealthBanner`** — Liquid-Glass card matching `SessionLapsedBanner`, reusing the generated `shell.offline_*` / `shell.update_available_*` strings.
- **`ConnectionHealthShell` wiring** in the app root's `.authenticated` branch (`.safeAreaInset`).
- **`ConnectionHealthObserverTests`** — Swift Testing spec for the flat enum.

### Validated on-device (Xcode 26.5, iPhone 17 sim)
- `xcodebuild build-for-testing` — SUCCEEDED (Swift + `onEnum` exhaustiveness + Kotlin accessor + test target).
- `xcodebuild test` (signed) — SUCCEEDED, `ConnectionHealthKindTests` pass, test host launches clean.
- Linux `spotlessCheck` + `detekt` — green (the Kotlin change).

Independent of #1087 (version exchange) — the `Outdated` state won't fire until #1087 merges, but the iOS code handles it. No export-surface baseline change.