### PR TITLE
🐛 fix: campfire lobby polish — round avatars, silent lobby, room renders without solo playback

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.api.streaming.RpcEvent
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackManager
+import com.calypsan.listenup.core.BookId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -137,7 +138,8 @@ internal class CampfireSessionController(
             is AppResult.Success -> {
                 selfUserId = userRepository.getCurrentUser()?.idString
                 val snapshot = result.data
-                if (snapshot.phase == CampfirePhase.LIVE) applyAnchorToPlayback(snapshot.anchor, nowMs())
+                // Publish Active first so the UI lands in the room/lobby immediately; then (LIVE only)
+                // load the book and apply the anchor — never gate the state transition on the player.
                 state.value =
                     CampfireUiState.Active(
                         sessionId = sessionId,
@@ -159,6 +161,10 @@ internal class CampfireSessionController(
                     )
                 startObserving(sessionId)
                 startDriftLoop()
+                if (snapshot.phase == CampfirePhase.LIVE) {
+                    loadCampfireBook(snapshot.bookId)
+                    applyAnchorToPlayback(snapshot.anchor, nowMs())
+                }
             }
 
             is AppResult.Failure -> {
@@ -192,20 +198,19 @@ internal class CampfireSessionController(
                 selfUserId = userRepository.getCurrentUser()?.idString
                 val snapshot = result.data
                 var pendingRejoinSync: CampfireAnchor? = null
+                var applyLiveAnchor = false
                 if (snapshot.phase == CampfirePhase.LIVE) {
-                    val nowMs = nowMs()
-                    val roomPositionMs = snapshot.anchor.posAt(nowMs)
+                    val roomPositionMs = snapshot.anchor.posAt(nowMs())
                     val localPositionMs = playbackManager.currentPositionMs.value
                     val isLargeDrift = abs(roomPositionMs - localPositionMs) > LARGE_DRIFT_THRESHOLD_MS
                     if (isLargeDrift) {
                         pendingRejoinSync = snapshot.anchor
                     } else {
-                        applyAnchorToPlayback(
-                            snapshot.anchor,
-                            nowMs,
-                        )
+                        applyLiveAnchor = true
                     }
                 }
+                // Publish Active first, then (if syncing) load the book and apply the anchor — never
+                // gate the state transition on the player.
                 state.value =
                     CampfireUiState.Active(
                         sessionId = sessionId,
@@ -228,6 +233,10 @@ internal class CampfireSessionController(
                     )
                 startObserving(sessionId)
                 startDriftLoop()
+                if (applyLiveAnchor) {
+                    loadCampfireBook(snapshot.bookId)
+                    applyAnchorToPlayback(snapshot.anchor, nowMs())
+                }
             }
 
             is AppResult.Failure -> {
@@ -413,13 +422,20 @@ internal class CampfireSessionController(
         val current = state.value as? CampfireUiState.Active ?: return
         when (frame) {
             is CampfireFrame.CampfireStarted -> {
-                applyAnchorToPlayback(frame.anchor, nowMs())
+                // Flip to LIVE immediately so the UI lands in the room the moment the fire is lit —
+                // never gated behind the player. Loading the book (and applying the anchor) is a
+                // suspend, potentially slow prepare; run it off the frame-collect coroutine so it can't
+                // block this transition or the processing of later frames.
                 state.value =
                     current.copy(
                         anchor = frame.anchor,
                         phase = CampfirePhase.LIVE,
                         startedAtEpochMs = frame.anchor.capturedAtEpochMs,
                     )
+                scope.launch {
+                    loadCampfireBook(current.bookId)
+                    applyAnchorToPlayback(frame.anchor, nowMs())
+                }
             }
 
             is CampfireFrame.AnchorChanged -> {
@@ -486,6 +502,26 @@ internal class CampfireSessionController(
         if (state.value is CampfireUiState.Active) {
             state.value = CampfireUiState.Disconnected(sessionId = sessionId, keepPlayingSolo = true)
         }
+    }
+
+    /**
+     * Loads the campfire's book into the local player so a subsequent [applyAnchorToPlayback] acts
+     * on the right book. The controller owns campfire playback end to end — the book-detail flow
+     * must NOT pre-load or play the book when entering the flow, which would start playback in the
+     * lobby before the fire is lit. Called only at the moments the room actually begins playing for
+     * this member (a [CampfireFrame.CampfireStarted] frame, or joining a room already [LIVE]) — never
+     * in the lobby, and never on routine [CampfireFrame.AnchorChanged] frames (the book is already
+     * loaded by then). Idempotent: a no-op when [bookId] is already active (the Never Stranded case
+     * where the host was already listening to it). A null [PlaybackManager.prepareForPlayback]
+     * (offline, not downloaded) is left to the existing playback-error surface — [applyAnchorToPlayback]
+     * then acts on whatever is loaded and the rejoin/drift paths recover once reachable.
+     */
+    private suspend fun loadCampfireBook(bookId: String) {
+        val target = BookId(bookId)
+        if (playbackManager.currentBookId.value == target) return
+        val prepared = playbackManager.prepareForPlayback(target) ?: return
+        playbackManager.activateBook(target)
+        playbackController.startPlayback(prepared)
     }
 
     private fun applyAnchorToPlayback(

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
@@ -21,8 +21,11 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.streaming.RpcEvent
 import com.calypsan.listenup.client.domain.model.User
 import com.calypsan.listenup.client.domain.repository.UserRepository
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.test.fake.FakePlaybackController
 import com.calypsan.listenup.client.test.fake.FakePlaybackManager
+import com.calypsan.listenup.core.BookId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -97,6 +100,36 @@ class CampfireSessionControllerTest :
             scope = scope,
             clock = clock,
         )
+
+        fun stubPrepareResult(bookId: BookId = BookId("book-1")) =
+            PlaybackManager.PrepareResult(
+                timeline =
+                    PlaybackTimeline(
+                        bookId = bookId,
+                        totalDurationMs = 1_800_000L,
+                        files =
+                            listOf(
+                                PlaybackTimeline.FileSegment(
+                                    audioFileId = "af-stub",
+                                    filename = "stub.m4b",
+                                    format = "m4b",
+                                    startOffsetMs = 0L,
+                                    durationMs = 1_800_000L,
+                                    size = 1_000_000L,
+                                    streamingUrl = "https://example.test/stub.m4b",
+                                    localPath = null,
+                                    mediaItemIndex = 0,
+                                ),
+                            ),
+                    ),
+                bookTitle = "Stub Book",
+                bookAuthor = "Stub Author",
+                seriesName = null,
+                coverPath = null,
+                totalChapters = 1,
+                resumePositionMs = 0L,
+                resumeSpeed = 1.0f,
+            )
 
         test("join applies the snapshot anchor to playback and seeds Active state") {
             runTest {
@@ -523,6 +556,71 @@ class CampfireSessionControllerTest :
                 active.phase shouldBe CampfirePhase.LIVE
                 active.startedAtEpochMs shouldBe startedAnchor.capturedAtEpochMs
                 active.anchor shouldBe startedAnchor
+            }
+        }
+
+        test("LOBBY join does not load the campfire book — the fire is not lit yet") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport =
+                    FakeCampfireTransport().apply {
+                        joinResult =
+                            AppResult.Success(snapshot(phase = CampfirePhase.LOBBY, anchor = anchor(positionMs = 0L, isPlaying = false)))
+                    }
+                val playbackManager = FakePlaybackManager().apply { stubbedPrepareResult = stubPrepareResult() }
+                val sut = controller(transport, backgroundScope, clock, playbackManager = playbackManager)
+
+                sut.join(sessionId)
+                runCurrent()
+
+                playbackManager.prepareForPlaybackCalls shouldBe emptyList()
+            }
+        }
+
+        test("CampfireStarted loads the campfire book, then applies the play anchor") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport =
+                    FakeCampfireTransport().apply {
+                        joinResult =
+                            AppResult.Success(snapshot(phase = CampfirePhase.LOBBY, anchor = anchor(positionMs = 0L, isPlaying = false)))
+                    }
+                val playbackManager = FakePlaybackManager().apply { stubbedPrepareResult = stubPrepareResult() }
+                val playbackController = FakePlaybackController()
+                val sut =
+                    controller(transport, backgroundScope, clock, playbackManager = playbackManager, playbackController = playbackController)
+                sut.join(sessionId)
+                runCurrent()
+
+                transport.emit(RpcEvent.Data(CampfireFrame.CampfireStarted(anchor = anchor(positionMs = 3_000L, isPlaying = true), byUserId = "host-1")))
+                runCurrent()
+
+                playbackManager.prepareForPlaybackCalls shouldBe listOf(BookId("book-1"))
+                playbackController.startPlaybackCalls.size shouldBe 1
+                playbackController.seekCalls.last() shouldBe 3_000L
+                playbackController.playCount shouldBe 1
+            }
+        }
+
+        test("joining an already-LIVE room loads the book before applying the anchor") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport =
+                    FakeCampfireTransport().apply {
+                        joinResult =
+                            AppResult.Success(snapshot(phase = CampfirePhase.LIVE, anchor = anchor(positionMs = 5_000L, isPlaying = true)))
+                    }
+                val playbackManager = FakePlaybackManager().apply { stubbedPrepareResult = stubPrepareResult() }
+                val playbackController = FakePlaybackController()
+                val sut =
+                    controller(transport, backgroundScope, clock, playbackManager = playbackManager, playbackController = playbackController)
+
+                sut.join(sessionId)
+                runCurrent()
+
+                playbackManager.prepareForPlaybackCalls shouldBe listOf(BookId("book-1"))
+                playbackController.startPlaybackCalls.size shouldBe 1
+                playbackController.seekCalls.last() shouldBe 5_000L
             }
         }
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
@@ -33,6 +33,7 @@ import androidx.window.core.layout.WindowSizeClass
 import com.calypsan.listenup.api.dto.campfire.CampfirePhase
 import com.calypsan.listenup.api.dto.campfire.CampfireSettings
 import com.calypsan.listenup.client.design.LocalDeviceContext
+import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.features.campfire.CampfireFeedRow
 import com.calypsan.listenup.client.features.campfire.CampfireFlowBook
@@ -57,6 +58,7 @@ import com.calypsan.listenup.client.playback.SleepTimerState
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.campfire_control_denied
 import org.jetbrains.compose.resources.getString
+import kotlinx.coroutines.flow.flowOf
 import org.koin.compose.koinInject
 
 /** Height of a standard snackbar for padding calculations */
@@ -425,9 +427,16 @@ private fun rememberCampfireHost(
     playingState: NowPlayingState.Active?,
     snackbarHostState: SnackbarHostState?,
     userRepository: UserRepository = koinInject(),
+    bookRepository: BookRepository = koinInject(),
 ): CampfireHostUi {
     val campfireState by campfireViewModel.state.collectAsStateWithLifecycle()
-    val session = (campfireState as? CampfireScreenUiState.Active)?.takeIf { it.bookId == playingState?.bookId }
+    // The lobby is pre-playback — nothing is loaded until the host lights the fire — so an Active
+    // session in LOBBY must show regardless of what (if anything) is playing. Once LIVE, the campfire
+    // controller has loaded the campfire's book, so the now-playing-book match holds for the room and
+    // keeps the campfire from hijacking the host of an unrelated solo book.
+    val session =
+        (campfireState as? CampfireScreenUiState.Active)
+            ?.takeIf { it.phase == CampfirePhase.LOBBY || it.bookId == playingState?.bookId }
 
     var showInvite by remember { mutableStateOf(false) }
     LaunchedEffect(session == null) {
@@ -440,6 +449,14 @@ private fun rememberCampfireHost(
     val currentUser by userRepository.observeCurrentUser().collectAsStateWithLifecycle(initialValue = null)
     val feed = session?.let { rememberCampfireFeed(it, currentUser?.idString) } ?: emptyList()
 
+    // The lobby has no playback yet, so the book cannot come from playingState — resolve the
+    // campfire's book from its id so the flow (Lobby/Invite/Room) has a title and cover to render.
+    // Once the fire is lit and the campfire's book is playing, the playingState branch below takes over.
+    val sessionBookId = session?.bookId
+    val sessionBook by remember(sessionBookId) {
+        if (sessionBookId != null) bookRepository.observeBookListItems(listOf(sessionBookId)) else flowOf(emptyList())
+    }.collectAsStateWithLifecycle(initialValue = emptyList())
+
     val book =
         playingState?.let {
             CampfireFlowBook(
@@ -449,6 +466,18 @@ private fun rememberCampfireHost(
                 coverPath = it.coverPath,
                 coverHash = it.coverHash,
                 coverBlurHash = it.coverBlurHash,
+            )
+        } ?: sessionBook.firstOrNull()?.let { item ->
+            CampfireFlowBook(
+                bookId = item.id.value,
+                title = item.title,
+                subtitle =
+                    item.narrators
+                        .joinToString(", ") { n -> n.name }
+                        .ifBlank { item.authors.joinToString(", ") { a -> a.name } },
+                coverPath = item.coverPath,
+                coverHash = item.coverHash,
+                coverBlurHash = item.coverBlurHash,
             )
         }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -362,7 +362,9 @@ private fun BookDetailReadyContent(
                 hostDisplayName = hostDisplayName,
                 liveCampfires = liveCampfires,
                 onJoin = { sessionId ->
-                    platformActions.playBook(BookId(bookId))
+                    // Playback is the campfire controller's job — it loads and plays the book when the
+                    // room is (or becomes) LIVE. Starting it here would play in the lobby, before the
+                    // fire is lit.
                     campfireViewModel.join(sessionId)
                     campfireFlowStep = CampfireFlowStep.None
                 },
@@ -379,7 +381,8 @@ private fun BookDetailReadyContent(
                 onLoadInvitableUsers = { campfireViewModel.listInvitableUsers(bookId) },
                 onBack = { campfireFlowStep = CampfireFlowStep.Create },
                 onContinue = { invitedUserIds ->
-                    platformActions.playBook(BookId(bookId))
+                    // No playback here — the room is born in the lobby. The campfire controller starts
+                    // playback for everyone in sync when the host lights the fire (CampfireStarted).
                     campfireViewModel.createCampfire(
                         bookId,
                         CampfireSettings(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireLobbyScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireLobbyScreen.kt
@@ -200,9 +200,11 @@ private fun LobbyRosterAvatar(
     joined: Boolean,
 ) {
     val ringColor = if (joined) CampfireFlowColors.Coral.copy(alpha = 0.7f) else CampfireFlowColors.OnGlassFaint
+    // Column width tracks the avatar's own diameter so the square avatar is never clamped narrower
+    // than it is tall — a non-square box under CircleShape renders as a pill, not a circle.
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.width(62.dp).alpha(if (joined) 1f else 0.55f),
+        modifier = Modifier.width(AvatarSize.Large.dp).alpha(if (joined) 1f else 0.55f),
     ) {
         Box(contentAlignment = Alignment.BottomCenter) {
             UserAvatar(


### PR DESCRIPTION
Live-device polish of the Campfire flow (Fold), all changes verified end-to-end on-device.

## What & why

**1. Round lobby roster avatars.** The `HOST`/member avatar was a vertical pill: an `AvatarSize.Large` (96dp) avatar clamped into a `.width(62.dp)` column, so `CircleShape` on a 62×96 box rendered as a lozenge. Column width now tracks the avatar's own diameter.

**2. No auto-play in the lobby — the controller owns campfire playback.** The book-detail flow called `platformActions.playBook(bookId)` (load **and** play) on campfire create/join, so the book started playing the instant you created a campfire — before the lobby, before anyone lit the fire. Deleted both premature calls. The `CampfireSessionController` now loads the campfire's book (`prepareForPlayback → activateBook → startPlayback`) only when the room actually begins playing for this member — on `CampfireStarted`, or when joining an already-`LIVE` room (which previously applied the anchor but never loaded the book — a latent bug). The controller is now the single owner of campfire playback.

**3. Lobby/room render without solo playback.** Removing `playBook` surfaced two hidden couplings in `NowPlayingHost` (which hosts the campfire flow): the session-visibility gate and the *book metadata* were both derived from the now-playing state. A `LOBBY`-phase session now shows regardless of playback, and the book is resolved from the session's `bookId` via `BookRepository` when nothing is playing.

**4. State-first transitions.** `handleFrame(CampfireStarted)` / `join` / `rejoin` loaded the book (a suspend, potentially-slow `startPlayback`) *before* publishing the `LIVE`/`Active` state — so a slow player prepare stalled the phase transition (book loaded, but stuck on "Warming up"). They now publish state first and load playback after (`CampfireStarted` runs it off the frame-collect coroutine). Invariant: **never gate a campfire state transition on the player.**

## Verification

Full walkthrough on Pixel 9 Pro Fold: create → **silent lobby** (round avatar, no now-playing bar bleed-through) → light the fire → **live room** (roaring fire) → synced playback (position advancing in real time). And the requested check — **campfire listening counts toward stats/streaks/progress**: confirmed in the DB (a `listening_events` row for the campfire span; `user_stats` listened total 360s → 561s). Works because campfire playback drives the real player, whose state transitions drive the recording pipeline, keyed on the `currentBookId` that `activateBook` sets.

New `CampfireSessionController` tests (RED→GREEN) cover controller-owned loading on `CampfireStarted`/`LIVE`-join and the silent lobby. Linux `verifyLocal` green.

## Follow-ups (not in this PR)
- Regression test for the state-flips-before-player-loads invariant (needs a suspending `startPlayback` fake).
- The campfire flow hard-codes brand orange — should defer to Material You (tracked separately).
- Proper decoupling of the campfire flow from `NowPlayingHost` (the "return to campfire" navigation affordance) — needs its own spec.