### PR TITLE
✨ feat(server): LibraryWriteBroker — the sole writer inside library folders (trio P1)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/LibraryWriteError.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/LibraryWriteError.kt
@@ -1,0 +1,27 @@
+package com.calypsan.listenup.api.error
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Typed failures from [com.calypsan.listenup.server.librarywrite.LibraryWriteBroker] — the sole
+ * component permitted to write inside library folders.
+ */
+@Serializable
+sealed interface LibraryWriteError : AppError {
+    /**
+     * The library folder isn't writable right now — the mount may be read-only, offline, or out
+     * of space. [isRetryable] is `true`: the underlying mount may come back on its own (e.g. a
+     * network share reconnecting), so retry middleware can blindly re-fire the write.
+     */
+    @Serializable
+    @SerialName("LibraryWriteError.Unavailable")
+    data class Unavailable(
+        override val correlationId: String? = null,
+        override val debugInfo: String? = null,
+    ) : LibraryWriteError {
+        override val message: String = "This library folder isn't writable right now."
+        override val code: String = "LIBRARY_WRITE_UNAVAILABLE"
+        override val isRetryable: Boolean = true
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationPlugins.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationPlugins.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.server.di.backupModule
 import com.calypsan.listenup.server.di.booksModule
 import com.calypsan.listenup.server.di.importModule
 import com.calypsan.listenup.server.di.libraryModule
+import com.calypsan.listenup.server.di.libraryWriteModule
 import com.calypsan.listenup.server.di.mdnsModule
 import com.calypsan.listenup.server.di.metadataModule
 import com.calypsan.listenup.server.di.playbackModule
@@ -96,6 +97,7 @@ internal fun Application.installDependencies(
         modules += metadataModule(homeDir)
         modules += playbackModule()
         modules += libraryModule()
+        modules += libraryWriteModule(homeDir)
         modules += embeddedmetaModule
         modules += syncModule()
         modules += publicProfileModule()

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationStartup.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationStartup.kt
@@ -8,6 +8,8 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.api.LibraryAdminServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserPrincipal
+import com.calypsan.listenup.server.librarywrite.LibraryWriteBroker
+import com.calypsan.listenup.server.librarywrite.LibraryWriteStatus
 import com.calypsan.listenup.server.mdns.MdnsAdvertiser
 import com.calypsan.listenup.server.mdns.launchMdnsRefreshOnServerInfoChange
 import com.calypsan.listenup.server.scanner.RescanScheduler
@@ -18,6 +20,7 @@ import com.calypsan.listenup.server.scheduler.MetadataCacheCleanupTask
 import com.calypsan.listenup.server.scheduler.OrphanImageCleanupTask
 import com.calypsan.listenup.server.scheduler.StatsFreshnessSweepTask
 import com.calypsan.listenup.server.services.BookPersister
+import com.calypsan.listenup.server.services.LibraryFolderRepository
 import com.calypsan.listenup.server.services.LibraryRegistry
 import com.calypsan.listenup.server.sync.ChangeBus
 import io.ktor.server.application.Application
@@ -79,7 +82,20 @@ internal fun Application.startBackgroundTasks(
     }
 
     val rescanOnStartup = environment.config.rescanOnStartup()
+    val libraryWriteBroker = koinGet<LibraryWriteBroker>()
+    val libraryFolderRepository = koinGet<LibraryFolderRepository>()
     scope.launch {
+        // Write-journal recovery MUST complete before bootstrapLibraries mounts any watcher
+        // (onLibraryAdded): recovery re-registers every path it touches with the
+        // SelfWriteRegistry, so ordering it first guarantees no watcher can observe a
+        // recovery write as an external change and churn a rescan. Sequential in this
+        // coroutine — the ordering is structural, not timing-based.
+        runCatching {
+            libraryWriteBroker.recoverJournal()
+        }.onFailure { e ->
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            logger.error(e) { "write-journal recovery failed — server keeps running" }
+        }
         runCatching {
             bootstrapLibraries(
                 libraryAdminService = libraryAdminService,
@@ -91,6 +107,15 @@ internal fun Application.startBackgroundTasks(
         }.onFailure { e ->
             if (e is kotlinx.coroutines.CancellationException) throw e
             logger.error(e) { "library bootstrap failed — server keeps running" }
+        }
+        // Writability probe — after folders load, so every live folder root gets a status
+        // line in the boot log. Purely informational at this phase (the admin surface that
+        // exposes LibraryWriteStatus to clients ships in a later phase).
+        runCatching {
+            probeLibraryFolders(libraryWriteBroker, libraryRegistry, libraryFolderRepository)
+        }.onFailure { e ->
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            logger.warn(e) { "library writability probe failed — server keeps running" }
         }
     }
 
@@ -141,6 +166,31 @@ private fun CoroutineScope.launchNeverFatal(
     runCatching { task() }.onFailure { e ->
         if (e is kotlinx.coroutines.CancellationException) throw e
         logger.error(e) { "$description — server keeps running" }
+    }
+}
+
+/**
+ * Probes every live library folder root for writability at boot and logs the outcome —
+ * `info` when writable, `warn` with the reason when not. Purely informational: an unwritable
+ * root degrades library writes to typed [com.calypsan.listenup.api.error.LibraryWriteError]
+ * failures at call time; it never blocks startup.
+ */
+internal suspend fun probeLibraryFolders(
+    broker: LibraryWriteBroker,
+    libraryRegistry: LibraryRegistry,
+    folderRepository: LibraryFolderRepository,
+) {
+    val libraryId = libraryRegistry.currentLibrary()
+    for (folder in folderRepository.listByLibrary(libraryId.value)) {
+        when (val status = broker.probe(Path(folder.rootPath))) {
+            is LibraryWriteStatus.Available -> {
+                logger.info { "library folder ${folder.rootPath} is writable" }
+            }
+
+            is LibraryWriteStatus.Unavailable -> {
+                logger.warn { "library folder ${folder.rootPath} is NOT writable — ${status.reason}" }
+            }
+        }
     }
 }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationStartup.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationStartup.kt
@@ -90,13 +90,10 @@ internal fun Application.startBackgroundTasks(
         // SelfWriteRegistry, so ordering it first guarantees no watcher can observe a
         // recovery write as an external change and churn a rescan. Sequential in this
         // coroutine — the ordering is structural, not timing-based.
-        runCatching {
+        runNeverFatal("write-journal recovery failed") {
             libraryWriteBroker.recoverJournal()
-        }.onFailure { e ->
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            logger.error(e) { "write-journal recovery failed — server keeps running" }
         }
-        runCatching {
+        runNeverFatal("library bootstrap failed") {
             bootstrapLibraries(
                 libraryAdminService = libraryAdminService,
                 scanOrchestrator = orchestrator,
@@ -104,18 +101,12 @@ internal fun Application.startBackgroundTasks(
                 libraryPaths = libraryPaths,
                 rescanOnStartup = rescanOnStartup,
             )
-        }.onFailure { e ->
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            logger.error(e) { "library bootstrap failed — server keeps running" }
         }
         // Writability probe — after folders load, so every live folder root gets a status
         // line in the boot log. Purely informational at this phase (the admin surface that
         // exposes LibraryWriteStatus to clients ships in a later phase).
-        runCatching {
+        runNeverFatal("library writability probe failed") {
             probeLibraryFolders(libraryWriteBroker, libraryRegistry, libraryFolderRepository)
-        }.onFailure { e ->
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            logger.warn(e) { "library writability probe failed — server keeps running" }
         }
     }
 
@@ -155,19 +146,25 @@ internal fun Application.startBackgroundTasks(
 }
 
 /**
- * Launches [task] as a fire-and-forget startup job that must never break server boot: any
- * non-cancellation failure is logged (prefixed with [description]) and swallowed.
+ * Runs [task] as a startup step that must never break server boot: any non-cancellation
+ * failure is logged (prefixed with [description]) and swallowed.
  * [kotlinx.coroutines.CancellationException] is re-raised to honor structured concurrency.
  */
-private fun CoroutineScope.launchNeverFatal(
+private suspend fun runNeverFatal(
     description: String,
     task: suspend () -> Unit,
-) = launch {
+) {
     runCatching { task() }.onFailure { e ->
         if (e is kotlinx.coroutines.CancellationException) throw e
         logger.error(e) { "$description — server keeps running" }
     }
 }
+
+/** Fire-and-forget variant of [runNeverFatal] for independent startup jobs. */
+private fun CoroutineScope.launchNeverFatal(
+    description: String,
+    task: suspend () -> Unit,
+) = launch { runNeverFatal(description, task) }
 
 /**
  * Probes every live library folder root for writability at boot and logs the outcome —

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/LibraryWriteModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/LibraryWriteModule.kt
@@ -1,0 +1,25 @@
+package com.calypsan.listenup.server.di
+
+import com.calypsan.listenup.server.librarywrite.LibraryWriteBroker
+import com.calypsan.listenup.server.librarywrite.SelfWriteRegistry
+import com.calypsan.listenup.server.librarywrite.WriteJournal
+import kotlinx.io.files.Path
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import kotlin.time.Clock
+
+/**
+ * Koin module for the library-write slice: [SelfWriteRegistry] (consulted by the file watcher),
+ * [WriteJournal] (crash-resumable manifest log under `$LISTENUP_HOME/write-journal/`), and
+ * [LibraryWriteBroker] — the sole component permitted to write inside library folders.
+ * [homeDir] is the data-home directory that also holds the live database.
+ */
+fun libraryWriteModule(homeDir: Path): Module =
+    module {
+        single {
+            val clock: Clock = get()
+            SelfWriteRegistry { clock.now().toEpochMilliseconds() }
+        }
+        single { WriteJournal(Path(homeDir, "write-journal")) }
+        single { LibraryWriteBroker(registry = get(), journal = get()) }
+    }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.server.scanner.ScannerBundle
 import com.calypsan.listenup.server.scanner.ScannerServiceImpl
 import com.calypsan.listenup.server.scanner.ScanOrchestrator
 import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import com.calypsan.listenup.server.librarywrite.SelfWriteRegistry
 import com.calypsan.listenup.server.scanner.metadata.MetadataPrecedence
 import com.calypsan.listenup.server.scanner.metadata.resolveLibraryPrecedence
 import com.calypsan.listenup.server.scanner.sidecar.DescTxtParser
@@ -106,6 +107,7 @@ fun scannerModule(
         single<WatcherSupervisorPort> {
             val scope: CoroutineScope = get()
             val debouncer: StableSizeDebouncer = get()
+            val selfWrites: SelfWriteRegistry = get()
             WatcherSupervisor { folder, onEvent ->
                 // Scanner-internal refs are always system-built with a real path; a null here
                 // means a member-redacted projection leaked into the scanner — fail loudly.
@@ -120,6 +122,7 @@ fun scannerModule(
                         libraryRoot = folderPath,
                         scope = scope,
                         debouncer = debouncer,
+                        selfWrites = selfWrites,
                     )
                 val job: Job =
                     scope.launch {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
@@ -19,15 +19,15 @@ private const val DEFAULT_SUPPRESSION_TTL_MS = 30_000L
 /**
  * The only component permitted to write inside library folders (Konsist-pinned — see
  * `LibraryWritesGoThroughBrokerRule`). Guarantees: watcher self-write suppression via
- * [SelfWriteRegistry], atomic visibility (temp file + rename), and typed degradation on
- * unwritable roots. Journaled multi-op manifests ([executeManifest]) land in a later phase of
- * this component.
+ * [SelfWriteRegistry], atomic visibility (temp file + rename), journaled crash-resumable
+ * multi-op manifests via [WriteJournal], and typed degradation on unwritable roots.
  *
  * The broker has no feature knowledge — it moves bytes. Sidecar/organize/upload semantics live
  * in their own domains and call through this seam.
  */
 class LibraryWriteBroker(
     private val registry: SelfWriteRegistry,
+    private val journal: WriteJournal,
     private val suppressionTtlMs: Long = DEFAULT_SUPPRESSION_TTL_MS,
 ) {
     /**
@@ -83,6 +83,102 @@ class LibraryWriteBroker(
         } catch (e: Exception) {
             registry.release(marker)
             LibraryWriteStatus.Unavailable(reason = "$root: ${e.message}")
+        }
+    }
+
+    /**
+     * Executes [manifest]'s ops in order. The manifest is journaled *before* its first op runs,
+     * so a crash mid-manifest leaves a resumable trail for [recoverJournal] to pick up at the
+     * next boot. Stops at the first op that fails, leaving the journal in place for a retry —
+     * ops already marked done in the journal are never re-applied. On full success the journal
+     * entry is deleted.
+     */
+    suspend fun executeManifest(manifest: WriteManifest): AppResult<Unit> =
+        try {
+            journal.persist(manifest)
+            applyFrom(manifest, doneFlags = List(manifest.ops.size) { false })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "failed to journal manifest ${manifest.opId}" }
+            failure(LibraryWriteError.Unavailable(debugInfo = "journal persist failed for ${manifest.opId}: ${e.message}"))
+        }
+
+    /**
+     * Re-applies every un-done op of every manifest still in the journal — the crash-resume path,
+     * called once at boot (before the watcher starts) so an interrupted [executeManifest] finishes
+     * instead of leaving the library folder half-changed forever. Idempotent: a manifest whose ops
+     * are already all done (or whose journal entry is simply absent) is a no-op. Never throws —
+     * a manifest that still can't complete (e.g. its root is still unwritable) stays in the
+     * journal and is retried on the next boot; other pending manifests still get their turn.
+     */
+    suspend fun recoverJournal() {
+        for (pending in journal.listPending()) {
+            applyFrom(pending.manifest, pending.doneFlags)
+        }
+    }
+
+    /** Applies [manifest]'s ops from the first un-done index onward, journaling progress as it goes. */
+    private suspend fun applyFrom(
+        manifest: WriteManifest,
+        doneFlags: List<Boolean>,
+    ): AppResult<Unit> {
+        for ((index, op) in manifest.ops.withIndex()) {
+            if (doneFlags[index]) continue
+            val result = applyOp(op)
+            if (result is AppResult.Failure) return result
+            journal.markOpDone(manifest.opId, index)
+        }
+        journal.delete(manifest.opId)
+        return AppResult.Success(Unit)
+    }
+
+    /**
+     * Applies a single [WriteOp], per the idempotency rule documented on its type (see
+     * [WriteOp]'s KDoc). Never throws — any I/O failure becomes a typed
+     * [LibraryWriteError.Unavailable].
+     */
+    private suspend fun applyOp(op: WriteOp): AppResult<Unit> =
+        try {
+            when (op) {
+                is WriteOp.EnsureDir -> {
+                    SystemFileSystem.createDirectories(op.dir)
+                    AppResult.Success(Unit)
+                }
+
+                is WriteOp.MoveFile -> applyMove(op)
+
+                is WriteOp.WriteFile -> writeFile(op.target, op.bytes).let { result ->
+                    if (result is AppResult.Failure) result else AppResult.Success(Unit)
+                }
+
+                is WriteOp.DeleteFile -> {
+                    registry.register(op.target, suppressionTtlMs)
+                    SystemFileSystem.delete(op.target, mustExist = false)
+                    AppResult.Success(Unit)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            failure(LibraryWriteError.Unavailable(debugInfo = "${op::class.simpleName} failed: ${e.message}"))
+        }
+
+    /** [WriteOp.MoveFile]'s idempotency rule — see its KDoc for the four-way case breakdown. */
+    private fun applyMove(op: WriteOp.MoveFile): AppResult<Unit> {
+        val fromExists = SystemFileSystem.exists(op.from)
+        val toExists = SystemFileSystem.exists(op.to)
+        return when {
+            !fromExists && toExists -> AppResult.Success(Unit) // already moved
+            fromExists && toExists ->
+                failure(LibraryWriteError.Unavailable(debugInfo = "ambiguous move: both ${op.from} and ${op.to} exist"))
+            !fromExists -> failure(LibraryWriteError.Unavailable(debugInfo = "move source missing: ${op.from}"))
+            else -> {
+                registry.register(op.from, suppressionTtlMs)
+                registry.register(op.to, suppressionTtlMs)
+                SystemFileSystem.atomicMove(op.from, op.to)
+                AppResult.Success(Unit)
+            }
         }
     }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
@@ -48,7 +48,7 @@ class LibraryWriteBroker(
                 ?: return failure(LibraryWriteError.Unavailable(debugInfo = "no parent directory: $target"))
         val tmp = Path(parent, ".listenup-tmp-${Uuid.random()}")
         return try {
-            SystemFileSystem.createDirectories(parent)
+            createDirectoriesSuppressed(parent)
             registry.register(target, suppressionTtlMs)
             registry.register(tmp, suppressionTtlMs)
             SystemFileSystem.sink(tmp).buffered().use { it.write(bytes) }
@@ -73,7 +73,7 @@ class LibraryWriteBroker(
     suspend fun probe(root: Path): LibraryWriteStatus {
         val marker = Path(root, ".listenup-probe-${Uuid.random()}")
         return try {
-            SystemFileSystem.createDirectories(root)
+            createDirectoriesSuppressed(root)
             registry.register(marker, suppressionTtlMs)
             SystemFileSystem.sink(marker).buffered().use { it.write(ByteArray(0)) }
             SystemFileSystem.delete(marker, mustExist = false)
@@ -144,7 +144,7 @@ class LibraryWriteBroker(
         try {
             when (op) {
                 is WriteOp.EnsureDir -> {
-                    SystemFileSystem.createDirectories(op.dir)
+                    createDirectoriesSuppressed(op.dir)
                     AppResult.Success(Unit)
                 }
 
@@ -169,6 +169,21 @@ class LibraryWriteBroker(
         } catch (e: Exception) {
             failure(LibraryWriteError.Unavailable(debugInfo = "${op::class.simpleName} failed: ${e.message}"))
         }
+
+    /**
+     * Creates [dir] (and any missing ancestors), registering every directory that does not yet
+     * exist with [registry] *before* it's created. A directory-create fires its own kernel event
+     * at the watcher — proven by the WatcherSuppression integration test — so the directories the
+     * broker brings into existence need claims exactly like the files it writes.
+     */
+    private fun createDirectoriesSuppressed(dir: Path) {
+        var missing: Path? = dir
+        while (missing != null && !SystemFileSystem.exists(missing)) {
+            registry.register(missing, suppressionTtlMs)
+            missing = missing.parent
+        }
+        SystemFileSystem.createDirectories(dir)
+    }
 
     /** [WriteOp.MoveFile]'s idempotency rule — see its KDoc for the four-way case breakdown. */
     private fun applyMove(op: WriteOp.MoveFile): AppResult<Unit> {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
@@ -63,4 +63,26 @@ class LibraryWriteBroker(
             failure(LibraryWriteError.Unavailable(debugInfo = "$target: ${e.message}"))
         }
     }
+
+    /**
+     * Probes whether [root] is currently writable: creates a marker file and immediately deletes
+     * it, reporting [LibraryWriteStatus.Available] on success. The marker is registered with
+     * [registry] before it's created, so the create+delete pair is swallowed as a self-write.
+     * Never throws — an I/O failure at any step reports [LibraryWriteStatus.Unavailable].
+     */
+    suspend fun probe(root: Path): LibraryWriteStatus {
+        val marker = Path(root, ".listenup-probe-${Uuid.random()}")
+        return try {
+            SystemFileSystem.createDirectories(root)
+            registry.register(marker, suppressionTtlMs)
+            SystemFileSystem.sink(marker).buffered().use { it.write(ByteArray(0)) }
+            SystemFileSystem.delete(marker, mustExist = false)
+            LibraryWriteStatus.Available
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            registry.release(marker)
+            LibraryWriteStatus.Unavailable(reason = "$root: ${e.message}")
+        }
+    }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
@@ -68,12 +68,16 @@ class LibraryWriteBroker(
      * Probes whether [root] is currently writable: creates a marker file and immediately deletes
      * it, reporting [LibraryWriteStatus.Available] on success. The marker is registered with
      * [registry] before it's created, so the create+delete pair is swallowed as a self-write.
-     * Never throws — an I/O failure at any step reports [LibraryWriteStatus.Unavailable].
+     * The probe observes and never mutates the root itself — a missing root (disconnected mount)
+     * reports [LibraryWriteStatus.Unavailable] rather than being silently created. Never throws —
+     * an I/O failure at any step also reports [LibraryWriteStatus.Unavailable].
      */
     suspend fun probe(root: Path): LibraryWriteStatus {
+        if (!SystemFileSystem.exists(root)) {
+            return LibraryWriteStatus.Unavailable(reason = "$root: does not exist")
+        }
         val marker = Path(root, ".listenup-probe-${Uuid.random()}")
         return try {
-            createDirectoriesSuppressed(root)
             registry.register(marker, suppressionTtlMs)
             SystemFileSystem.sink(marker).buffered().use { it.write(ByteArray(0)) }
             SystemFileSystem.delete(marker, mustExist = false)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
@@ -101,7 +101,9 @@ class LibraryWriteBroker(
             throw e
         } catch (e: Exception) {
             logger.warn(e) { "failed to journal manifest ${manifest.opId}" }
-            failure(LibraryWriteError.Unavailable(debugInfo = "journal persist failed for ${manifest.opId}: ${e.message}"))
+            failure(
+                LibraryWriteError.Unavailable(debugInfo = "journal persist failed for ${manifest.opId}: ${e.message}"),
+            )
         }
 
     /**
@@ -146,10 +148,14 @@ class LibraryWriteBroker(
                     AppResult.Success(Unit)
                 }
 
-                is WriteOp.MoveFile -> applyMove(op)
+                is WriteOp.MoveFile -> {
+                    applyMove(op)
+                }
 
-                is WriteOp.WriteFile -> writeFile(op.target, op.bytes).let { result ->
-                    if (result is AppResult.Failure) result else AppResult.Success(Unit)
+                is WriteOp.WriteFile -> {
+                    writeFile(op.target, op.bytes).let { result ->
+                        if (result is AppResult.Failure) result else AppResult.Success(Unit)
+                    }
                 }
 
                 is WriteOp.DeleteFile -> {
@@ -169,10 +175,18 @@ class LibraryWriteBroker(
         val fromExists = SystemFileSystem.exists(op.from)
         val toExists = SystemFileSystem.exists(op.to)
         return when {
-            !fromExists && toExists -> AppResult.Success(Unit) // already moved
-            fromExists && toExists ->
+            !fromExists && toExists -> {
+                AppResult.Success(Unit) // already moved
+            }
+
+            fromExists && toExists -> {
                 failure(LibraryWriteError.Unavailable(debugInfo = "ambiguous move: both ${op.from} and ${op.to} exist"))
-            !fromExists -> failure(LibraryWriteError.Unavailable(debugInfo = "move source missing: ${op.from}"))
+            }
+
+            !fromExists -> {
+                failure(LibraryWriteError.Unavailable(debugInfo = "move source missing: ${op.from}"))
+            }
+
             else -> {
                 registry.register(op.from, suppressionTtlMs)
                 registry.register(op.to, suppressionTtlMs)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBroker.kt
@@ -1,0 +1,66 @@
+package com.calypsan.listenup.server.librarywrite
+
+import com.calypsan.listenup.api.error.LibraryWriteError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.failure
+import com.calypsan.listenup.server.io.hashBytesSha256
+import com.calypsan.listenup.server.logging.loggerFor
+import kotlinx.coroutines.CancellationException
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlin.uuid.Uuid
+
+private val logger = loggerFor<LibraryWriteBroker>()
+
+/** Default self-write suppression window — long enough for the watcher's debounce settle window to elapse. */
+private const val DEFAULT_SUPPRESSION_TTL_MS = 30_000L
+
+/**
+ * The only component permitted to write inside library folders (Konsist-pinned — see
+ * `LibraryWritesGoThroughBrokerRule`). Guarantees: watcher self-write suppression via
+ * [SelfWriteRegistry], atomic visibility (temp file + rename), and typed degradation on
+ * unwritable roots. Journaled multi-op manifests ([executeManifest]) land in a later phase of
+ * this component.
+ *
+ * The broker has no feature knowledge — it moves bytes. Sidecar/organize/upload semantics live
+ * in their own domains and call through this seam.
+ */
+class LibraryWriteBroker(
+    private val registry: SelfWriteRegistry,
+    private val suppressionTtlMs: Long = DEFAULT_SUPPRESSION_TTL_MS,
+) {
+    /**
+     * Writes [bytes] to [target] atomically: staged to a sibling temp file, then renamed into
+     * place, so a concurrent reader (or the watcher) never observes a partial file. Both the temp
+     * and target paths are registered with [registry] *before* either is touched on disk, so
+     * every filesystem event the write produces is swallowed as a self-write. On any I/O failure
+     * the target's claim is released (no write landed, so no matching filesystem event will ever
+     * arrive) and the caller gets a typed [LibraryWriteError.Unavailable] — never a thrown
+     * exception.
+     */
+    suspend fun writeFile(
+        target: Path,
+        bytes: ByteArray,
+    ): AppResult<WrittenFile> {
+        val parent =
+            target.parent
+                ?: return failure(LibraryWriteError.Unavailable(debugInfo = "no parent directory: $target"))
+        val tmp = Path(parent, ".listenup-tmp-${Uuid.random()}")
+        return try {
+            SystemFileSystem.createDirectories(parent)
+            registry.register(target, suppressionTtlMs)
+            registry.register(tmp, suppressionTtlMs)
+            SystemFileSystem.sink(tmp).buffered().use { it.write(bytes) }
+            SystemFileSystem.atomicMove(tmp, target)
+            AppResult.Success(WrittenFile(target, hashBytesSha256(bytes)))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            registry.release(target)
+            registry.release(tmp)
+            logger.warn(e) { "writeFile failed for $target" }
+            failure(LibraryWriteError.Unavailable(debugInfo = "$target: ${e.message}"))
+        }
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteStatus.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteStatus.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.server.librarywrite
+
+/**
+ * Whether a library folder root is currently writable by [LibraryWriteBroker], as determined by
+ * [LibraryWriteBroker.probe]. Server-internal for now — the admin surface that exposes this to
+ * clients ships in a later phase, which will map it to a contract type then.
+ */
+sealed interface LibraryWriteStatus {
+    /** The root accepted a probe write-and-delete cleanly. */
+    data object Available : LibraryWriteStatus
+
+    /** The root rejected the probe. [reason] is a short, loggable technical detail — not user-facing copy. */
+    data class Unavailable(
+        val reason: String,
+    ) : LibraryWriteStatus
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/SelfWriteRegistry.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/SelfWriteRegistry.kt
@@ -1,0 +1,63 @@
+package com.calypsan.listenup.server.librarywrite
+
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import kotlinx.io.files.Path
+
+/**
+ * Registry of paths the server itself is about to touch inside library folders.
+ *
+ * The file watcher consults this at raw-event intake: a registered, unexpired path means
+ * "this event is our own write — swallow it". A path may receive several kernel events per
+ * write (create + modify + rename); claims are therefore TTL-scoped, and [consumeIfSelfWrite]
+ * exists for the terminal check where one-shot semantics matter. Thread-safe via a plain lock
+ * (matches [com.calypsan.listenup.server.sync.SyncRegistry] and [com.calypsan.listenup.server.scanner.watcher.FolderWatcher]'s
+ * own shared-state pattern — a `SynchronizedObject` critical section, not a suspending `Mutex`,
+ * since claim bookkeeping is a bounded in-memory map op that never itself suspends). Clock
+ * injected for tests. Deliberately in-memory: on restart, the persisted content-hash state
+ * (Phase 2) catches anything the registry forgot.
+ */
+class SelfWriteRegistry(
+    private val clock: () -> Long,
+) {
+    private val lock = SynchronizedObject()
+    private val claims = mutableMapOf<String, Long>() // canonical path string → expiry epoch-ms
+
+    /** Claims [path] as a self-write for the next [ttlMs] milliseconds. */
+    fun register(
+        path: Path,
+        ttlMs: Long,
+    ) = synchronized(lock) {
+        claims[path.toString()] = clock() + ttlMs
+    }
+
+    /** True if [path] is currently claimed (registered and not yet expired). Does not consume the claim. */
+    fun isSelfWrite(path: Path): Boolean =
+        synchronized(lock) {
+            val expiry = claims[path.toString()] ?: return@synchronized false
+            if (clock() > expiry) {
+                claims.remove(path.toString())
+                false
+            } else {
+                true
+            }
+        }
+
+    /**
+     * Atomically checks and removes the claim for [path], returning whether it was
+     * self-write. Use this at the terminal watcher check so a second, human-authored
+     * event for the same path is never mistaken for our own write.
+     */
+    fun consumeIfSelfWrite(path: Path): Boolean =
+        synchronized(lock) {
+            val expiry = claims.remove(path.toString()) ?: return@synchronized false
+            clock() <= expiry
+        }
+
+    /** Clears a claim early — e.g. the write failed, so no matching filesystem event will ever arrive. */
+    fun release(path: Path) =
+        synchronized(lock) {
+            claims.remove(path.toString())
+            Unit
+        }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/WriteJournal.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/WriteJournal.kt
@@ -6,12 +6,16 @@ import com.calypsan.listenup.server.io.readBytes
 import com.calypsan.listenup.server.io.readText
 import com.calypsan.listenup.server.io.writeBytes
 import com.calypsan.listenup.server.io.writeText
+import com.calypsan.listenup.server.logging.loggerFor
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+
+private val logger = loggerFor<WriteJournal>()
 
 /**
  * Crash-resumable journal for in-flight [WriteManifest]s, filesystem-truth like
@@ -38,15 +42,24 @@ class WriteJournal(
             val persistedOps =
                 manifest.ops.map { op ->
                     when (op) {
-                        is WriteOp.EnsureDir -> PersistedOp.PersistedEnsureDir(dir = op.dir.toString())
-                        is WriteOp.MoveFile -> PersistedOp.PersistedMoveFile(from = op.from.toString(), to = op.to.toString())
+                        is WriteOp.EnsureDir -> {
+                            PersistedOp.PersistedEnsureDir(dir = op.dir.toString())
+                        }
+
+                        is WriteOp.MoveFile -> {
+                            PersistedOp.PersistedMoveFile(from = op.from.toString(), to = op.to.toString())
+                        }
+
                         is WriteOp.WriteFile -> {
                             val index = dataIndex++
                             SystemFileSystem.createDirectories(dataDirFor(manifest.opId))
                             dataFileFor(manifest.opId, index).writeBytes(op.bytes)
                             PersistedOp.PersistedWriteFile(target = op.target.toString(), dataIndex = index)
                         }
-                        is WriteOp.DeleteFile -> PersistedOp.PersistedDeleteFile(target = op.target.toString())
+
+                        is WriteOp.DeleteFile -> {
+                            PersistedOp.PersistedDeleteFile(target = op.target.toString())
+                        }
                     }
                 }
             jsonFor(manifest.opId).writeText(json.encodeToString(PersistedManifest(manifest.opId, persistedOps)))
@@ -71,24 +84,39 @@ class WriteJournal(
             deleteRecursively(dataDirFor(opId))
         }
 
-    /** Every manifest still in the journal, with staged [WriteOp.WriteFile] bytes reattached, and its per-op done flags. */
+    /**
+     * Every manifest still in the journal, with staged [WriteOp.WriteFile] bytes reattached, and
+     * its per-op done flags. Per-file isolation: a journal file that fails to read or deserialize
+     * (corrupt, truncated, missing staged data) is logged, **left on disk for inspection**, and
+     * skipped — one bad file must never abort recovery of every other pending manifest, since
+     * [LibraryWriteBroker.recoverJournal] sits on the boot path.
+     */
     suspend fun listPending(): List<PendingManifest> =
         onIo {
             if (!SystemFileSystem.exists(journalDir)) return@onIo emptyList()
             SystemFileSystem
                 .list(journalDir)
                 .filter { it.name.endsWith(".json") }
-                .map { file ->
-                    val persisted = json.decodeFromString<PersistedManifest>(file.readText())
-                    PendingManifest(
-                        manifest =
-                            WriteManifest(
-                                opId = persisted.opId,
-                                ops = persisted.ops.map { it.toWriteOp(persisted.opId) },
-                            ),
-                        doneFlags = persisted.ops.map { it.done },
-                    )
-                }
+                .mapNotNull { file -> readPendingOrNull(file) }
+        }
+
+    /** Reads one journal file into a [PendingManifest], or null (with a warning) if it's unreadable. */
+    private fun readPendingOrNull(file: Path): PendingManifest? =
+        try {
+            val persisted = json.decodeFromString<PersistedManifest>(file.readText())
+            PendingManifest(
+                manifest =
+                    WriteManifest(
+                        opId = persisted.opId,
+                        ops = persisted.ops.map { it.toWriteOp(persisted.opId) },
+                    ),
+                doneFlags = persisted.ops.map { it.done },
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "skipping unreadable write-journal file $file — left on disk for inspection" }
+            null
         }
 
     private fun jsonFor(opId: String) = Path(journalDir, "$opId.json")
@@ -102,10 +130,24 @@ class WriteJournal(
 
     private fun PersistedOp.toWriteOp(opId: String): WriteOp =
         when (this) {
-            is PersistedOp.PersistedEnsureDir -> WriteOp.EnsureDir(Path(dir))
-            is PersistedOp.PersistedMoveFile -> WriteOp.MoveFile(Path(from), Path(to))
-            is PersistedOp.PersistedWriteFile -> WriteOp.WriteFile(Path(target), dataFileFor(opId, dataIndex).readBytes())
-            is PersistedOp.PersistedDeleteFile -> WriteOp.DeleteFile(Path(target))
+            is PersistedOp.PersistedEnsureDir -> {
+                WriteOp.EnsureDir(Path(dir))
+            }
+
+            is PersistedOp.PersistedMoveFile -> {
+                WriteOp.MoveFile(Path(from), Path(to))
+            }
+
+            is PersistedOp.PersistedWriteFile -> {
+                WriteOp.WriteFile(
+                    Path(target),
+                    dataFileFor(opId, dataIndex).readBytes(),
+                )
+            }
+
+            is PersistedOp.PersistedDeleteFile -> {
+                WriteOp.DeleteFile(Path(target))
+            }
         }
 
     private suspend fun <T> onIo(block: () -> T): T = withContext(fileIoDispatcher) { block() }
@@ -133,8 +175,10 @@ private data class PersistedManifest(
 /** Server-internal persisted shape of a single [WriteOp], plus its completion flag. */
 @Serializable
 private sealed interface PersistedOp {
+    /** Whether this op already completed — a resumed manifest never re-applies a done op. */
     val done: Boolean
 
+    /** Persisted [WriteOp.EnsureDir]: the directory to create. Naturally idempotent to re-apply. */
     @Serializable
     @SerialName("PersistedOp.EnsureDir")
     data class PersistedEnsureDir(
@@ -144,6 +188,7 @@ private sealed interface PersistedOp {
         override val done: Boolean = false,
     ) : PersistedOp
 
+    /** Persisted [WriteOp.MoveFile]: source and destination paths. Idempotency rule on [WriteOp.MoveFile]. */
     @Serializable
     @SerialName("PersistedOp.MoveFile")
     data class PersistedMoveFile(
@@ -155,6 +200,7 @@ private sealed interface PersistedOp {
         override val done: Boolean = false,
     ) : PersistedOp
 
+    /** Persisted [WriteOp.WriteFile]: target path plus the index of its staged bytes under `<opId>.data/`. */
     @Serializable
     @SerialName("PersistedOp.WriteFile")
     data class PersistedWriteFile(
@@ -166,6 +212,7 @@ private sealed interface PersistedOp {
         override val done: Boolean = false,
     ) : PersistedOp
 
+    /** Persisted [WriteOp.DeleteFile]: the path to delete. A missing target counts as already done. */
     @Serializable
     @SerialName("PersistedOp.DeleteFile")
     data class PersistedDeleteFile(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/WriteJournal.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/WriteJournal.kt
@@ -1,0 +1,185 @@
+package com.calypsan.listenup.server.librarywrite
+
+import com.calypsan.listenup.server.io.deleteRecursively
+import com.calypsan.listenup.server.io.fileIoDispatcher
+import com.calypsan.listenup.server.io.readBytes
+import com.calypsan.listenup.server.io.readText
+import com.calypsan.listenup.server.io.writeBytes
+import com.calypsan.listenup.server.io.writeText
+import kotlinx.coroutines.withContext
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Crash-resumable journal for in-flight [WriteManifest]s, filesystem-truth like
+ * [com.calypsan.listenup.server.absimport.ImportPaths] / `ImportStore` — no database table.
+ *
+ * One `<opId>.json` file per manifest under [journalDir] holds the ops plus a per-op `done` flag,
+ * index-aligned with the manifest's op list. [WriteOp.WriteFile] payloads are staged to a sibling
+ * `<opId>.data/<index>` file rather than inlined in the JSON — write bytes are typically
+ * image/document-sized and don't belong in a struct rewritten on every op completion. Both the
+ * `<opId>.json` file and its `.data/` sibling are removed once every op reports done ([delete]).
+ *
+ * [LibraryWriteBroker] is the only caller: [persist] before executing a manifest's first op,
+ * [markOpDone] after each op lands, [delete] once the whole manifest completes, and [listPending]
+ * to reconstruct interrupted manifests for [LibraryWriteBroker.recoverJournal] at boot.
+ */
+class WriteJournal(
+    private val journalDir: Path,
+) {
+    /** Persists [manifest] with every op undone, staging each [WriteOp.WriteFile]'s bytes to a data file. */
+    suspend fun persist(manifest: WriteManifest): Unit =
+        onIo {
+            SystemFileSystem.createDirectories(journalDir)
+            var dataIndex = 0
+            val persistedOps =
+                manifest.ops.map { op ->
+                    when (op) {
+                        is WriteOp.EnsureDir -> PersistedOp.PersistedEnsureDir(dir = op.dir.toString())
+                        is WriteOp.MoveFile -> PersistedOp.PersistedMoveFile(from = op.from.toString(), to = op.to.toString())
+                        is WriteOp.WriteFile -> {
+                            val index = dataIndex++
+                            SystemFileSystem.createDirectories(dataDirFor(manifest.opId))
+                            dataFileFor(manifest.opId, index).writeBytes(op.bytes)
+                            PersistedOp.PersistedWriteFile(target = op.target.toString(), dataIndex = index)
+                        }
+                        is WriteOp.DeleteFile -> PersistedOp.PersistedDeleteFile(target = op.target.toString())
+                    }
+                }
+            jsonFor(manifest.opId).writeText(json.encodeToString(PersistedManifest(manifest.opId, persistedOps)))
+        }
+
+    /** Marks op [index] of manifest [opId] as done, so a later [listPending] skips re-applying it. */
+    suspend fun markOpDone(
+        opId: String,
+        index: Int,
+    ): Unit =
+        onIo {
+            val file = jsonFor(opId)
+            val current = json.decodeFromString<PersistedManifest>(file.readText())
+            val updated = current.copy(ops = current.ops.mapIndexed { i, op -> if (i == index) op.markDone() else op })
+            file.writeText(json.encodeToString(updated))
+        }
+
+    /** Removes the journal entry and any staged data for [opId] — call once every op has completed. */
+    suspend fun delete(opId: String): Unit =
+        onIo {
+            SystemFileSystem.delete(jsonFor(opId), mustExist = false)
+            deleteRecursively(dataDirFor(opId))
+        }
+
+    /** Every manifest still in the journal, with staged [WriteOp.WriteFile] bytes reattached, and its per-op done flags. */
+    suspend fun listPending(): List<PendingManifest> =
+        onIo {
+            if (!SystemFileSystem.exists(journalDir)) return@onIo emptyList()
+            SystemFileSystem
+                .list(journalDir)
+                .filter { it.name.endsWith(".json") }
+                .map { file ->
+                    val persisted = json.decodeFromString<PersistedManifest>(file.readText())
+                    PendingManifest(
+                        manifest =
+                            WriteManifest(
+                                opId = persisted.opId,
+                                ops = persisted.ops.map { it.toWriteOp(persisted.opId) },
+                            ),
+                        doneFlags = persisted.ops.map { it.done },
+                    )
+                }
+        }
+
+    private fun jsonFor(opId: String) = Path(journalDir, "$opId.json")
+
+    private fun dataDirFor(opId: String) = Path(journalDir, "$opId.data")
+
+    private fun dataFileFor(
+        opId: String,
+        index: Int,
+    ) = Path(dataDirFor(opId), index.toString())
+
+    private fun PersistedOp.toWriteOp(opId: String): WriteOp =
+        when (this) {
+            is PersistedOp.PersistedEnsureDir -> WriteOp.EnsureDir(Path(dir))
+            is PersistedOp.PersistedMoveFile -> WriteOp.MoveFile(Path(from), Path(to))
+            is PersistedOp.PersistedWriteFile -> WriteOp.WriteFile(Path(target), dataFileFor(opId, dataIndex).readBytes())
+            is PersistedOp.PersistedDeleteFile -> WriteOp.DeleteFile(Path(target))
+        }
+
+    private suspend fun <T> onIo(block: () -> T): T = withContext(fileIoDispatcher) { block() }
+
+    private companion object {
+        val json = Json { ignoreUnknownKeys = true }
+    }
+}
+
+/** A manifest reconstructed from the journal, paired with which of its ops are already done. */
+data class PendingManifest(
+    val manifest: WriteManifest,
+    val doneFlags: List<Boolean>,
+)
+
+/** Server-internal persisted shape of a [WriteManifest] (`<opId>.json`). */
+@Serializable
+private data class PersistedManifest(
+    @SerialName("opId")
+    val opId: String,
+    @SerialName("ops")
+    val ops: List<PersistedOp>,
+)
+
+/** Server-internal persisted shape of a single [WriteOp], plus its completion flag. */
+@Serializable
+private sealed interface PersistedOp {
+    val done: Boolean
+
+    @Serializable
+    @SerialName("PersistedOp.EnsureDir")
+    data class PersistedEnsureDir(
+        @SerialName("dir")
+        val dir: String,
+        @SerialName("done")
+        override val done: Boolean = false,
+    ) : PersistedOp
+
+    @Serializable
+    @SerialName("PersistedOp.MoveFile")
+    data class PersistedMoveFile(
+        @SerialName("from")
+        val from: String,
+        @SerialName("to")
+        val to: String,
+        @SerialName("done")
+        override val done: Boolean = false,
+    ) : PersistedOp
+
+    @Serializable
+    @SerialName("PersistedOp.WriteFile")
+    data class PersistedWriteFile(
+        @SerialName("target")
+        val target: String,
+        @SerialName("dataIndex")
+        val dataIndex: Int,
+        @SerialName("done")
+        override val done: Boolean = false,
+    ) : PersistedOp
+
+    @Serializable
+    @SerialName("PersistedOp.DeleteFile")
+    data class PersistedDeleteFile(
+        @SerialName("target")
+        val target: String,
+        @SerialName("done")
+        override val done: Boolean = false,
+    ) : PersistedOp
+}
+
+private fun PersistedOp.markDone(): PersistedOp =
+    when (this) {
+        is PersistedOp.PersistedEnsureDir -> copy(done = true)
+        is PersistedOp.PersistedMoveFile -> copy(done = true)
+        is PersistedOp.PersistedWriteFile -> copy(done = true)
+        is PersistedOp.PersistedDeleteFile -> copy(done = true)
+    }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/WriteManifest.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/WriteManifest.kt
@@ -25,7 +25,8 @@ sealed interface WriteOp {
      * Moves [from] to [to]. Idempotency rule: if [from] is missing and [to] exists, the move
      * already happened — skip. If both exist, the outcome is ambiguous (which one is which
      * generation of content?) — resume must fail the manifest typed and keep the journal for
-     * manual inspection rather than guess.
+     * manual inspection rather than guess. If both are missing, the content is simply gone
+     * (external interference) — also fail typed and keep the journal; never fabricate success.
      */
     data class MoveFile(
         val from: Path,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/WriteManifest.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/librarywrite/WriteManifest.kt
@@ -1,0 +1,55 @@
+package com.calypsan.listenup.server.librarywrite
+
+import kotlinx.io.files.Path
+
+/**
+ * One journaled multi-file operation for [LibraryWriteBroker.executeManifest]. [ops] execute in
+ * order; each is individually idempotent to re-apply (see the KDoc on each [WriteOp] subtype),
+ * so a crash mid-manifest can resume from the first un-`done` op without double-applying earlier
+ * ones. [opId] is a server-minted id and doubles as the journal filename
+ * (`$LISTENUP_HOME/write-journal/<opId>.json`).
+ */
+data class WriteManifest(
+    val opId: String,
+    val ops: List<WriteOp>,
+)
+
+/** A single filesystem step inside a [WriteManifest]. See each subtype's KDoc for its idempotency rule under crash-resume. */
+sealed interface WriteOp {
+    /** Ensures [dir] exists. Naturally idempotent — `createDirectories` on an existing directory is a no-op. */
+    data class EnsureDir(
+        val dir: Path,
+    ) : WriteOp
+
+    /**
+     * Moves [from] to [to]. Idempotency rule: if [from] is missing and [to] exists, the move
+     * already happened — skip. If both exist, the outcome is ambiguous (which one is which
+     * generation of content?) — resume must fail the manifest typed and keep the journal for
+     * manual inspection rather than guess.
+     */
+    data class MoveFile(
+        val from: Path,
+        val to: Path,
+    ) : WriteOp
+
+    /**
+     * Writes [bytes] to [target] atomically (temp + rename). Idempotency rule: always safe to
+     * rewrite unconditionally — the write is atomic and re-writing the same bytes produces the
+     * same outcome.
+     */
+    data class WriteFile(
+        val target: Path,
+        val bytes: ByteArray,
+    ) : WriteOp
+
+    /** Deletes [target]. Idempotency rule: a missing target means the delete already happened — skip. */
+    data class DeleteFile(
+        val target: Path,
+    ) : WriteOp
+}
+
+/** The result of a single successful [LibraryWriteBroker.writeFile] — the landed path and its content hash. */
+data class WrittenFile(
+    val path: Path,
+    val contentHashHex: String,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -95,10 +95,11 @@ fun Application.installAppErrorStatusPages() {
 /**
  * Status mapping for typed [AppError]. Used by both REST handlers and tests.
  *
- * This `when` is exhaustive over all direct [AppError] implementors. Two grouped branches keep its
+ * This `when` is exhaustive over all direct [AppError] implementors. Grouped branches keep its
  * cyclomatic complexity under the project threshold of 25 while preserving compile-time
  * exhaustiveness: the client-local [InternalError]/[TransportError]/[PlaybackError] share a 500
- * branch, and [ShelfError]/[SocialError] delegate to [shelfOrSocialHttpStatus]. Adding a new
+ * branch, [ShelfError]/[SocialError] delegate to [shelfOrSocialHttpStatus], and
+ * [LibraryError]/[LibraryWriteError] delegate to [libraryFamilyHttpStatus]. Adding a new
  * [AppError] sub-interface will still fail this `when` at compile time.
  */
 internal fun AppError.toHttpStatus(): HttpStatusCode =
@@ -117,9 +118,10 @@ internal fun AppError.toHttpStatus(): HttpStatusCode =
 
         is AudioMetadataError -> toHttpStatus()
 
-        is LibraryError -> toHttpStatus()
-
-        is LibraryWriteError -> toHttpStatus()
+        // LibraryError + LibraryWriteError share one branch (delegating to an exhaustive helper)
+        // to keep this function's cyclomatic complexity under the project threshold while
+        // preserving per-variant exhaustiveness for both families.
+        is LibraryError, is LibraryWriteError -> libraryFamilyHttpStatus()
 
         is MetadataError -> toHttpStatus()
 
@@ -201,12 +203,11 @@ internal fun AppError.withCorrelationId(id: String?): AppError =
             withCorrelationId(id)
         }
 
-        is LibraryError -> {
-            withCorrelationId(id)
-        }
-
-        is LibraryWriteError -> {
-            withCorrelationId(id)
+        // LibraryError + LibraryWriteError share one branch (delegating to an exhaustive helper)
+        // to keep this function's cyclomatic complexity under the project threshold while
+        // preserving per-variant exhaustiveness for both families.
+        is LibraryError, is LibraryWriteError -> {
+            libraryFamilyWithCorrelationId(id)
         }
 
         is MetadataError -> {
@@ -292,6 +293,35 @@ private fun AppError.leafWithCorrelationId(id: String?): AppError =
         is InternalError -> copy(correlationId = id)
         is TransportError -> withCorrelationId(id)
         is PlaybackError -> withCorrelationId(id)
+        else -> this // unreachable: only called from the grouped branch above
+    }
+
+/**
+ * Status mapping for the library-folder error families, [LibraryError] and [LibraryWriteError].
+ *
+ * Split from [toHttpStatus] solely to keep that function's cyclomatic complexity under the
+ * project threshold. The `else` branch here is unreachable in practice — this function is only
+ * called from the single grouped branch in [toHttpStatus].
+ */
+private fun AppError.libraryFamilyHttpStatus(): HttpStatusCode =
+    when (this) {
+        is LibraryError -> toHttpStatus()
+        is LibraryWriteError -> toHttpStatus()
+        else -> HttpStatusCode.InternalServerError // unreachable: only called from the grouped branch
+    }
+
+/**
+ * Correlation-id stamping for the library-folder error families, [LibraryError] and
+ * [LibraryWriteError].
+ *
+ * Split from [withCorrelationId] solely to keep that function's cyclomatic complexity under the
+ * project threshold. The `else` branch here is unreachable in practice — this function is only
+ * called from the single grouped branch in [withCorrelationId].
+ */
+private fun AppError.libraryFamilyWithCorrelationId(id: String?): AppError =
+    when (this) {
+        is LibraryError -> withCorrelationId(id)
+        is LibraryWriteError -> withCorrelationId(id)
         else -> this // unreachable: only called from the grouped branch above
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -15,6 +15,7 @@ import com.calypsan.listenup.api.error.ImportError
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.error.InviteError
 import com.calypsan.listenup.api.error.LibraryError
+import com.calypsan.listenup.api.error.LibraryWriteError
 import com.calypsan.listenup.api.error.MetadataError
 import com.calypsan.listenup.api.error.MoodError
 import com.calypsan.listenup.api.error.PlaybackError
@@ -118,6 +119,8 @@ internal fun AppError.toHttpStatus(): HttpStatusCode =
 
         is LibraryError -> toHttpStatus()
 
+        is LibraryWriteError -> toHttpStatus()
+
         is MetadataError -> toHttpStatus()
 
         // TagError + MoodError share one branch (delegating to an exhaustive helper) to keep
@@ -199,6 +202,10 @@ internal fun AppError.withCorrelationId(id: String?): AppError =
         }
 
         is LibraryError -> {
+            withCorrelationId(id)
+        }
+
+        is LibraryWriteError -> {
             withCorrelationId(id)
         }
 
@@ -342,6 +349,16 @@ private fun ScanError.withCorrelationId(id: String?): ScanError =
         is ScanError.FileUnreadable -> copy(correlationId = id)
         is ScanError.MetadataParseError -> copy(correlationId = id)
         is ScanError.TitleInferenceError -> copy(correlationId = id)
+    }
+
+private fun LibraryWriteError.toHttpStatus(): HttpStatusCode =
+    when (this) {
+        is LibraryWriteError.Unavailable -> HttpStatusCode.ServiceUnavailable
+    }
+
+private fun LibraryWriteError.withCorrelationId(id: String?): LibraryWriteError =
+    when (this) {
+        is LibraryWriteError.Unavailable -> copy(correlationId = id)
     }
 
 private fun TransportError.withCorrelationId(id: String?): TransportError =

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcher.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcher.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server.scanner.watcher
 
 import com.calypsan.listenup.server.io.isSymlink
+import com.calypsan.listenup.server.librarywrite.SelfWriteRegistry
 import com.calypsan.listenup.server.scanner.inference.MultiDiscPattern
 import com.calypsan.listenup.server.scanner.inference.SkipRules
 import com.calypsan.listenup.server.logging.loggerFor
@@ -43,6 +44,9 @@ private val logger = loggerFor<FolderWatcher>()
  *    invisible to the watcher just as they are to the Walker.
  *  - **Symlinks not followed** during initial registration (mirrors
  *    Walker behavior).
+ *  - **Self-write suppression.** Events whose path holds a live claim in the
+ *    [SelfWriteRegistry] — server-initiated writes via the LibraryWriteBroker —
+ *    are dropped at raw-event intake, before skip rules and the debouncer.
  *
  * The watcher does not start listening until [start] is called; cleanup
  * via [close] releases the inotify / FSEvents / RDC handles.
@@ -53,6 +57,7 @@ internal class FolderWatcher(
     private val debouncer: StableSizeDebouncer = StableSizeDebouncer(),
     private val skipRules: (Path) -> Boolean = { path -> SkipRules.shouldSkip(path) },
     private val watcher: LowLevelDirectoryWatcher = newLowLevelDirectoryWatcher(scope),
+    private val selfWrites: SelfWriteRegistry = SelfWriteRegistry { 0L },
 ) {
     private val emissions = MutableSharedFlow<Path>(extraBufferCapacity = 64)
     val events: Flow<Path> = emissions.asSharedFlow()
@@ -109,6 +114,14 @@ internal class FolderWatcher(
         // event.path is the absolute child path (the low-level watcher resolves it against the
         // watched directory before emitting).
         val fullPath = Path(event.path)
+
+        // Server-initiated writes (LibraryWriteBroker) are swallowed at raw-event intake, before
+        // skip rules, delete handling, and the debouncer — a self-write must not even wake the
+        // debouncer. isSelfWrite (TTL-scoped, non-consuming) rather than consume-on-first-match:
+        // one write produces several kernel events (create + modify + rename + tmp delete), and
+        // every one of them must match the single registration.
+        if (selfWrites.isSelfWrite(fullPath)) return
+
         val isDelete = event.kind == DirectoryWatchEventKind.Delete
         // Skip rules must NOT filter delete events: the deleted path no longer exists
         // on disk, so filesystem probes inside skipRules (e.g. the `.ignore` sentinel

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/di/LibraryWriteModuleVerifyTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/di/LibraryWriteModuleVerifyTest.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.server.di
+
+import com.calypsan.listenup.server.librarywrite.LibraryWriteBroker
+import com.calypsan.listenup.server.librarywrite.SelfWriteRegistry
+import com.calypsan.listenup.server.librarywrite.WriteJournal
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import java.nio.file.Files
+import kotlin.time.Clock
+import kotlinx.io.files.Path as IoPath
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class LibraryWriteModuleVerifyTest :
+    FunSpec({
+        test("libraryWriteModule resolves the registry, journal, and broker") {
+            val homeDir = Files.createTempDirectory("listenup-librarywrite-verify-")
+            try {
+                val app =
+                    koinApplication {
+                        modules(
+                            module { single<Clock> { Clock.System } },
+                            libraryWriteModule(IoPath(homeDir.toString())),
+                        )
+                    }
+                app.koin.get<SelfWriteRegistry>().shouldNotBeNull()
+                app.koin.get<WriteJournal>().shouldNotBeNull()
+                app.koin.get<LibraryWriteBroker>().shouldNotBeNull()
+                app.close()
+            } finally {
+                homeDir.toFile().deleteRecursively()
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/LibraryWritesGoThroughBrokerRule.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/LibraryWritesGoThroughBrokerRule.kt
@@ -1,0 +1,89 @@
+package com.calypsan.listenup.server.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+
+/**
+ * Konsist guard pinning the Foundation-Trio invariant that
+ * [com.calypsan.listenup.server.librarywrite.LibraryWriteBroker] is the **sole component that
+ * writes inside library folders**. The packages that handle library-folder content (`scanner`
+ * today; `organize` and `upload` when those phases land — the prefix list already names them so
+ * they are born covered) must contain no direct filesystem-write token; every mutation routes
+ * through the broker, which suppresses the watcher, journals multi-op manifests, and degrades
+ * typed on unwritable roots.
+ *
+ * Token-based like [SidecarParsersAreReadOnly]: comments are stripped so a mention in KDoc can't
+ * false-fail. The floor assertions keep the rule non-vacuous — it must observe both the broker
+ * package (else the invariant's subject is gone) and a real population of checked files.
+ */
+class LibraryWritesGoThroughBrokerRule :
+    FunSpec({
+
+        /** Package prefixes whose code handles library-folder content and must never write directly. */
+        val libraryContentPackages =
+            listOf(
+                "com.calypsan.listenup.server.scanner",
+                "com.calypsan.listenup.server.organize",
+                "com.calypsan.listenup.server.upload",
+            )
+
+        /** The kotlinx-io write surfaces (and the repo's helpers over them) a checked package must not touch. */
+        val forbiddenWriteTokens =
+            listOf(
+                "SystemFileSystem.sink(",
+                "SystemFileSystem.atomicMove(",
+                "SystemFileSystem.delete(",
+                "SystemFileSystem.createDirectories(",
+                ".writeText(",
+                ".writeBytes(",
+                "deleteRecursively(",
+                "createTempFileIn(",
+            )
+
+        // Add a path suffix here ONLY with a review note proving the write never lands inside a
+        // library folder. This list is a debt ledger, not an escape hatch.
+        val allowlist =
+            listOf(
+                // CoverSpool stages embedded-cover bytes under $LISTENUP_HOME/scan-spool — the
+                // server data home, never a library folder (see its class KDoc).
+                "server/scanner/CoverSpool.kt",
+            )
+
+        test("library-content packages have no direct FS-write tokens — the broker is the sole library writer") {
+            val serverCommonMainFiles =
+                Konsist
+                    .scopeFromProduction()
+                    .files
+                    .filter { it.path.contains("server/src/commonMain") }
+
+            // Non-vacuous floor 1: the broker package must exist — if librarywrite disappears,
+            // the invariant this rule pins has no subject and the rule must fail, not pass.
+            val brokerFiles =
+                serverCommonMainFiles.filter {
+                    it.packagee?.name == "com.calypsan.listenup.server.librarywrite"
+                }
+            brokerFiles.size shouldBeGreaterThanOrEqual 4
+
+            val checkedFiles =
+                serverCommonMainFiles.filter { file ->
+                    val pkg = file.packagee?.name ?: return@filter false
+                    libraryContentPackages.any { pkg == it || pkg.startsWith("$it.") }
+                }
+            // Non-vacuous floor 2: the scanner package alone is far larger than this.
+            checkedFiles.size shouldBeGreaterThanOrEqual 10
+
+            val offenders =
+                checkedFiles
+                    .filterNot { file -> allowlist.any { file.path.endsWith(it) } }
+                    .flatMap { file ->
+                        val body = stripComments(file.text)
+                        forbiddenWriteTokens
+                            .filter { token -> body.contains(token) }
+                            .map { token -> "${file.path} -> $token" }
+                    }
+
+            offenders.shouldBeEmpty()
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerFileTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerFileTest.kt
@@ -1,0 +1,84 @@
+package com.calypsan.listenup.server.librarywrite
+
+import com.calypsan.listenup.api.error.LibraryWriteError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.io.hashBytesSha256
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+
+private fun tempLibraryDir(): Path {
+    val dir = Files.createTempDirectory("library-write-broker-")
+    return Path(dir.toString())
+}
+
+private fun testBroker(
+    dir: Path,
+    registry: SelfWriteRegistry = SelfWriteRegistry { 0L },
+): LibraryWriteBroker = LibraryWriteBroker(registry)
+
+private fun makeReadOnly(dir: Path) {
+    Files.setPosixFilePermissions(
+        java.nio.file.Path.of(dir.toString()),
+        setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE),
+    )
+}
+
+private fun isPosix(): Boolean = !System.getProperty("os.name").lowercase().contains("windows")
+
+class LibraryWriteBrokerFileTest :
+    FunSpec({
+        test("writeFile lands atomically with exact bytes and returns the content hash") {
+            runTest {
+                val dir = tempLibraryDir()
+                val broker = testBroker(dir)
+                val target = Path(Path(dir, "Book"), "listenup.json")
+                val bytes = "{\"schemaVersion\":1}".encodeToByteArray()
+
+                val result = broker.writeFile(target, bytes)
+
+                result.shouldBeInstanceOf<AppResult.Success<WrittenFile>>()
+                SystemFileSystem.exists(target) shouldBe true
+                SystemFileSystem.source(target).buffered().use { it.readByteArray() } shouldBe bytes
+                result.data.contentHashHex shouldBe hashBytesSha256(bytes)
+                SystemFileSystem
+                    .list(target.parent!!)
+                    .none { it.name.startsWith(".listenup-tmp") } shouldBe true
+            }
+        }
+
+        test("writeFile registers target in the SelfWriteRegistry before the rename") {
+            runTest {
+                val dir = tempLibraryDir()
+                val registry = SelfWriteRegistry { 0L }
+                val broker = testBroker(dir, registry)
+                val target = Path(Path(dir, "Book"), "listenup.json")
+
+                val result = broker.writeFile(target, byteArrayOf(1))
+
+                result.shouldBeInstanceOf<AppResult.Success<WrittenFile>>()
+                registry.isSelfWrite(target) shouldBe true
+            }
+        }
+
+        test("writeFile into a read-only directory returns LibraryWriteError.Unavailable, no throw") {
+            if (!isPosix()) return@test
+            runTest {
+                val dir = tempLibraryDir()
+                makeReadOnly(dir)
+                val broker = testBroker(dir)
+
+                val result = broker.writeFile(Path(dir, "x.json"), byteArrayOf(1))
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                result.error.shouldBeInstanceOf<LibraryWriteError.Unavailable>()
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerFileTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerFileTest.kt
@@ -11,34 +11,13 @@ import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.readByteArray
-import java.nio.file.Files
-import java.nio.file.attribute.PosixFilePermission
-
-private fun tempLibraryDir(): Path {
-    val dir = Files.createTempDirectory("library-write-broker-")
-    return Path(dir.toString())
-}
-
-private fun testBroker(
-    dir: Path,
-    registry: SelfWriteRegistry = SelfWriteRegistry { 0L },
-): LibraryWriteBroker = LibraryWriteBroker(registry)
-
-private fun makeReadOnly(dir: Path) {
-    Files.setPosixFilePermissions(
-        java.nio.file.Path.of(dir.toString()),
-        setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE),
-    )
-}
-
-private fun isPosix(): Boolean = !System.getProperty("os.name").lowercase().contains("windows")
 
 class LibraryWriteBrokerFileTest :
     FunSpec({
         test("writeFile lands atomically with exact bytes and returns the content hash") {
             runTest {
                 val dir = tempLibraryDir()
-                val broker = testBroker(dir)
+                val broker = testBroker()
                 val target = Path(Path(dir, "Book"), "listenup.json")
                 val bytes = "{\"schemaVersion\":1}".encodeToByteArray()
 
@@ -58,7 +37,7 @@ class LibraryWriteBrokerFileTest :
             runTest {
                 val dir = tempLibraryDir()
                 val registry = SelfWriteRegistry { 0L }
-                val broker = testBroker(dir, registry)
+                val broker = testBroker(registry)
                 val target = Path(Path(dir, "Book"), "listenup.json")
 
                 val result = broker.writeFile(target, byteArrayOf(1))
@@ -73,7 +52,7 @@ class LibraryWriteBrokerFileTest :
             runTest {
                 val dir = tempLibraryDir()
                 makeReadOnly(dir)
-                val broker = testBroker(dir)
+                val broker = testBroker()
 
                 val result = broker.writeFile(Path(dir, "x.json"), byteArrayOf(1))
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerManifestTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerManifestTest.kt
@@ -1,0 +1,126 @@
+package com.calypsan.listenup.server.librarywrite
+
+import com.calypsan.listenup.api.result.AppResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
+
+class LibraryWriteBrokerManifestTest :
+    FunSpec({
+        test("manifest executes all ops in order and removes its journal") {
+            runTest {
+                val dir = tempLibraryDir()
+                val journalDir = tempJournalDir()
+                val journal = WriteJournal(journalDir)
+                val broker = testBroker(journal = journal)
+                val bookDir = Path(dir, "Book")
+                val sidecar = Path(bookDir, "listenup.json")
+                val renamed = Path(bookDir, "listenup.json.bak")
+                val bytes = "{}".encodeToByteArray()
+
+                val manifest =
+                    WriteManifest(
+                        opId = "manifest-1",
+                        ops =
+                            listOf(
+                                WriteOp.EnsureDir(bookDir),
+                                WriteOp.WriteFile(sidecar, bytes),
+                                WriteOp.MoveFile(sidecar, renamed),
+                            ),
+                    )
+
+                val result = broker.executeManifest(manifest)
+
+                result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                SystemFileSystem.exists(renamed) shouldBe true
+                SystemFileSystem.exists(sidecar) shouldBe false
+                journal.listPending() shouldBe emptyList()
+            }
+        }
+
+        test("every path touched by a manifest is registered for suppression") {
+            runTest {
+                val dir = tempLibraryDir()
+                val registry = SelfWriteRegistry { 0L }
+                val broker = testBroker(registry = registry)
+                val target = Path(dir, "listenup.json")
+
+                val manifest =
+                    WriteManifest(
+                        opId = "manifest-2",
+                        ops = listOf(WriteOp.WriteFile(target, byteArrayOf(1))),
+                    )
+                broker.executeManifest(manifest).shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                registry.isSelfWrite(target) shouldBe true
+            }
+        }
+
+        test("manifest against an unavailable root fails typed and leaves the journal for retry") {
+            if (!isPosix()) return@test
+            runTest {
+                val dir = tempLibraryDir()
+                makeReadOnly(dir)
+                val journal = WriteJournal(tempJournalDir())
+                val broker = testBroker(journal = journal)
+                val target = Path(dir, "listenup.json")
+
+                val manifest =
+                    WriteManifest(
+                        opId = "manifest-3",
+                        ops = listOf(WriteOp.WriteFile(target, byteArrayOf(1))),
+                    )
+
+                val result = broker.executeManifest(manifest)
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                journal.listPending().map { it.manifest.opId } shouldBe listOf("manifest-3")
+            }
+        }
+
+        test("interrupted manifest resumes idempotently via recoverJournal") {
+            runTest {
+                val dir = tempLibraryDir()
+                val journalDir = tempJournalDir()
+                val firstTarget = Path(dir, "a.json")
+                val secondTarget = Path(dir, "b.json")
+                val manifest =
+                    WriteManifest(
+                        opId = "manifest-4",
+                        ops =
+                            listOf(
+                                WriteOp.WriteFile(firstTarget, byteArrayOf(1)),
+                                WriteOp.WriteFile(secondTarget, byteArrayOf(2)),
+                            ),
+                    )
+
+                // Simulate a crash after op 0 completed: persist the manifest, apply op 0's
+                // filesystem effect directly (bypassing the broker, as the pre-crash process
+                // would have already done), and mark it done in the journal — but never call
+                // executeManifest, so op 1 never ran and the journal was never deleted.
+                val crashedJournal = WriteJournal(journalDir)
+                crashedJournal.persist(manifest)
+                SystemFileSystem.sink(firstTarget).buffered().use { it.write(byteArrayOf(1)) }
+                crashedJournal.markOpDone("manifest-4", 0)
+
+                // Fresh broker + journal instance over the same journal directory, as a real
+                // restart would construct — recovery must finish op 1 and clean up the journal.
+                val recoveredJournal = WriteJournal(journalDir)
+                val broker = testBroker(journal = recoveredJournal)
+
+                broker.recoverJournal()
+
+                SystemFileSystem.source(secondTarget).buffered().use { it.readByteArray() } shouldBe byteArrayOf(2)
+                recoveredJournal.listPending() shouldBe emptyList()
+
+                // Re-running recovery with nothing left in the journal is a no-op.
+                broker.recoverJournal()
+                recoveredJournal.listPending() shouldBe emptyList()
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerManifestTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerManifestTest.kt
@@ -151,4 +151,65 @@ class LibraryWriteBrokerManifestTest :
             }
         }
 
+        test("move whose source and destination both exist fails typed and keeps the journal") {
+            runTest {
+                val dir = tempLibraryDir()
+                val journal = WriteJournal(tempJournalDir())
+                val broker = testBroker(journal = journal)
+                val from = Path(dir, "from.json")
+                val to = Path(dir, "to.json")
+                SystemFileSystem.sink(from).buffered().use { it.write(byteArrayOf(1)) }
+                SystemFileSystem.sink(to).buffered().use { it.write(byteArrayOf(2)) }
+
+                val result =
+                    broker.executeManifest(
+                        WriteManifest(opId = "move-ambiguous", ops = listOf(WriteOp.MoveFile(from, to))),
+                    )
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                journal.listPending().map { it.manifest.opId } shouldBe listOf("move-ambiguous")
+                // Neither file was touched — the ambiguity is preserved for inspection.
+                SystemFileSystem.exists(from) shouldBe true
+                SystemFileSystem.exists(to) shouldBe true
+            }
+        }
+
+        test("move whose source is gone but destination exists is skipped as already done") {
+            runTest {
+                val dir = tempLibraryDir()
+                val journal = WriteJournal(tempJournalDir())
+                val broker = testBroker(journal = journal)
+                val from = Path(dir, "from.json")
+                val to = Path(dir, "to.json")
+                SystemFileSystem.sink(to).buffered().use { it.write(byteArrayOf(9)) }
+
+                val result =
+                    broker.executeManifest(
+                        WriteManifest(opId = "move-done", ops = listOf(WriteOp.MoveFile(from, to))),
+                    )
+
+                result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                journal.listPending() shouldBe emptyList()
+                SystemFileSystem.source(to).buffered().use { it.readByteArray() } shouldBe byteArrayOf(9)
+            }
+        }
+
+        test("move whose source and destination are both missing fails typed and keeps the journal") {
+            runTest {
+                val dir = tempLibraryDir()
+                val journal = WriteJournal(tempJournalDir())
+                val broker = testBroker(journal = journal)
+
+                val result =
+                    broker.executeManifest(
+                        WriteManifest(
+                            opId = "move-lost",
+                            ops = listOf(WriteOp.MoveFile(Path(dir, "gone.json"), Path(dir, "never.json"))),
+                        ),
+                    )
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                journal.listPending().map { it.manifest.opId } shouldBe listOf("move-lost")
+            }
+        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerManifestTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteBrokerManifestTest.kt
@@ -123,4 +123,32 @@ class LibraryWriteBrokerManifestTest :
                 recoveredJournal.listPending() shouldBe emptyList()
             }
         }
+
+        test("corrupt journal file is skipped and left on disk; valid manifests still recover") {
+            runTest {
+                val dir = tempLibraryDir()
+                val journalDir = tempJournalDir()
+                val corruptFile = Path(journalDir, "corrupt-op.json")
+                SystemFileSystem.createDirectories(journalDir)
+                SystemFileSystem.sink(corruptFile).buffered().use { it.write("{not json!".encodeToByteArray()) }
+
+                val target = Path(dir, "recovered.json")
+                WriteJournal(journalDir).persist(
+                    WriteManifest(
+                        opId = "valid-op",
+                        ops = listOf(WriteOp.WriteFile(target, byteArrayOf(7))),
+                    ),
+                )
+
+                val broker = testBroker(journal = WriteJournal(journalDir))
+                broker.recoverJournal() // must not throw
+
+                // The valid manifest recovered fully and its journal entry is gone.
+                SystemFileSystem.source(target).buffered().use { it.readByteArray() } shouldBe byteArrayOf(7)
+                // The corrupt file stays on disk for inspection and no longer aborts anything.
+                SystemFileSystem.exists(corruptFile) shouldBe true
+                WriteJournal(journalDir).listPending() shouldBe emptyList()
+            }
+        }
+
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteProbeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteProbeTest.kt
@@ -1,9 +1,11 @@
 package com.calypsan.listenup.server.librarywrite
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 class LibraryWriteProbeTest :
     FunSpec({
@@ -24,6 +26,16 @@ class LibraryWriteProbeTest :
                 val broker = testBroker()
 
                 broker.probe(Path(ro.toString())).shouldBeInstanceOf<LibraryWriteStatus.Unavailable>()
+            }
+        }
+
+        test("probe reports Unavailable for a missing root and never creates it") {
+            runTest {
+                val missing = Path(tempLibraryDir(), "unmounted")
+                val broker = testBroker()
+
+                broker.probe(missing).shouldBeInstanceOf<LibraryWriteStatus.Unavailable>()
+                SystemFileSystem.exists(missing) shouldBe false
             }
         }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteProbeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteProbeTest.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.server.librarywrite
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path
+
+class LibraryWriteProbeTest :
+    FunSpec({
+        test("probe reports Available for a writable root") {
+            runTest {
+                val ok = tempLibraryDir()
+                val broker = testBroker()
+
+                broker.probe(Path(ok.toString())).shouldBeInstanceOf<LibraryWriteStatus.Available>()
+            }
+        }
+
+        test("probe reports Unavailable for a read-only root") {
+            if (!isPosix()) return@test
+            runTest {
+                val ro = tempLibraryDir()
+                makeReadOnly(ro)
+                val broker = testBroker()
+
+                broker.probe(Path(ro.toString())).shouldBeInstanceOf<LibraryWriteStatus.Unavailable>()
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteTestFixtures.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteTestFixtures.kt
@@ -1,0 +1,25 @@
+package com.calypsan.listenup.server.librarywrite
+
+import kotlinx.io.files.Path
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+
+/** A fresh empty temp directory to stand in for a library folder root. */
+internal fun tempLibraryDir(): Path {
+    val dir = Files.createTempDirectory("library-write-broker-")
+    return Path(dir.toString())
+}
+
+/** Strips write permission from [dir] (POSIX only) so broker operations against it fail typed. */
+internal fun makeReadOnly(dir: Path) {
+    Files.setPosixFilePermissions(
+        java.nio.file.Path.of(dir.toString()),
+        setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE),
+    )
+}
+
+/** POSIX permission bits (and thus [makeReadOnly]) don't apply on Windows — guard those tests with this. */
+internal fun isPosix(): Boolean = !System.getProperty("os.name").lowercase().contains("windows")
+
+/** A [LibraryWriteBroker] wired to a fresh [SelfWriteRegistry] (or the given one) for tests. */
+internal fun testBroker(registry: SelfWriteRegistry = SelfWriteRegistry { 0L }): LibraryWriteBroker = LibraryWriteBroker(registry)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteTestFixtures.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteTestFixtures.kt
@@ -13,7 +13,8 @@ internal fun tempLibraryDir(): Path {
 /** Strips write permission from [dir] (POSIX only) so broker operations against it fail typed. */
 internal fun makeReadOnly(dir: Path) {
     Files.setPosixFilePermissions(
-        java.nio.file.Path.of(dir.toString()),
+        java.nio.file.Path
+            .of(dir.toString()),
         setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE),
     )
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteTestFixtures.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/LibraryWriteTestFixtures.kt
@@ -21,5 +21,14 @@ internal fun makeReadOnly(dir: Path) {
 /** POSIX permission bits (and thus [makeReadOnly]) don't apply on Windows — guard those tests with this. */
 internal fun isPosix(): Boolean = !System.getProperty("os.name").lowercase().contains("windows")
 
-/** A [LibraryWriteBroker] wired to a fresh [SelfWriteRegistry] (or the given one) for tests. */
-internal fun testBroker(registry: SelfWriteRegistry = SelfWriteRegistry { 0L }): LibraryWriteBroker = LibraryWriteBroker(registry)
+/** A fresh empty temp directory to stand in for `$LISTENUP_HOME/write-journal/`. */
+internal fun tempJournalDir(): Path {
+    val dir = Files.createTempDirectory("write-journal-")
+    return Path(dir.toString())
+}
+
+/** A [LibraryWriteBroker] wired to a fresh [SelfWriteRegistry] and [WriteJournal] (or the given ones) for tests. */
+internal fun testBroker(
+    registry: SelfWriteRegistry = SelfWriteRegistry { 0L },
+    journal: WriteJournal = WriteJournal(tempJournalDir()),
+): LibraryWriteBroker = LibraryWriteBroker(registry, journal)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/SelfWriteRegistryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/SelfWriteRegistryTest.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.server.librarywrite
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.io.files.Path
+
+class SelfWriteRegistryTest :
+    FunSpec({
+        fun registry(nowMs: () -> Long) = SelfWriteRegistry(clock = nowMs)
+
+        test("registered path is claimed exactly while unexpired") {
+            var now = 1_000L
+            val reg = registry { now }
+            val p = Path("/lib/Author/Book/listenup.json")
+
+            reg.register(p, ttlMs = 30_000)
+            reg.isSelfWrite(p) shouldBe true
+
+            now += 30_001
+            reg.isSelfWrite(p) shouldBe false // expired
+        }
+
+        test("unregistered sibling path is never claimed") {
+            val reg = registry { 0L }
+            reg.register(Path("/lib/A/x.json"), ttlMs = 30_000)
+            reg.isSelfWrite(Path("/lib/A/y.json")) shouldBe false
+        }
+
+        test("consume-on-match removes the claim so a SECOND event is external") {
+            val reg = registry { 0L }
+            val p = Path("/lib/A/x.json")
+            reg.register(p, ttlMs = 30_000)
+            reg.consumeIfSelfWrite(p) shouldBe true // our write event
+            reg.consumeIfSelfWrite(p) shouldBe false // a later edit = human
+        }
+
+        test("release clears a claim early (write failed, nothing will arrive)") {
+            val reg = registry { 0L }
+            val p = Path("/lib/A/x.json")
+            reg.register(p, ttlMs = 30_000)
+            reg.release(p)
+            reg.isSelfWrite(p) shouldBe false
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/WatcherSuppressionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/WatcherSuppressionTest.kt
@@ -1,0 +1,188 @@
+package com.calypsan.listenup.server.librarywrite
+
+import com.calypsan.listenup.server.scanner.watcher.FolderWatcher
+import com.calypsan.listenup.server.scanner.watcher.StableSizeDebouncer
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.buffered
+import kotlinx.io.files.SystemFileSystem
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.io.files.Path as IoPath
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The load-bearing integration test of the LibraryWriteBroker phase: a REAL [FolderWatcher]
+ * (real `LowLevelDirectoryWatcher`, real inotify on Linux CI) watching a temp library while the
+ * broker writes into it. A broker write must never wake the watcher; an external write to the
+ * very same path must. Linux-only, same as [com.calypsan.listenup.server.scanner.watcher.FolderWatcherTest]
+ * — CI runs Linux, macOS verification is a developer-machine task.
+ *
+ * The broker under test uses a short suppression TTL (500 ms) so the external-write control
+ * probe isn't swallowed by the leftover claim from the broker's own write.
+ */
+class WatcherSuppressionTest :
+    FunSpec({
+
+        val isLinux = System.getProperty("os.name").lowercase().contains("linux")
+
+        if (!isLinux) {
+            test("watcher suppression integration tests are Linux-only — skipping suite") { /* no-op */ }
+        } else {
+            test("broker writeFile never wakes the watcher; an external write to the same path does") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("listenup-suppression-")
+                    val bookDir = (tmp / "Author/Title").apply { createDirectories() }
+                    val target = IoPath(bookDir.toString(), "listenup.json")
+                    val registry = SelfWriteRegistry { System.currentTimeMillis() }
+                    val broker =
+                        LibraryWriteBroker(
+                            registry = registry,
+                            journal = WriteJournal(tempJournalDir()),
+                            suppressionTtlMs = 500,
+                        )
+                    try {
+                        withSuppressingWatcher(tmp, registry) { watcher ->
+                            val emissions = mutableListOf<IoPath>()
+                            val collector =
+                                launch(start = CoroutineStart.UNDISPATCHED) {
+                                    watcher.events.collect { emissions.add(it) }
+                                }
+
+                            broker.writeFile(target, "{\"schemaVersion\":1}".encodeToByteArray())
+                            delay(1_500) // generous: settle window + inotify latency + TTL expiry
+
+                            withClue("broker self-write must be suppressed. emissions: $emissions") {
+                                emissions.size shouldBe 0
+                            }
+
+                            // Control: the SAME path written externally (claim now expired) DOES fire.
+                            SystemFileSystem.sink(target).buffered().use {
+                                it.write("{\"edited\":true}".encodeToByteArray())
+                            }
+                            delay(1_500)
+
+                            withClue("external write must reach the watcher. emissions: $emissions") {
+                                emissions shouldContain IoPath(bookDir.toString())
+                            }
+
+                            collector.cancel()
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            test("broker writeFile that creates its parent directory is fully suppressed too") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("listenup-suppression-dir-")
+                    (tmp / "Author").createDirectories()
+                    // "NewBook" does NOT exist — the broker's createDirectories makes it, which
+                    // fires a directory-Create event that must also be suppressed.
+                    val target = IoPath(tmp.toString(), "Author", "NewBook", "listenup.json")
+                    val registry = SelfWriteRegistry { System.currentTimeMillis() }
+                    val broker =
+                        LibraryWriteBroker(
+                            registry = registry,
+                            journal = WriteJournal(tempJournalDir()),
+                            suppressionTtlMs = 500,
+                        )
+                    try {
+                        withSuppressingWatcher(tmp, registry) { watcher ->
+                            val emissions = mutableListOf<IoPath>()
+                            val collector =
+                                launch(start = CoroutineStart.UNDISPATCHED) {
+                                    watcher.events.collect { emissions.add(it) }
+                                }
+
+                            broker.writeFile(target, byteArrayOf(1))
+                            delay(1_500)
+
+                            withClue("directory-create from the broker must be suppressed. emissions: $emissions") {
+                                emissions.size shouldBe 0
+                            }
+
+                            collector.cancel()
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            test("multiple kernel events for one registered path are ALL swallowed") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("listenup-suppression-multi-")
+                    val bookDir = (tmp / "Author/Title").apply { createDirectories() }
+                    val target = IoPath(bookDir.toString(), "track.mp3")
+                    val registry = SelfWriteRegistry { System.currentTimeMillis() }
+                    try {
+                        withSuppressingWatcher(tmp, registry) { watcher ->
+                            val emissions = mutableListOf<IoPath>()
+                            val collector =
+                                launch(start = CoroutineStart.UNDISPATCHED) {
+                                    watcher.events.collect { emissions.add(it) }
+                                }
+
+                            // One registration, then a create + two modifies: a real write produces
+                            // several kernel events, and every one of them must be swallowed (this
+                            // is why intake checks isSelfWrite, not consume-on-first-match).
+                            registry.register(target, ttlMs = 30_000)
+                            SystemFileSystem.sink(target).buffered().use { it.write(byteArrayOf(1)) }
+                            delay(100)
+                            SystemFileSystem.sink(target).buffered().use { it.write(byteArrayOf(1, 2)) }
+                            delay(100)
+                            SystemFileSystem.sink(target).buffered().use { it.write(byteArrayOf(1, 2, 3)) }
+                            delay(1_500)
+
+                            withClue("every event of a registered path must be swallowed. emissions: $emissions") {
+                                emissions.size shouldBe 0
+                            }
+
+                            collector.cancel()
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+        }
+    })
+
+/** Starts a real [FolderWatcher] over [libraryRoot] consulting [registry], with a fast test debouncer. */
+private suspend fun withSuppressingWatcher(
+    libraryRoot: Path,
+    registry: SelfWriteRegistry,
+    block: suspend (FolderWatcher) -> Unit,
+) {
+    val supervisor = SupervisorJob()
+    val scope = CoroutineScope(supervisor + Dispatchers.Default)
+    val watcher =
+        FolderWatcher(
+            libraryRoot = IoPath(libraryRoot.toString()),
+            scope = scope,
+            debouncer = StableSizeDebouncer(settle = 50.milliseconds, poll = 25.milliseconds),
+            selfWrites = registry,
+        )
+    try {
+        watcher.start()
+        delay(150) // give inotify time to attach watches across the tree
+        block(watcher)
+    } finally {
+        watcher.close()
+        scope.cancel()
+    }
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/WriteJournalTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/librarywrite/WriteJournalTest.kt
@@ -1,0 +1,85 @@
+package com.calypsan.listenup.server.librarywrite
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+class WriteJournalTest :
+    FunSpec({
+        test("persist writes a journal entry with all ops undone, staging WriteFile bytes to a data file") {
+            runTest {
+                val journalDir = tempJournalDir()
+                val journal = WriteJournal(journalDir)
+                val target = Path(journalDir, "book-listenup.json")
+                val bytes = "hello".encodeToByteArray()
+                val manifest =
+                    WriteManifest(
+                        opId = "op-1",
+                        ops =
+                            listOf(
+                                WriteOp.EnsureDir(Path(journalDir, "book")),
+                                WriteOp.WriteFile(target, bytes),
+                            ),
+                    )
+
+                journal.persist(manifest)
+
+                val pending = journal.listPending()
+                pending.map { it.manifest.opId } shouldContainExactly listOf("op-1")
+                val reloaded = pending.single()
+                reloaded.doneFlags shouldBe listOf(false, false)
+                val writeOp = reloaded.manifest.ops[1] as WriteOp.WriteFile
+                writeOp.target shouldBe target
+                writeOp.bytes.contentEquals(bytes) shouldBe true
+            }
+        }
+
+        test("markOpDone flips only the targeted op's done flag") {
+            runTest {
+                val journalDir = tempJournalDir()
+                val journal = WriteJournal(journalDir)
+                val manifest =
+                    WriteManifest(
+                        opId = "op-2",
+                        ops =
+                            listOf(
+                                WriteOp.EnsureDir(Path(journalDir, "a")),
+                                WriteOp.EnsureDir(Path(journalDir, "b")),
+                            ),
+                    )
+                journal.persist(manifest)
+
+                journal.markOpDone("op-2", 0)
+
+                journal.listPending().single().doneFlags shouldBe listOf(true, false)
+            }
+        }
+
+        test("delete removes the journal file and its staged data") {
+            runTest {
+                val journalDir = tempJournalDir()
+                val journal = WriteJournal(journalDir)
+                val manifest =
+                    WriteManifest(
+                        opId = "op-3",
+                        ops = listOf(WriteOp.WriteFile(Path(journalDir, "x.json"), byteArrayOf(1, 2, 3))),
+                    )
+                journal.persist(manifest)
+
+                journal.delete("op-3")
+
+                journal.listPending() shouldBe emptyList()
+                SystemFileSystem.exists(Path(journalDir, "op-3.data")) shouldBe false
+            }
+        }
+
+        test("listPending is empty when the journal directory doesn't exist yet") {
+            runTest {
+                val journalDir = Path(tempJournalDir(), "nonexistent")
+                WriteJournal(journalDir).listPending() shouldBe emptyList()
+            }
+        }
+    })

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PushRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PushRepositoryImpl.kt
@@ -24,7 +24,10 @@ internal class PushRepositoryImpl(
     override suspend fun registerToken(token: String): AppResult<Unit> =
         rpcFactory.callResult { it.registerToken(token, platform) }
 
-    override suspend fun unregisterToken(token: String): AppResult<Unit> = rpcFactory.callResult { it.unregisterToken(token) }
+    override suspend fun unregisterToken(token: String): AppResult<Unit> =
+        rpcFactory.callResult {
+            it.unregisterToken(token)
+        }
 
     override suspend fun sendTestNotification(): AppResult<Unit> = rpcFactory.callResult { it.sendTestNotification() }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminSettingsViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminSettingsViewModel.kt
@@ -142,7 +142,11 @@ class AdminSettingsViewModel(
                     logger.error { "Failed to save push notifications setting: ${result.error}" }
                     // Revert the optimistic flip to the last server-confirmed value.
                     updateReady {
-                        it.copy(pushNotificationsEnabled = savedPushNotificationsEnabled, error = result.error).withDirty()
+                        it
+                            .copy(
+                                pushNotificationsEnabled = savedPushNotificationsEnabled,
+                                error = result.error,
+                            ).withDirty()
                     }
                 }
             }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PushRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PushRepositoryImplTest.kt
@@ -27,8 +27,7 @@ private class FakePushRpcFactory(
 ) : PushRpcFactory {
     override suspend fun get(): PushService = provide()
 
-    override suspend fun <T> callResult(block: suspend (PushService) -> AppResult<T>): AppResult<T> =
-        catchingRpcResult { block(provide()) }
+    override suspend fun <T> callResult(block: suspend (PushService) -> AppResult<T>): AppResult<T> = catchingRpcResult { block(provide()) }
 
     override suspend fun invalidate() {}
 }


### PR DESCRIPTION
Foundation Trio Phase 1 (spec: sidecar-metadata design §3). Builds the one component allowed to write inside library folders, so sidecars (#956), organization (#850), and uploads (#851) all write through a single proven seam.

**Guarantees shipped:**
- **Watcher self-write suppression** — `SelfWriteRegistry` consulted at raw-event intake (before the debouncer); `isSelfWrite` (TTL-scoped, multi-event tolerant) chosen over consume-on-first-match after the real-watcher test proved a single write emits several kernel events. Ancestor-directory creation is registered too — empirically forced by a RED test (directory-Create events reach the reanalyze path).
- **Atomic visibility** — temp + `atomicMove`, content-hash returned, no temp litter.
- **Crash-resumable multi-op manifests** — `WriteJournal` (ImportStore marker pattern, bytes staged beside the journal, never inlined); per-op idempotency rules KDoc'd and tested (incl. ambiguous-move → typed fail + journal kept); recovery isolates corrupt journal files (skip + warn, never abort the rest) and runs at boot strictly before watchers mount.
- **Honest degradation** — writability probe observes only (a probe against a disconnected mount reports `Unavailable`, never creates the root); typed `LibraryWriteError.Unavailable` (503) crosses the wire.
- **Konsist rule** — `LibraryWritesGoThroughBrokerRule` pins `scanner`/`organize`/`upload` packages to zero direct FS-write tokens (deliberate RED proof performed and reverted).

**Evidence:** real-inotify suppression test staged RED→GREEN (3-fail → 1-fail → green as each mechanism landed) with an external-write control that still triggers reanalyze. Full gates green: `:server:jvmTest` (9m37s), `:server:linuxX64Test`, `:sharedLogic:jvmTest`+`:contract:jvmTest` (529 result files, zero failures), `spotlessCheck detekt`. Rebased onto `next` and re-gated (incl. MigrationRunner with `V2__push_tokens`).

No DB migration in this phase. New commonMain contract type `LibraryWriteError` is server-surface only (no iOS export impact expected; flag in review if the export inventory disagrees).

Stacked children coming: `feat/sidecar-write-read` (P2, migration V3), `feat/file-organizer` (P3).