### PR TITLE
✨ feat: connection-resilience Phase 3 — ContractMismatch safety net

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/TransportError.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/TransportError.kt
@@ -88,4 +88,22 @@ sealed interface TransportError : AppError {
         override val code: String = "TRANSPORT_DATA_MALFORMED"
         override val isRetryable: Boolean = false
     }
+
+    /**
+     * A well-formed 2xx response whose body this client cannot parse (envelope-version skew or a
+     * shape mismatch) — evidence the app and server contract versions have diverged. NON-BLOCKING:
+     * surfaced as the "Update available" hint, never as an auth failure. [detail] is the technical
+     * per-instance context (not user-facing).
+     */
+    @Serializable
+    @SerialName("TransportError.ContractMismatch")
+    data class ContractMismatch(
+        override val correlationId: String? = null,
+        override val debugInfo: String? = null,
+        val detail: String,
+    ) : TransportError {
+        override val message: String = "The app and server versions don't match."
+        override val code: String = "TRANSPORT_CONTRACT_MISMATCH"
+        override val isRetryable: Boolean = false
+    }
 }

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/api/error/TransportErrorSerializationTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/api/error/TransportErrorSerializationTest.kt
@@ -1,0 +1,27 @@
+package com.calypsan.listenup.api.error
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.encodeToString
+
+class TransportErrorSerializationTest :
+    FunSpec({
+        test("ContractMismatch round-trips through the contract JSON as a typed AppError") {
+            val original: AppError =
+                TransportError.ContractMismatch(
+                    correlationId = "c",
+                    detail = "x",
+                )
+
+            val json = contractJson.encodeToString(original)
+            val decoded = contractJson.decodeFromString<AppError>(json)
+
+            decoded.shouldBeInstanceOf<TransportError.ContractMismatch>()
+            decoded shouldBe original
+            decoded.code shouldBe "TRANSPORT_CONTRACT_MISMATCH"
+            decoded.isRetryable shouldBe false
+            decoded.message shouldBe "The app and server versions don't match."
+        }
+    })

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -344,6 +344,7 @@ private fun TransportError.withCorrelationId(id: String?): TransportError =
         is TransportError.Server4xx -> copy(correlationId = id)
         is TransportError.Server5xx -> copy(correlationId = id)
         is TransportError.DataMalformed -> copy(correlationId = id)
+        is TransportError.ContractMismatch -> copy(correlationId = id)
     }
 
 private fun SyncError.toHttpStatus(): HttpStatusCode =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.client.data.remote.RpcFailureClassifier
 import com.calypsan.listenup.client.data.remote.ServerUrlNotConfiguredException
+import com.calypsan.listenup.client.data.remote.model.EnvelopeMismatchException
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
@@ -60,6 +61,17 @@ internal object ErrorMapper {
                         TransportError.Server4xx(statusCode = status, debugInfo = exception.message)
                     }
                 }
+            }
+
+            // A well-formed 2xx whose envelope this client can't parse (version/shape skew) is
+            // evidence of a contract mismatch, not an internal fault — surfaced as the
+            // non-blocking "Update available" hint. Checked before the SerializationException arm
+            // below since it is the more specific case.
+            exception is EnvelopeMismatchException -> {
+                TransportError.ContractMismatch(
+                    detail = exception.message ?: "envelope mismatch",
+                    debugInfo = exception.message,
+                )
             }
 
             exception is SerializationException -> {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionHealthStore.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionHealthStore.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.connection
 
 import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.client.data.auth.invalidatesSession
 import com.calypsan.listenup.client.data.sync.ConnectionState
 import com.calypsan.listenup.client.data.sync.SyncEngineState
@@ -151,13 +152,28 @@ internal class ConnectionHealthStore(
 
     /**
      * Report a typed failure observed by a headless seam. Cheap and non-suspending — safe to
-     * call redundantly from every failure branch. Session-invalidating errors are forwarded to
-     * the [ErrorBus] exactly once per lapse — but only while currently [AuthState.Authenticated],
-     * so a failure reported before first login (or while already lapsed) never surfaces a
-     * snackbar. Everything else is swallowed. Same guard + dedup discipline as the absorbed
+     * call redundantly from every failure branch. Dispatches on the error's shape, never both:
+     * contract-mismatch evidence ([TransportError.ContractMismatch] / [TransportError.DataMalformed])
+     * routes to [reportCompat] — non-blocking, independent of auth state, since a parse failure
+     * can occur before first login and is never a session failure. Everything else falls through
+     * to the auth path: session-invalidating errors are forwarded to the [ErrorBus] exactly once
+     * per lapse — but only while currently [AuthState.Authenticated], so a failure reported before
+     * first login (or while already lapsed) never surfaces a snackbar. Everything not
+     * session-invalidating is swallowed. Same guard + dedup discipline as the absorbed
      * `ConnectionIssueReporter`.
      */
     fun report(error: AppError) {
+        val compatEvidence =
+            when (error) {
+                is TransportError.ContractMismatch -> error.detail
+                is TransportError.DataMalformed -> error.detail
+                else -> null
+            }
+        if (compatEvidence != null) {
+            reportCompat(compatEvidence)
+            return
+        }
+
         if (authStateFlow.value !is AuthState.Authenticated) return
         if (!error.invalidatesSession()) return
         if (reportedSinceAuthenticated) return

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -31,6 +31,7 @@ internal class SyncEventDispatcher(
     private val onAccessChanged: suspend (scope: AccessScope?) -> Unit = {},
     private val onUserDeleted: suspend (reason: String?) -> Unit = {},
     private val onLibraryDataChanged: suspend () -> Unit = {},
+    private val reportCompat: (String) -> Unit = {},
 ) {
     /** Route a parsed SSE frame: control events, data events, or no-op for missing event lines. */
     suspend fun handle(frame: ParsedSseFrame) {
@@ -49,6 +50,7 @@ internal class SyncEventDispatcher(
                 throw e
             } catch (e: Exception) {
                 logger.warn(e) { "Failed to decode SyncControl frame" }
+                reportCompat("SSE control frame undecodable: ${e.message}")
                 return
             }
         // Refreshed tier: catalog-declared refresh strategies. Engine/lifecycle controls fall through.
@@ -124,6 +126,7 @@ internal class SyncEventDispatcher(
                 throw e
             } catch (e: Exception) {
                 logger.warn(e) { "Failed to decode SyncEvent for domain '$domainName'" }
+                reportCompat("SSE event undecodable for domain '$domainName': ${e.message}")
                 return
             }
         val isOwnEcho = event.clientOpId?.let { queue.containsAndAck(it) } ?: false

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
@@ -225,6 +225,7 @@ internal val clientSyncModule =
                 // above-cursor rows before the digest pass. Same lazy-SyncEngine resolution as
                 // onCursorStale/onAccessChanged to break the construction cycle.
                 onLibraryDataChanged = { get<SyncEngine>().lifecycleReconcile(force = true) },
+                reportCompat = get<ConnectionHealthStore>()::reportCompat,
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/error/ErrorMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/error/ErrorMapperTest.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.client.checkIs
 import com.calypsan.listenup.client.data.remote.ServerUrlNotConfiguredException
+import com.calypsan.listenup.client.data.remote.model.EnvelopeMismatchException
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -26,6 +27,28 @@ import kotlinx.serialization.SerializationException
  */
 class ErrorMapperTest :
     FunSpec({
+        // ========== EnvelopeMismatchException → TransportError.ContractMismatch ==========
+
+        test("map EnvelopeMismatchException returns ContractMismatch, not InternalError or AuthError") {
+            val exception = EnvelopeMismatchException("Envelope version mismatch. Expected v=1, got v=2.")
+            val error = ErrorMapper.map(exception)
+
+            val contractMismatch = error.shouldBeInstanceOf<TransportError.ContractMismatch>()
+            contractMismatch.message shouldBe "The app and server versions don't match."
+            contractMismatch.code shouldBe "TRANSPORT_CONTRACT_MISMATCH"
+            contractMismatch.isRetryable shouldBe false
+            contractMismatch.detail shouldBe "Envelope version mismatch. Expected v=1, got v=2."
+            contractMismatch.debugInfo shouldBe "Envelope version mismatch. Expected v=1, got v=2."
+        }
+
+        test("ContractMismatch is not retryable") {
+            val exception = EnvelopeMismatchException("Response missing 'v' field.")
+            val error = ErrorMapper.map(exception)
+
+            val contractMismatch = error.shouldBeInstanceOf<TransportError.ContractMismatch>()
+            contractMismatch.isRetryable shouldBe false
+        }
+
         // ========== SerializationException → TransportError.DataMalformed ==========
 
         test("map SerializationException returns DataMalformed") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ConnectionHealthStoreTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ConnectionHealthStoreTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.client.data.sync.ConnectionState
 import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.domain.model.AuthState
@@ -87,6 +88,60 @@ class ConnectionHealthStoreTest :
 
                 errorBus.errors.test {
                     store.reportCompat("envelope v=2")
+                    expectNoEvents()
+                    cancelAndConsumeRemainingEvents()
+                }
+
+                advanceTimeBy(1)
+                store.state.value.shouldBeInstanceOf<ConnectionHealth.Outdated>()
+            }
+        }
+
+        test("report(ContractMismatch) routes to compat, never auth") {
+            runTest {
+                val engineState = SyncEngineState()
+                engineState.setConnection(ConnectionState.Connected(lastEventId = null))
+                val authState = MutableStateFlow<AuthState>(authed())
+                val errorBus = ErrorBus()
+                val store =
+                    ConnectionHealthStore(
+                        engineState = engineState,
+                        authStateFlow = authState,
+                        errorBus = errorBus,
+                        clientIdentity = FakeClientIdentity(),
+                        localPreferences = fakeLocalPreferences(),
+                        scope = backgroundScope,
+                    )
+
+                errorBus.errors.test {
+                    store.report(TransportError.ContractMismatch(detail = "envelope v=2"))
+                    expectNoEvents()
+                    cancelAndConsumeRemainingEvents()
+                }
+
+                advanceTimeBy(1)
+                store.state.value.shouldBeInstanceOf<ConnectionHealth.Outdated>()
+            }
+        }
+
+        test("report(DataMalformed) routes to compat, never auth") {
+            runTest {
+                val engineState = SyncEngineState()
+                engineState.setConnection(ConnectionState.Connected(lastEventId = null))
+                val authState = MutableStateFlow<AuthState>(authed())
+                val errorBus = ErrorBus()
+                val store =
+                    ConnectionHealthStore(
+                        engineState = engineState,
+                        authStateFlow = authState,
+                        errorBus = errorBus,
+                        clientIdentity = FakeClientIdentity(),
+                        localPreferences = fakeLocalPreferences(),
+                        scope = backgroundScope,
+                    )
+
+                errorBus.errors.test {
+                    store.report(TransportError.DataMalformed(detail = "bad body"))
                     expectNoEvents()
                     cancelAndConsumeRemainingEvents()
                 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
@@ -521,6 +521,68 @@ class SyncEventDispatcherTest :
             }
         }
 
+        test("control: malformed frame reports contract-mismatch evidence, doesn't throw, doesn't advance cursor") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                var advanced = false
+                val compatReports = mutableListOf<String>()
+                val dispatcher =
+                    SyncEventDispatcher(
+                        registry = ClientSyncDomainRegistry(),
+                        queue =
+                            PendingOperationQueue(
+                                dao = db.pendingOperationV2Dao(),
+                                sender = PendingOperationSender { AppResult.Success(Unit) },
+                            ),
+                        state = SyncEngineState(),
+                        cursorAdvance = { _, _ -> advanced = true },
+                        reportCompat = { compatReports += it },
+                    )
+                val frame =
+                    ParsedSseFrame(
+                        id = 1L,
+                        event = "control",
+                        data = "{not valid json for SyncControl}",
+                    )
+                dispatcher.handle(frame) // no throw
+                compatReports shouldHaveSize 1
+                advanced shouldBe false
+                db.close()
+            }
+        }
+
+        test("data event: malformed frame reports contract-mismatch evidence, doesn't throw, doesn't advance cursor") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val registry = ClientSyncDomainRegistry()
+                registry.register(RecordingHandler())
+                var advanced = false
+                val compatReports = mutableListOf<String>()
+                val dispatcher =
+                    SyncEventDispatcher(
+                        registry = registry,
+                        queue =
+                            PendingOperationQueue(
+                                dao = db.pendingOperationV2Dao(),
+                                sender = PendingOperationSender { AppResult.Success(Unit) },
+                            ),
+                        state = SyncEngineState(),
+                        cursorAdvance = { _, _ -> advanced = true },
+                        reportCompat = { compatReports += it },
+                    )
+                val frame =
+                    ParsedSseFrame(
+                        id = 1L,
+                        event = "tags",
+                        data = "{not valid json for a Tag SyncEvent}",
+                    )
+                dispatcher.handle(frame) // no throw
+                compatReports shouldHaveSize 1
+                advanced shouldBe false
+                db.close()
+            }
+        }
+
         test("a failed apply does not stall the stream — a later successful event still advances the cursor") {
             runTest {
                 val db = createInMemoryTestDatabase()


### PR DESCRIPTION
## Phase 3 — the ContractMismatch safety net

Completes the connection-resilience arc (Phases 1/2a/2b merged). When the client receives a **well-formed 2xx** whose body it can't parse — an envelope-version skew or a shape mismatch, i.e. evidence the app is outdated — it now surfaces the non-blocking **"Update available"** (`Outdated`) hint, *strictly separate from auth* (a parse error can never trigger a re-login loop), and the connection survives (the unparseable slice is skipped, never a teardown).

The store's `reportCompat` → `Outdated` derivation already existed (2a); this PR adds the **feeder** across both transports.

### What's here (3 commits)
- **Typed error + mapping** (`75e640ae0`): `TransportError.ContractMismatch` (§8) in `:contract`; `ErrorMapper` maps `EnvelopeMismatchException` → `ContractMismatch` (before the `SerializationException → DataMalformed` arm). Adding the sealed subtype rippled to the server's exhaustive `withCorrelationId` `when` — the contract-is-source-of-truth working as designed.
- **REST path** (`8ab32332e`): `ConnectionHealthStore.report()` dispatches `ContractMismatch`/`DataMalformed` → `reportCompat` **before** the auth guard. The existing sync-read seams (`SyncReconciler`/`SyncCatchUpClient`/`SyncEngine`) already call `report(error)`, so this lights up the banner with **no seam-site change**.
- **SSE path** (`83c83f22e`): `SyncEventDispatcher`'s two decode-catch blocks (which already log-and-drop, keeping the connection alive) now also call a `reportCompat` seam, wired via DI to `ConnectionHealthStore::reportCompat`.

### The invariant, tested both directions
- `ContractMismatch`/`DataMalformed` → `Outdated`, and the `ErrorBus` stays **silent** (no auth snackbar).
- An `AuthError` → `SessionExpired` and **never** `Outdated`.
- A malformed SSE frame → `reportCompat` fires, `handle` doesn't throw, cursor isn't advanced (slice skipped, connection survives).

### Verification (Linux lane, all green — server run in isolation)
`verifyStrings` · `verifyLicenses` · `:contract:jvmTest` · `:sharedLogic:jvmTest` · both `testAndroidHostTest` · `:build-logic:convention:test` · `:androidApp:assembleDebug` · `:server:jvmTest` (isolated) · `:server:compileKotlinLinuxX64` · `spotlessCheck` · `detekt`. TDD throughout; RED confirmed per task.

iOS renders the `Outdated` state via #1088 (connection-health banner). Deferred per spec §12: per-feature version branching, compat-enforcement Konsist rule.