### PR TITLE
Scanner data-integrity: stop mass-tombstoning + identity/ordering/enrichment loss on rescans (Fable audit)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanResult.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanResult.kt
@@ -43,6 +43,17 @@ data class ScanResult(
     val filesWalked: Int,
     val filesSkipped: Int,
     val scope: ScanScope = ScanScope.Full,
+    /**
+     * True when a [ScanScope.Full] scan walked every configured folder root, so its book set is
+     * authoritative for library-wide absence and `BookPersister` may run the tombstone sweep.
+     *
+     * Set `false` when at least one configured root was unreachable or unreadable at scan time
+     * (a dropped NAS/SMB mount, a permission change): that folder walked empty, so the sweep would
+     * wrongly tombstone every live book under it. A non-authoritative full scan skips the sweep
+     * entirely — genuine removals reconcile on the next scan where every root is reachable. Always
+     * `true` for a [ScanScope.Subtree] scan (which never sweeps regardless).
+     */
+    val fullScanAuthoritative: Boolean = true,
 )
 
 /**

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/BookSyncPayload.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/BookSyncPayload.kt
@@ -196,12 +196,13 @@ enum class ChapterSource {
 }
 
 /**
- * A user-editable book metadata field whose in-app edit is rescan-protected.
+ * A book metadata field whose user-applied value is rescan-protected.
  *
- * When the user edits one of these in the app, the field is recorded in
- * [BookSyncPayload.userEditedFields], so a later rescan preserves the user's value instead of
- * re-deriving it from the files/sidecars and clobbering the edit. Chapters and covers carry their own
- * provenance ([ChapterSource.USER] / [CoverSource.UPLOADED]) and are not part of this set.
+ * A field lands here when the user either hand-edits it in the app or applies provider enrichment
+ * (Audible/Audnexus) to it — both are deliberate user choices the scanner must not silently revert.
+ * The field is recorded in [BookSyncPayload.userEditedFields], so a later rescan preserves the stored
+ * value instead of re-deriving it from the files/sidecars and clobbering it. Chapters and covers carry
+ * their own provenance ([ChapterSource.USER] / [CoverSource.UPLOADED]) and are not part of this set.
  */
 @Serializable
 enum class UserEditedField {
@@ -210,6 +211,10 @@ enum class UserEditedField {
     DESCRIPTION,
     CONTRIBUTORS,
     SERIES,
+    PUBLISHER,
+    LANGUAGE,
+    PUBLISH_YEAR,
+    GENRES,
 }
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.api.result.flatMap
 import com.calypsan.listenup.api.sync.BookContributorPayload
 import com.calypsan.listenup.api.sync.BookSeriesPayload
 import com.calypsan.listenup.api.sync.CoverSource
+import com.calypsan.listenup.api.sync.UserEditedField
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.cover.CoverImageStore
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
@@ -103,6 +104,9 @@ internal class BookMetadataApplier(
                     asin = asin,
                     contributors = mergeContributors(existing.contributors, match, selection),
                     series = mergeSeries(existing.series, match, selection),
+                    // Stamp provenance for every field this apply overwrites so a later rescan
+                    // preserves the enriched value instead of reverting it to file-derived data (A7).
+                    userEditedFields = existing.userEditedFields + enrichedFields(selection),
                 )
 
             val upsertResult = bookRepository.upsert(updated, clientOpId = null)
@@ -122,6 +126,27 @@ internal class BookMetadataApplier(
             AppResult.Success(Unit)
         }
     }
+
+    /**
+     * The provenance bits to stamp for an apply: every field this [selection] overwrites is marked
+     * rescan-protected so a later scan preserves the enriched value. Contributors/series are marked
+     * only when their ASIN set is non-empty (an empty set leaves the role untouched — see
+     * [mergeContributors]/[mergeSeries]); genres only when non-empty.
+     */
+    private fun enrichedFields(selection: MetadataApplySelection): Set<UserEditedField> =
+        buildSet {
+            if (selection.title) add(UserEditedField.TITLE)
+            if (selection.subtitle) add(UserEditedField.SUBTITLE)
+            if (selection.description) add(UserEditedField.DESCRIPTION)
+            if (selection.publisher) add(UserEditedField.PUBLISHER)
+            if (selection.language) add(UserEditedField.LANGUAGE)
+            if (selection.releaseDate) add(UserEditedField.PUBLISH_YEAR)
+            if (selection.authorAsins.isNotEmpty() || selection.narratorAsins.isNotEmpty()) {
+                add(UserEditedField.CONTRIBUTORS)
+            }
+            if (selection.seriesAsins.isNotEmpty()) add(UserEditedField.SERIES)
+            if (selection.genres.isNotEmpty()) add(UserEditedField.GENRES)
+        }
 
     /** Release year overwrites only when selected and parseable, else keeps [current]. */
     private fun selectedPublishYear(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
@@ -86,14 +86,20 @@ fun scannerModule(
         }
 
         // Scan-result bus: the BookPersister consumes each ScanResult as it arrives.
-        // replay = 0: BookPersister subscribes before any scan starts, so no replay
-        // is needed — and replaying the last artwork-bearing result would re-pin
-        // ~230MB of embedded cover bytes in the SharedFlow's internal buffer between
-        // scans. DROP_OLDEST keeps a fast scan stream from ever blocking the Scanner.
-        // Qualified by name because Koin keys on the erased KClass — an unqualified
-        // MutableSharedFlow<ScanResult> would collide with the ScanEvent bus.
+        // replay = 0: BookPersister subscribes before any scan starts, so no replay is needed — and
+        // replaying the last artwork-bearing result would re-pin ~230MB of embedded cover bytes in the
+        // SharedFlow's internal buffer between scans.
+        //
+        // onBufferOverflow = SUSPEND is load-bearing (finding A4): this seam must be NON-LOSSY. The
+        // persister does heavy per-result DB + cover I/O, so a bulk reorg can queue scan results faster
+        // than it drains. The prior DROP_OLDEST silently EVICTED the oldest outstanding result once more
+        // than the buffer held — its Added/Modified never persisted, its Removed tombstones never applied,
+        // its Completed never fired. SUSPEND back-pressures the scanner instead (the scanner waits for the
+        // persister, which is correct), so no scan result is ever dropped. Qualified by name because Koin
+        // keys on the erased KClass — an unqualified MutableSharedFlow<ScanResult> would collide with the
+        // ScanEvent bus.
         single<MutableSharedFlow<ScanResult>>(EventBusQualifiers.ScanResults) {
-            MutableSharedFlow(replay = 0, extraBufferCapacity = 8, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+            MutableSharedFlow(replay = 0, extraBufferCapacity = 64, onBufferOverflow = BufferOverflow.SUSPEND)
         }
 
         single { AbsMetadataReader(contractJson) }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3Parser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3Parser.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
 import com.calypsan.listenup.server.embeddedmeta.AudioFormatParser
 import com.calypsan.listenup.server.io.SeekableSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.IOException
 
 /**
@@ -83,6 +84,22 @@ internal class Mp3Parser : AudioFormatParser {
                 AudioMetadataError.IoError(
                     pathString = "<source>",
                     ioMessage = e.message ?: "io error",
+                ),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // An unexpected fault in the ID3/MPEG readers (a malformed frame that trips index/format
+            // math) must degrade THIS file to a typed ParseError so the book still ingests with a scan
+            // warning — never let it escape and drop the whole book from the library (A11). The parser
+            // contract already promises a typed failure, not a thrown exception.
+            AppResult.Failure(
+                AudioMetadataError.CorruptHeader(
+                    pathString = "<source>",
+                    format = AudioFormat.Mp3,
+                    offset = 0L,
+                    expected = "readable ID3/MPEG structure",
+                    debugInfo = e.message ?: e::class.simpleName,
                 ),
             )
         }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
@@ -22,6 +22,14 @@ import kotlinx.io.files.Path
  */
 internal interface ScannerResultPort {
     fun lastResult(): ScanResult?
+
+    /**
+     * Marks this scanner's bundle as superseded by a later one (a folder was added/removed and the
+     * orchestrator rebuilt the bundle). A scan still in flight on the old bundle walked a stale folder
+     * set; once superseded it must NOT publish its result — a stale full-scan result would
+     * tombstone-sweep the newly-added folder's books, which are absent from its seen set (A8).
+     */
+    fun markSuperseded()
 }
 
 private val logger = loggerFor<ScanOrchestrator>()
@@ -105,22 +113,25 @@ internal class ScanOrchestrator(
         libraryId: LibraryId,
         folder: LibraryFolderRef,
     ) {
-        val staleCoordinator =
+        val stale =
             mutex.withLock {
                 val current = bundle
                 if (current != null && current.library.id == libraryId) {
                     val updatedLibrary = current.library.copy(folders = current.library.folders + folder)
+                    // Supersede the old scanner BEFORE swapping so a scan already in flight on it drops
+                    // its stale result instead of sweeping the new folder's books (A8).
+                    current.scanner.markSuperseded()
                     // Rebuild so the Scanner's captured folder list includes the new folder
                     // (a full scan walks the Scanner's roots; a snapshot-only patch wouldn't reach it).
                     bundle = scannerFactory(updatedLibrary)
-                    current.coordinator
+                    current
                 } else {
                     null
                 }
             }
         // Close the old coordinator outside the lock — closes the incremental channel,
         // letting its worker coroutine drain and exit without cancelling the shared scope.
-        staleCoordinator?.close()
+        stale?.coordinator?.close()
         if (watchEnabled) {
             watcherSupervisor.mount(libraryId, folder) { libId, path -> onFileChanged(libId, path) }
         }
@@ -140,20 +151,23 @@ internal class ScanOrchestrator(
      * Called after a successful `removeFolder` admin RPC.
      */
     suspend fun onFolderRemoved(folderId: FolderId) {
-        val staleCoordinator =
+        val stale =
             mutex.withLock {
                 bundle?.let { current ->
                     val updatedLibrary =
                         current.library.copy(
                             folders = current.library.folders.filterNot { it.id == folderId },
                         )
+                    // Supersede the old scanner before swapping so an in-flight scan drops its stale
+                    // result rather than sweeping against a folder set that no longer applies (A8).
+                    current.scanner.markSuperseded()
                     bundle = scannerFactory(updatedLibrary)
-                    current.coordinator
+                    current
                 }
             }
         // Close the old coordinator outside the lock — closes the incremental channel,
         // letting its worker coroutine drain and exit without cancelling the shared scope.
-        staleCoordinator?.close()
+        stale?.coordinator?.close()
         watcherSupervisor.unmount(folderId)
         logger.info { "Folder removed: folder=${folderId.value}" }
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -36,6 +36,7 @@ import kotlin.time.Clock
 import kotlin.uuid.Uuid
 import kotlin.concurrent.Volatile
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 private val logger = loggerFor<Scanner>()
 
@@ -110,10 +111,30 @@ internal class Scanner(
         // could differ). Parallel to [folderRoots].
         val folderRootPaths = mutableListOf<String>()
         val candidatesPerFolder = mutableListOf<List<CandidateBook>>()
+        // A full scan is authoritative for library-wide absence ONLY if every configured root was
+        // actually walked. An unreachable/unreadable root (a dropped NAS/SMB mount, a permission
+        // change) walks empty — treating that as authoritative would let BookPersister sweep every
+        // live book under it into a tombstone. Track reachability and surface the failure honestly.
+        var fullScanAuthoritative = true
+        val rootErrors = mutableListOf<ScanError>()
 
         for (folder in library.folders) {
             val rootPath = folder.rootPath ?: continue
             val folderRoot = Path(rootPath)
+            // Reachability gate: if the root is not a readable directory right now, skip it, surface a
+            // typed warning, and mark the whole full scan NON-AUTHORITATIVE so the tombstone sweep is
+            // suppressed downstream. This is the disk-reachability analogue of BookPersister's
+            // folder-row sentinel guard. A reachable-but-empty root is NOT flagged — an emptied
+            // library is a legitimate sweep.
+            if (SystemFileSystem.metadataOrNull(folderRoot)?.isDirectory != true) {
+                logger.error {
+                    "scan: configured root '$rootPath' is unreachable or unreadable — skipping it and " +
+                        "marking this scan non-authoritative (tombstone sweep suppressed) corr=$correlationId"
+                }
+                rootErrors += ScanError.LibraryPathNotFound(correlationId = correlationId, path = rootPath)
+                fullScanAuthoritative = false
+                continue
+            }
             val files = Walker().walk(folderRoot).toList()
             val candidates = Grouper().group(files.asFlow()).toList()
             totalFileCount += files.size
@@ -207,11 +228,13 @@ internal class Scanner(
                 rootPath = primaryRootPath,
                 books = allBooks, // artwork-bearing: BookPersister needs these to write covers to disk
                 changes = changes, // artwork-free: Differ used stripped books
-                errors = allErrors,
+                errors = allErrors + rootErrors,
                 durationMs = clock() - started,
                 filesWalked = totalFileCount,
                 filesSkipped = 0,
                 scope = ScanScope.Full,
+                // Non-authoritative when any configured root was unreachable — suppresses the sweep.
+                fullScanAuthoritative = fullScanAuthoritative,
             )
         // Store a stripped copy in lastResult so artwork bytes are not retained between scans.
         lastResult = result.withoutArtwork()
@@ -294,6 +317,7 @@ internal class Scanner(
             partitionBooksUnder(
                 bookRoot,
                 folderRoot,
+                folderRootPath,
                 lastResult?.books.orEmpty(), // already stripped from previous scan
             )
         // Strip artwork from the new books before diffing so both sides are comparable without
@@ -509,13 +533,24 @@ internal class Scanner(
     private fun partitionBooksUnder(
         bookRoot: Path,
         folderRoot: Path,
+        folderRootPath: String,
         books: List<AnalyzedBook>,
     ): Pair<List<AnalyzedBook>, List<AnalyzedBook>> {
         val rootPrefix = bookRoot.relativeTo(folderRoot).replace('\\', '/')
         return books.partition { book ->
+            // A book is "affected" by this incremental only if it belongs to the SAME folder as the
+            // scanned subtree. The previous snapshot spans EVERY folder, and each rootRelPath is
+            // relative to its OWN folder — so a path-prefix match alone (especially the empty prefix
+            // when bookRoot == folderRoot) wrongly claimed every other folder's books as affected,
+            // and the Differ then emitted Removed for them (mass cross-folder tombstoning). Filtering
+            // on the stamped folderRootPath first prevents that. A null folderRootPath (legacy /
+            // unattributed) can't be excluded, so it falls through to the prefix check as before.
+            if (book.folderRootPath != null && book.folderRootPath != folderRootPath) {
+                return@partition false
+            }
             val rel = book.candidate.rootRelPath
             if (rootPrefix.isEmpty()) {
-                true // bookRoot is the folder root → all books in this folder are affected
+                true // bookRoot is the folder root → all of THIS folder's books are affected
             } else {
                 rel == rootPrefix || rel.startsWith("$rootPrefix/")
             }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -87,7 +87,18 @@ internal class Scanner(
     @Volatile
     private var lastResult: ScanResult? = null
 
+    // Set once the orchestrator rebuilds the bundle (a folder was added/removed). A scan that was
+    // already in flight then walked a stale folder set; publishing its result would let BookPersister
+    // sweep the newly-added folder's books (absent from this scan's seen set). Once superseded, both
+    // emit sites drop the result instead of handing it to the persister (A8).
+    @Volatile
+    private var superseded = false
+
     override fun lastResult(): ScanResult? = lastResult
+
+    override fun markSuperseded() {
+        superseded = true
+    }
 
     suspend fun runFullScan(): ScanResult {
         val correlationId = correlationIdFactory()
@@ -158,9 +169,11 @@ internal class Scanner(
             booksTotal = totalCandidateCount,
         )
 
-        // Build a path-keyed cache from the previous scan so unchanged books can
-        // be reused without re-parsing their audio files.
-        val previousByPath = lastResult?.books.orEmpty().associateBy { it.candidate.rootRelPath }
+        // Group the previous scan's books by owning folder so each folder's fingerprint cache is
+        // keyed within that folder only — a bare-rootRelPath cache aliases a book to a same-relpath
+        // book in ANOTHER folder, reusing the wrong analysis (A11). Each pass below builds its own
+        // path-keyed map from its folder's bucket.
+        val previousByFolder = lastResult?.books.orEmpty().groupBy { it.folderRootPath }
 
         // Analyze each folder with an Analyzer anchored to that folder's root.
         // Aggregated books and errors replace the single-pass result; the Differ
@@ -173,6 +186,10 @@ internal class Scanner(
         var recentBooks: List<ScanBookRef> = emptyList()
 
         for (i in folderRoots.indices) {
+            val previousByPath =
+                previousByFolder[folderRootPaths[i]]
+                    .orEmpty()
+                    .associateBy { it.candidate.rootRelPath }
             val analyzer =
                 Analyzer(
                     folderRoots[i],
@@ -238,9 +255,28 @@ internal class Scanner(
             )
         // Store a stripped copy in lastResult so artwork bytes are not retained between scans.
         lastResult = result.withoutArtwork()
-        // Hand the artwork-bearing result to BookPersister; it emits ScanEvent.Completed once the
-        // books are persisted (see BookPersister.persist). The Scanner must NOT emit Completed here
-        // — that would signal "done" before any book is queryable.
+        return publishFullScanResult(result, correlationId)
+    }
+
+    /**
+     * Hands the full-scan [result] to [BookPersister] via [scanResultBus] — UNLESS this scanner was
+     * superseded by a bundle rebuild (a folder was added/removed) while the scan was in flight. A
+     * superseded scan walked a stale folder set, so its `seenPaths` omit the newly-added folder;
+     * publishing it would let the persister's tombstone sweep wrongly delete that folder's live books
+     * (A8). In that case the result is dropped and the new bundle's next scan reconciles. The Scanner
+     * never emits `ScanEvent.Completed` here — that fires only after the persister has committed.
+     */
+    private suspend fun publishFullScanResult(
+        result: ScanResult,
+        correlationId: String,
+    ): ScanResult {
+        if (superseded) {
+            logger.warn {
+                "scan superseded by a bundle rebuild (folder add/remove) — dropping stale full-scan " +
+                    "result [library=${library.id.value}] corr=$correlationId (sweep suppressed)"
+            }
+            return result
+        }
         scanResultBus.emit(result)
         logger.info {
             "scan walk complete [library=${library.id.value}]: ${formatScanCompleteLog(
@@ -361,6 +397,15 @@ internal class Scanner(
         logger.info {
             "incremental scan complete: library=${library.id.value} root=$bookRoot" +
                 " books=${books.size} changes=${changes.size} errors=${errors.size} in ${durationMs}ms corr=$correlationId"
+        }
+        // A superseded bundle's incremental result is stale too — drop it rather than let its
+        // Removed changes tombstone against a folder set the new bundle has already moved past (A8).
+        if (superseded) {
+            logger.warn {
+                "incremental scan superseded by a bundle rebuild — dropping stale result " +
+                    "[library=${library.id.value}] corr=$correlationId"
+            }
+            return
         }
         // BookPersister emits ScanEvent.Completed after persisting this incremental result.
         scanResultBus.emit(incrementalResult)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
@@ -20,24 +20,31 @@ internal data class TrackInfo(
  * (`getTrackAndDiscNumberFromFilename`).
  *
  * Disc number is sourced from (in priority order):
- *  1. `\b(disc|cd) ?(\d{1,2})\b` matched anywhere in the filename.
+ *  1. `\b(disc|cd) ?(\d{1,3})\b` matched anywhere in the filename.
  *  2. `^(cd|dis[ck])\s*(\d{1,3})$` matched against the parent folder name
  *     (the multi-disc subdirectory convention).
  *
- * Track number is the first 1–4 digit run remaining in the filename after
- * stripping any matched disc prefix. Strict heuristic: ABS additionally
- * strips title/author/series/year text before this match, but this parser
- * skips that — embedded-tag-driven track inference (`TrackNumberSource.METADATA`)
- * is the better fix.
+ * Track number is the **last** complete 1–4 digit run remaining in the
+ * filename after stripping any matched disc prefix. Audiobook filenames
+ * conventionally place the sequence number after the title
+ * (`"1984 - 12.mp3"`, `"Title - 05.mp3"`), so a leading numeric token is
+ * usually a year or title text; taking the last run avoids inferring `1984`
+ * as the track for every file in a book named after a year. When a genuine
+ * `"NN - Title"` prefix is the only run, last == first, so the leading-number
+ * convention still works. A run of 5+ digits is not a track number and is
+ * ignored entirely. ABS additionally strips title/author/series/year text
+ * before this match; embedded-tag inference (`TrackNumberSource.METADATA`) is
+ * the stronger fix and already wins when present.
  */
 internal object TrackInference {
-    private val discInFilename = Regex("""\b(disc|cd) ?(\d{1,2})\b""", RegexOption.IGNORE_CASE)
+    // `\d{1,3}` matches MultiDiscPattern's folder-disc range so 100+-disc sets are handled
+    // consistently whether the disc number is in the filename or the parent folder name.
+    private val discInFilename = Regex("""\b(disc|cd) ?(\d{1,3})\b""", RegexOption.IGNORE_CASE)
 
-    // No `\b` boundaries: filenames like `track01` don't have a word boundary
-    // between `k` and `0`, since both classes are "word" characters. Greedy
-    // `\d{1,4}` matches the longest 1-4 digit run and bounds 5+ digit numbers
-    // (e.g. `12345.mp3` → 1234, leaving `5` unmatched).
-    private val trackPattern = Regex("""(\d{1,4})""")
+    // Complete digit runs (maximal, delimited by non-digits). The consumer
+    // picks the last run of 1-4 digits; a 5+ digit run is skipped, not
+    // truncated, since a long numeric blob is not a track number.
+    private val digitRun = Regex("""\d+""")
 
     fun infer(
         filename: String,
@@ -63,8 +70,12 @@ internal object TrackInference {
             }
         }
 
-        val trackMatch = trackPattern.find(trackHaystack)
-        val trackNumber = trackMatch?.groupValues?.get(1)?.toIntOrNull()
+        val trackNumber =
+            digitRun
+                .findAll(trackHaystack)
+                .map { it.value }
+                .lastOrNull { it.length in 1..4 }
+                ?.toIntOrNull()
         val trackSource = trackNumber?.let { TrackNumberSource.FILENAME }
 
         return TrackInfo(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -404,8 +404,21 @@ internal class Analyzer(
             sources = collectSources(shape, parsed, embedded, metadata, sidecar),
             // A ParseError / UnsupportedFormat status means a file the scanner could
             // not fully read. MetadataStatus.Available and a null status (no audio
-            // file, or a clean parse) are not warnings.
-            hasScanWarning = embeddedStatus.isParseFailure(),
+            // file, or a clean parse) are not warnings. On TOP of that, a book that
+            // produced no usable duration (0-length looks normal to clients but can't
+            // be scrubbed) or a multi-file book with a track whose length failed to
+            // parse (a missing middle-file duration shifts every later chapter left —
+            // silent whole-book corruption) is flagged honestly. (A9)
+            hasScanWarning =
+                embeddedStatus.isParseFailure() ||
+                    durationScanWarning(
+                        bookDurationMs = bookDurationMs(tracks, embedded),
+                        trackDurations = tracks.map { it.durationMs },
+                    ) ||
+                    groupingScanWarning(
+                        trackExtensions = tracks.map { it.file.ext },
+                        distinctAlbumTags = distinctAlbumTagCount(perTrackMetadata),
+                    ),
             documents = documentCollector.collect(rootPath, Path(rootPath, candidate.rootRelPath), candidate.files),
         )
     }
@@ -434,7 +447,13 @@ internal class Analyzer(
             return sidecar.toDomainChapters() to BookChapterSource.AbsMetadata
         }
         if (embedded != null && embedded.chapters.isNotEmpty()) {
-            return embedded.chapters to BookChapterSource.Embedded(embedded.chaptersSource)
+            // Clamp against the file's own duration ONLY for a single-file book, where
+            // `embedded.durationMs` is the authoritative end-of-book. For a multi-file book the
+            // primary file's duration is not the book's, so a valid whole-book chapter set would be
+            // wrongly truncated — there we only drop structurally-impossible chapters (null bound).
+            val clampBound = if (tracks.size <= 1) embedded.durationMs else null
+            return clampEmbeddedChapters(embedded.chapters, clampBound) to
+                BookChapterSource.Embedded(embedded.chaptersSource)
         }
         if (tracks.size >= 2) {
             return synthesizeChapters(tracks, perTrackMetadata, bookTitle) to
@@ -674,6 +693,97 @@ private fun List<AbsChapter>.toDomainChapters(): List<Chapter> =
 private fun MetadataStatus?.isParseFailure(): Boolean =
     this is MetadataStatus.UnsupportedFormat || this is MetadataStatus.ParseError
 
+/**
+ * The book's effective total duration: the sum of per-track durations (multi-file books) or, when
+ * those are absent (single-file books leave `TrackEntry.durationMs` null), the book-level embedded
+ * duration. Mirrors `AnalyzedBookMapper`'s `totalDuration` derivation so the warning below reflects
+ * what actually gets persisted.
+ */
+private fun bookDurationMs(
+    tracks: List<TrackEntry>,
+    embedded: EmbeddedAudioMetadata?,
+): Long =
+    tracks
+        .sumOf { it.durationMs ?: 0L }
+        .takeIf { it > 0L }
+        ?: (embedded?.durationMs ?: 0L)
+
+/**
+ * True when a book warrants an operator scan warning for duration integrity: audio files exist but
+ * yielded no usable book duration, or a multi-file book has a track whose duration failed to parse
+ * (a 0-length track shifts every later chapter's offset left — F2-class silent corruption).
+ */
+internal fun durationScanWarning(
+    bookDurationMs: Long,
+    trackDurations: List<Long?>,
+): Boolean {
+    val audioPresent = trackDurations.isNotEmpty()
+    val zeroLengthBook = audioPresent && bookDurationMs <= 0L
+    val missingMultiTrackDuration =
+        trackDurations.size >= 2 && trackDurations.any { (it ?: 0L) <= 0L }
+    return zeroLengthBook || missingMultiTrackDuration
+}
+
+/** The number of distinct non-blank album tags across a multi-file book's per-track metadata. */
+private fun distinctAlbumTagCount(perTrackMetadata: Map<TrackEntry, EmbeddedAudioMetadata?>): Int =
+    perTrackMetadata.values
+        .mapNotNull {
+            it
+                ?.tags
+                ?.custom
+                ?.get(AudioTags.ALBUM_KEY)
+                ?.takeUnless(String::isBlank)
+        }.distinct()
+        .size
+
+/**
+ * True when a book's file shape looks wrong even though grouping (ABS convention) still produced one
+ * book — a silent "library looks off" the operator should see (A10). Two heuristics, no grouping
+ * change: mixed audio container formats in one book (e.g. `m4b` + `mp3` concatenated), or more than
+ * one distinct album tag across its files (two books that landed in one folder).
+ */
+internal fun groupingScanWarning(
+    trackExtensions: List<String>,
+    distinctAlbumTags: Int,
+): Boolean {
+    val mixedFormats =
+        trackExtensions
+            .map { it.lowercase() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .size > 1
+    return mixedFormats || distinctAlbumTags > 1
+}
+
+/**
+ * Validates embedded chapter bounds at ingest (A9), re-indexing survivors 1-based and contiguous.
+ *
+ * Always dropped, regardless of [durationMs] — structurally impossible chapters a mistagged file can
+ * carry: a negative start, or an end before its own start.
+ *
+ * Additionally, when [durationMs] is a known positive end-of-book (single-file books, where the
+ * embedded duration is authoritative): a chapter starting at/after EOF is dropped, and a trailing
+ * chapter whose end overruns EOF is clamped back to it. A `null`/`0` bound skips the EOF checks (a
+ * multi-file book, whose primary file's duration is not the book's — clamping there would truncate a
+ * valid whole-book chapter set).
+ */
+internal fun clampEmbeddedChapters(
+    chapters: List<Chapter>,
+    durationMs: Long?,
+): List<Chapter> {
+    val bound = durationMs?.takeIf { it > 0L }
+    return chapters
+        .mapNotNull { chapter ->
+            when {
+                chapter.startMs < 0L -> null
+                chapter.endMs < chapter.startMs -> null
+                bound != null && chapter.startMs >= bound -> null
+                bound != null && chapter.endMs > bound -> chapter.copy(endMs = bound)
+                else -> chapter
+            }
+        }.mapIndexed { i, chapter -> chapter.copy(index = i + 1) }
+}
+
 private fun FolderShape.contributesAnything(): Boolean =
     titleFolder.isNotEmpty() || seriesFolder != null || authorFolder != null
 
@@ -681,12 +791,24 @@ private fun ParsedTitle.hasAnyFilenameAnnotation(): Boolean =
     asin != null || narrators.isNotEmpty() || publishedYear != null ||
         sequence != null || subtitle != null
 
+/**
+ * Playback order for a book's tracks.
+ *
+ *  1. **Disc** — a file with no disc signal sorts *after* every known disc
+ *     (`Int.MAX_VALUE`), so a disc-less bonus/intro file at the book root can't
+ *     jump ahead of `CD1`/`CD2`.
+ *  2. **Track** — a file with no track signal sorts last within its disc.
+ *  3. **Filename** — natural (numeric-aware, case-insensitive) tiebreak, so
+ *     `"1984 - 2.mp3"` precedes `"1984 - 10.mp3"` instead of the UTF-16
+ *     lexicographic order that would place `10` before `2`.
+ *
+ * Tagged files (embedded track/disc) still win — they populate `trackNumber`/
+ * `discNumber` before this comparator runs.
+ */
 private val NATURAL_TRACK_ORDER =
-    compareBy<TrackEntry>(
-        { it.discNumber ?: 0 },
-        { it.trackNumber ?: Int.MAX_VALUE },
-        { it.file.name },
-    )
+    compareBy<TrackEntry> { it.discNumber ?: Int.MAX_VALUE }
+        .thenBy { it.trackNumber ?: Int.MAX_VALUE }
+        .thenBy(NaturalFileNameOrder) { it.file.name }
 
 /**
  * A candidate that contains files but none recognized as audio. It is *not* a book, so it is

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
@@ -43,19 +43,22 @@ internal class Differ {
         previous: List<AnalyzedBook>,
     ): Flow<ChangeEventDto> =
         flow {
-            val previousByRoot = previous.associateBy { it.candidate.rootRelPath }
+            // Key path matches by (folderRootPath, rootRelPath), not the bare rootRelPath: two folders
+            // can hold a book at the same relative path, and a bare-path index would alias them —
+            // masking a removal or matching a book to its cross-folder twin until the next full scan.
+            val previousByRoot = previous.associateBy { it.rootKey() }
             val previousByInode = inodeIndexFor(previous)
-            val matchedRoots = mutableSetOf<String>()
+            val matchedKeys = mutableSetOf<Pair<String?, String>>()
 
             current.collect { book ->
-                val match = previousByRoot[book.candidate.rootRelPath] ?: book.findByInode(previousByInode)
+                val match = previousByRoot[book.rootKey()] ?: book.findByInode(previousByInode)
                 val event = changeFor(book, match)
                 if (event != null) emit(event)
-                if (match != null) matchedRoots += match.candidate.rootRelPath
+                if (match != null) matchedKeys += match.rootKey()
             }
 
             previous.forEach { previousBook ->
-                if (previousBook.candidate.rootRelPath !in matchedRoots) {
+                if (previousBook.rootKey() !in matchedKeys) {
                     logger.debug { "book removed: path=${previousBook.candidate.rootRelPath}" }
                     // Carry the vanished book's owning-folder root so the persister tombstones it in
                     // the correct folder — a same-relpath book in another folder must stay untouched.
@@ -113,6 +116,12 @@ internal class Differ {
         }
         return index
     }
+
+    /**
+     * The folder-scoped path identity of a book: `(folderRootPath, rootRelPath)`. Two folders sharing
+     * a relative path stay distinct; a legacy null `folderRootPath` degrades to bare-path keying.
+     */
+    private fun AnalyzedBook.rootKey(): Pair<String?, String> = folderRootPath to candidate.rootRelPath
 
     private fun AnalyzedBook.findByInode(index: Map<Long, AnalyzedBook>): AnalyzedBook? =
         candidate.files.firstNotNullOfOrNull { file ->

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/NaturalFileNameOrder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/NaturalFileNameOrder.kt
@@ -1,0 +1,63 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+/**
+ * Natural (numeric-aware, case-insensitive) string order for filename
+ * tiebreaks. Digit runs compare by numeric value, non-digit runs compare
+ * case-insensitively, so `"1984 - 2.mp3"` sorts before `"1984 - 10.mp3"`
+ * rather than the plain UTF-16 lexicographic order that places `"10"` before
+ * `"2"` (and would silently corrupt a book's playback order).
+ *
+ * A digit run's numeric value wins first; equal values fall back to the raw
+ * run length so `"01"` and `"1"` remain deterministically ordered.
+ */
+internal object NaturalFileNameOrder : Comparator<String> {
+    override fun compare(
+        left: String,
+        right: String,
+    ): Int {
+        var i = 0
+        var j = 0
+        while (i < left.length && j < right.length) {
+            if (left[i].isDigit() && right[j].isDigit()) {
+                val lEnd = digitRunEnd(left, i)
+                val rEnd = digitRunEnd(right, j)
+                val cmp = compareNumericRun(left.substring(i, lEnd), right.substring(j, rEnd))
+                if (cmp != 0) return cmp
+                i = lEnd
+                j = rEnd
+            } else {
+                val cmp = left[i].lowercaseChar().compareTo(right[j].lowercaseChar())
+                if (cmp != 0) return cmp
+                i++
+                j++
+            }
+        }
+        return left.length - i - (right.length - j)
+    }
+
+    /** Index one past the maximal digit run starting at [start] in [s]. */
+    private fun digitRunEnd(
+        s: String,
+        start: Int,
+    ): Int {
+        var i = start
+        while (i < s.length && s[i].isDigit()) i++
+        return i
+    }
+
+    /**
+     * Compares two digit runs by numeric value: fewer significant digits (after stripping leading
+     * zeros) is smaller; equal magnitudes fall back to raw width so `"01"` and `"1"` stay
+     * deterministically ordered.
+     */
+    private fun compareNumericRun(
+        left: String,
+        right: String,
+    ): Int {
+        val leftDigits = left.trimStart('0')
+        val rightDigits = right.trimStart('0')
+        if (leftDigits.length != rightDigits.length) return leftDigits.length - rightDigits.length
+        val magnitude = leftDigits.compareTo(rightDigits)
+        return if (magnitude != 0) magnitude else left.length - right.length
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapper.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapper.kt
@@ -4,6 +4,8 @@ package com.calypsan.listenup.server.services
 
 import com.calypsan.listenup.api.dto.ContributorRole
 import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileType
 import com.calypsan.listenup.api.sync.BookAudioFilePayload
 import com.calypsan.listenup.api.sync.BookChapterPayload
 import com.calypsan.listenup.api.sync.BookContributorPayload
@@ -71,7 +73,7 @@ class AnalyzedBookMapper(
         resolvedSeries: List<BookSeriesPayload>,
     ): BookSyncPayload {
         val candidate = analyzed.candidate
-        val inode = candidate.files.firstOrNull()?.inode
+        val inode = candidate.identityInode()
         // Sum the per-track durations (multi-file books); fall back to the book-level
         // embedded duration for single-file books, where TrackEntry.durationMs is null.
         val totalDuration =
@@ -235,3 +237,18 @@ class AnalyzedBookMapper(
             creditedAs = null,
         )
 }
+
+/**
+ * The inode that anchors a book's stable identity across rescans: the first
+ * AUDIO file's inode (the first file that both is audio and has a stable inode).
+ *
+ * Anchoring on audio — rather than `files.first()`, which can be a cover image
+ * that name-sorts ahead of the audio — keeps identity aligned with the
+ * [com.calypsan.listenup.server.scanner.pipeline.Differ]'s audio-inode move
+ * matching. Replacing or adding a non-audio file (a retag writing a fresh cover,
+ * a new `00-intro` sorted first) can no longer flip the anchor inode and re-mint
+ * the book's UUID, which would strand the user's positions, progress, shelves,
+ * and edits on the swept-away old row.
+ */
+internal fun CandidateBook.identityInode(): Long? =
+    files.firstOrNull { it.fileType == FileType.AUDIO && it.inode != null }?.inode

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -348,12 +348,24 @@ class BookPersister internal constructor(
         if (toPersist > 0 && lastTickAt != toPersist) emitPersistProgress(toPersist)
 
         if (result.scope is ScanScope.Full) {
-            // Sentinel guard: if ANY walked root failed to resolve to a live folder (folder soft-deleted
-            // mid-scan, or a stale bundle path), its books carry the "unknown" sentinel folder_id and are
-            // absent from every real folder's seen set — the sweep would then tombstone that folder's live
-            // books (the original library-wide corruption). Skip the sweep entirely and log loudly; the
-            // next clean Full scan reconciles genuine removals once every root resolves.
-            if (folderIdByRoot.values.any { it == UNKNOWN_FOLDER_ID }) {
+            // Reachability guard (A1): if the Scanner couldn't walk every configured root (a dropped
+            // NAS/SMB mount, a permission change), that folder walked empty and its live books are
+            // absent from the seen set — sweeping would tombstone every one of them. The Scanner marked
+            // the scan non-authoritative; skip the sweep entirely and log loudly. The next scan where
+            // every root is reachable reconciles genuine removals. This is the disk-reachability
+            // counterpart to the folder-row sentinel guard below.
+            if (!result.fullScanAuthoritative) {
+                log.error {
+                    "Skipping full-scan tombstone sweep for library ${libraryId.value}: the scan was " +
+                        "non-authoritative (a configured root was unreachable/unreadable and walked empty) " +
+                        "— sweeping would wrongly tombstone that folder's live books."
+                }
+            } else if (folderIdByRoot.values.any { it == UNKNOWN_FOLDER_ID }) {
+                // Sentinel guard: if ANY walked root failed to resolve to a live folder (folder soft-deleted
+                // mid-scan, or a stale bundle path), its books carry the "unknown" sentinel folder_id and are
+                // absent from every real folder's seen set — the sweep would then tombstone that folder's live
+                // books (the original library-wide corruption). Skip the sweep entirely and log loudly; the
+                // next clean Full scan reconciles genuine removals once every root resolves.
                 log.error {
                     "Skipping full-scan tombstone sweep for library ${libraryId.value}: a walked root did " +
                         "not resolve to a live folder (sentinel folder_id present) — sweeping would wrongly " +

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -579,9 +579,8 @@ class BookRepository(
             return write(existing).map { IngestOutcome(existing, wasNew = false) }
         }
 
-        analyzed.candidate.files
-            .firstOrNull()
-            ?.inode
+        analyzed.candidate
+            .identityInode()
             ?.let { inode ->
                 // The move hint is folder-scoped `(folder_id, inode)` — identity is anchored to the
                 // owning folder. Tradeoff: moving a book directory BETWEEN two folders of the same
@@ -821,12 +820,7 @@ class BookRepository(
         // Bulk existence: one IN-read for natural keys, one for inodes — replacing the per-book
         // findByPath/findByInode read transactions with two reads for the whole scan.
         val byPath = bookFinder.findExistingByPaths(folderId, valid.map { it.candidate.rootRelPath })
-        val inodes =
-            valid.mapNotNull {
-                it.candidate.files
-                    .firstOrNull()
-                    ?.inode
-            }
+        val inodes = valid.mapNotNull { it.candidate.identityInode() }
         val byInode = bookFinder.findExistingByInodes(folderId, inodes)
 
         // Resolve each book's stable BookId in memory from the bulk maps (natural key, then inode,
@@ -840,10 +834,7 @@ class BookRepository(
         val resolved =
             valid.map { analyzed ->
                 val rootRelPath = analyzed.candidate.rootRelPath
-                val inode =
-                    analyzed.candidate.files
-                        .firstOrNull()
-                        ?.inode
+                val inode = analyzed.candidate.identityInode()
                 val existing = byPath[rootRelPath] ?: inode?.let { byInode[it] }
                 Resolved(analyzed, existing ?: BookId(Uuid.random().toString()), isNew = existing == null)
             }
@@ -1274,7 +1265,11 @@ class BookRepository(
             // Genres: a separate, sequential pass over SQLDelight (idempotent, no revision bump).
             // The writer's synchronous junction queries auto-commit and the auto-create upsert runs
             // its own transaction — sequential after the book write, so no SQLITE_BUSY contention.
-            bookGenreWriter.processGenreStrings(bookId, analyzed.genres, now)
+            // Skip when GENRES is user-protected (hand-edited or applied via enrichment): a rescan's
+            // file-derived genres must not silently revert the curated set (A7).
+            if (merge?.preserveGenres != true) {
+                bookGenreWriter.processGenreStrings(bookId, analyzed.genres, now)
+            }
             bookTagWriter?.writeScanTags(bookId, analyzed.tags)
         }
         return result
@@ -1290,6 +1285,7 @@ class BookRepository(
         val payload: BookSyncPayload,
         val preserveContributors: Boolean,
         val preserveSeries: Boolean,
+        val preserveGenres: Boolean,
     )
 
     /**
@@ -1323,12 +1319,16 @@ class BookRepository(
                 title = kept(UserEditedField.TITLE, existing.title, incoming.title),
                 subtitle = kept(UserEditedField.SUBTITLE, existing.subtitle, incoming.subtitle),
                 description = kept(UserEditedField.DESCRIPTION, existing.description, incoming.description),
+                publisher = kept(UserEditedField.PUBLISHER, existing.publisher, incoming.publisher),
+                language = kept(UserEditedField.LANGUAGE, existing.language, incoming.language),
+                publishYear = kept(UserEditedField.PUBLISH_YEAR, existing.publishYear, incoming.publishYear),
                 userEditedFields = existing.userEditedFields + incoming.userEditedFields,
             )
         return UserEditMerge(
             payload = merged,
             preserveContributors = UserEditedField.CONTRIBUTORS in stillProtected,
             preserveSeries = UserEditedField.SERIES in stillProtected,
+            preserveGenres = UserEditedField.GENRES in stillProtected,
         )
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -65,6 +65,12 @@ private class PreparedBook(
     val genreIds: List<String>,
     val tags: List<String>,
     val extras: BookWriteExtras,
+    /**
+     * The `deleted_at` of the stored row this write is reviving, or null when the book is genuinely
+     * new or already live. Non-null only when re-ingesting a TOMBSTONED book — the write clears its
+     * `deleted_at`, so its cascade-tombstoned junctions must be revived (floored at this value).
+     */
+    val revivedFromDeletedAt: Long?,
 )
 
 /**
@@ -718,6 +724,16 @@ class BookRepository(
                     if (book.tags.isNotEmpty()) writer.writeScanTags(book.bookId, book.tags)
                 }
             }
+
+            // Scan revival cascade (A3): any book in this chunk that revived a tombstoned row must get
+            // its cascade-tombstoned junctions (tags/moods/collection memberships) revived too, floored
+            // at each book's own deleted_at. Grouped by floor so books removed together share one call.
+            // Post-commit, exactly like the tag pass above and the per-book path's cascade.
+            succeeded
+                .filter { it.revivedFromDeletedAt != null }
+                .groupBy({ it.revivedFromDeletedAt!! }, { it.bookId.value })
+                .forEach { (floor, ids) -> reviveBookJunctions(ids, floor) }
+
             onProgress(persisted + failed, failed)
         }
         return PersistResult(persisted = persisted, failed = failed, resolvedIds = resolvedIds)
@@ -895,6 +911,9 @@ class BookRepository(
                             preserveContributors = merge?.preserveContributors == true,
                             preserveSeries = merge?.preserveSeries == true,
                         ),
+                    // Non-null only when reviving a tombstoned row (skip is always false in that case,
+                    // so the write runs and clears deleted_at) — drives the A3 junction-revival cascade.
+                    revivedFromDeletedAt = existing?.deletedAt,
                 )
             }
         return PreparedBatch(prepared = prepared, prepareFailed = invalid.size)
@@ -981,6 +1000,29 @@ class BookRepository(
             if (linkedParents != null) orphanParentPurger.purgeOrphaned(linkedParents)
         }
         return result
+    }
+
+    /**
+     * Revives the junction rows (`book_tags` / `book_moods` / `collection_books`) for [bookIds] that
+     * were tombstoned at or after [cascadeFloor] — the same cascade [reviveByIds] runs for a folder
+     * re-add, reused by the scan revival paths.
+     *
+     * A scan re-ingest of a removed book revives the book ROW ([updateContent] clears `deleted_at`) but
+     * would otherwise leave its cascade-tombstoned junctions dead — so the book returned uncollected
+     * (invisible under the pure-union rule) with the user's tags/moods silently gone. [cascadeFloor] is
+     * the book's own `deleted_at`, so only junctions tombstoned BY that removal return; a membership the
+     * user removed manually earlier (an older tombstone) stays dead. A no-op when [bookIds] is empty;
+     * each repo opens its own transaction (the per-row substrate contract), run after the reviving book
+     * write commits.
+     */
+    private suspend fun reviveBookJunctions(
+        bookIds: List<String>,
+        cascadeFloor: Long,
+    ) {
+        if (bookIds.isEmpty()) return
+        bookTagRepository?.reviveAllForBooks(bookIds, cascadeFloor)
+        bookMoodRepository?.reviveAllForBooks(bookIds, cascadeFloor)
+        collectionBookRepository?.reviveAllForBooks(bookIds, cascadeFloor)
     }
 
     /**
@@ -1223,6 +1265,11 @@ class BookRepository(
                 }
             }
         if (result is AppResult.Success) {
+            // Scan revival cascade (A3): when this write revived a tombstoned row (existing.deletedAt
+            // was set, so the write cleared it via updateContent's deleted_at = NULL), restore the
+            // book's cascade-tombstoned junctions too — floored at its own deleted_at — so a transient
+            // remove→re-add never returns the book uncollected with its tags/moods lost.
+            existing?.deletedAt?.let { floor -> reviveBookJunctions(listOf(bookId.value), floor) }
             val now = clock.now().toEpochMilliseconds()
             // Genres: a separate, sequential pass over SQLDelight (idempotent, no revision bump).
             // The writer's synchronous junction queries auto-commit and the auto-create upsert runs

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/ApplicationBootstrapTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/ApplicationBootstrapTest.kt
@@ -222,6 +222,8 @@ private fun fakeBundle(library: Library): ScannerBundle {
     val fakeScannerPort =
         object : ScannerResultPort {
             override fun lastResult(): ScanResult? = null
+
+            override fun markSuperseded() = Unit
         }
     val coordinator =
         ScanCoordinator(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AdminSettingsServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AdminSettingsServiceImplTest.kt
@@ -323,6 +323,8 @@ private fun noOpOrchestrator(): ScanOrchestrator =
                 scanner =
                     object : ScannerResultPort {
                         override fun lastResult(): ScanResult? = null
+
+                        override fun markSuperseded() = Unit
                     },
                 coordinator = coordinator,
             )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/LibraryAdminServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/LibraryAdminServiceImplTest.kt
@@ -555,6 +555,8 @@ private fun fakeBundle(
     val fakeScannerPort =
         object : ScannerResultPort {
             override fun lastResult(): ScanResult? = null
+
+            override fun markSuperseded() = Unit
         }
     val coordinator =
         ScanCoordinator(
@@ -610,6 +612,8 @@ private fun recordingBundle(
     val scanner =
         object : ScannerResultPort {
             override fun lastResult(): ScanResult? = null
+
+            override fun markSuperseded() = Unit
         }
     val coordinator =
         ScanCoordinator(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MatchApplySelectionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MatchApplySelectionTest.kt
@@ -5,6 +5,11 @@ package com.calypsan.listenup.server.api
 import com.calypsan.listenup.api.dto.ContributorRole
 import com.calypsan.listenup.api.dto.MetadataApplySelection
 import com.calypsan.listenup.api.dto.MetadataBook
+import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.api.dto.scanner.TrackEntry
 import com.calypsan.listenup.api.dto.MetadataChapters
 import com.calypsan.listenup.api.dto.MetadataContributorRef
 import com.calypsan.listenup.api.dto.MetadataSeriesRef
@@ -413,6 +418,49 @@ class MatchApplySelectionTest :
             }
         }
 
+        test("enriched publisher/language/publishYear/genres survive a later rescan (A7)") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val contributors = ContributorRepository(sql, bus, registry)
+                val series = SeriesRepository(sql, bus, registry)
+                val genreRepo = GenreRepository(sql, bus, registry)
+                val books = BookRepository(sql, bus, registry, driver, contributors, series, genreRepo)
+                runTest {
+                    sql.seedGenre("g-fant", "Fantasy", "fantasy", "/fantasy")
+                    val oldAuthorId = contributors.resolveOrCreate("Old Author", sortName = null).value
+                    books.upsert(seedBook("b1", oldAuthorId), clientOpId = null).shouldBeInstanceOf<AppResult.Success<*>>()
+                    val a = applier(this@withSqlDatabase, genreRepo, books, contributors, series, fakeProvider(matchBook()))
+
+                    // Apply provider enrichment: publisher/language/publishYear + Fantasy genre.
+                    a
+                        .apply(BookId("b1"), "B0NEW", AudibleRegion.US, allButCover().copy(genres = setOf("Fantasy")))
+                        .shouldBeInstanceOf<AppResult.Success<*>>()
+
+                    // Rescan the same book (natural-key hit on folder+rootRelPath) with DIFFERENT
+                    // file-derived scalars and genres. Enriched provenance must win.
+                    books.resolveOrInsert(
+                        LibraryId("test-library"),
+                        FolderId("test-folder"),
+                        rescanFor(
+                            rootRelPath = "test/b1",
+                            publisher = "File Publisher",
+                            language = "german",
+                            publishYear = 1900,
+                            genres = listOf("Horror"),
+                        ),
+                    )
+
+                    val saved = books.findById(BookId("b1"))!!
+                    saved.publisher shouldBe "New Publisher"
+                    saved.language shouldBe "english"
+                    saved.publishYear shouldBe 2015
+                    saved.genres.map { it.name } shouldContainExactly listOf("Fantasy")
+                }
+            }
+        }
+
         test("non-empty but unresolvable authorAsins leaves existing authors untouched") {
             withSqlDatabase {
                 sql.seedTestLibraryAndFolder()
@@ -439,6 +487,39 @@ class MatchApplySelectionTest :
             }
         }
     })
+
+/**
+ * A minimal file-derived [AnalyzedBook] for a rescan of an existing book at [rootRelPath], with
+ * scalar/genre values that deliberately differ from any enrichment already applied — so a test can
+ * assert the enriched values survive the scan (A7).
+ */
+private fun rescanFor(
+    rootRelPath: String,
+    publisher: String?,
+    language: String?,
+    publishYear: Int?,
+    genres: List<String>,
+): AnalyzedBook {
+    val file =
+        FileEntry(
+            relPath = "$rootRelPath/01.m4b",
+            name = "01.m4b",
+            ext = "m4b",
+            size = 1024L,
+            mtimeMs = 0L,
+            inode = rootRelPath.hashCode().toLong(),
+            fileType = FileType.AUDIO,
+        )
+    return AnalyzedBook(
+        candidate = CandidateBook(rootRelPath = rootRelPath, isFile = false, files = listOf(file)),
+        title = "New Title",
+        publisher = publisher,
+        language = language,
+        publishedYear = publishYear,
+        genres = genres,
+        tracks = listOf(TrackEntry(file = file)),
+    )
+}
 
 @Suppress("LongParameterList")
 private fun ListenUpDatabase.seedGenre(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/CollectionMembershipRoutingRule.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/CollectionMembershipRoutingRule.kt
@@ -36,6 +36,9 @@ import io.kotest.matchers.collections.shouldBeEmpty
  *    tombstoned *entirely*, not re-homed between collections, so ALL_BOOKS exclusivity is moot.
  *  - `reviveByIds` — `BookRepository.reviveByIds`'s revival (`reviveAllForBooks`): restores the book's
  *    prior membership set verbatim (deletedAt-floored), so there is nothing to reconcile.
+ *  - `reviveBookJunctions` — `BookRepository`'s scan-revival helper (`reviveAllForBooks`): same verbatim,
+ *    deletedAt-floored restore as `reviveByIds` (only junctions tombstoned by the book's own removal
+ *    return), so the membership set is already consistent — nothing to reconcile.
  *  ( `deleteCollection` is NOT allowlisted — it matches `softDeleteAllForCollection` but already loops
  *    `reconcileSystemMembership` per affected book, so the reconcile filter clears it correctly. )
  */
@@ -78,6 +81,7 @@ class CollectionMembershipRoutingRule :
                 "writeSystemMembership",
                 "softDelete",
                 "reviveByIds",
+                "reviveBookJunctions",
             )
     }
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestratorTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestratorTest.kt
@@ -206,6 +206,34 @@ class ScanOrchestratorTest :
             }
         }
 
+        test("onFolderAdded supersedes the old scanner so an in-flight scan can't sweep the new folder") {
+            runTest {
+                val factory = FakeScannerFactory()
+                val orchestrator = orchestrator(factory, FakeWatcherSupervisor(), backgroundScope)
+                orchestrator.onLibraryAdded(testLib("lib-1", "/tmp/books"))
+                val firstScanner = factory.scanners.single()
+
+                orchestrator.onFolderAdded(LibraryId("lib-1"), LibraryFolderRef(FolderId("f-extra"), "/tmp/extras"))
+
+                // The pre-swap scanner is superseded; the new one is not.
+                firstScanner.superseded shouldBe true
+                factory.scanners.last().superseded shouldBe false
+            }
+        }
+
+        test("onFolderRemoved supersedes the old scanner so its in-flight scan drops its stale result") {
+            runTest {
+                val factory = FakeScannerFactory()
+                val orchestrator = orchestrator(factory, FakeWatcherSupervisor(), backgroundScope)
+                orchestrator.onLibraryAdded(testLib("lib-1", "/tmp/books"))
+                val firstScanner = factory.scanners.single()
+
+                orchestrator.onFolderRemoved(FolderId("lib-1-f-0"))
+
+                firstScanner.superseded shouldBe true
+            }
+        }
+
         test("scanFolder finds new folder after onFolderAdded updates the snapshot") {
             runTest {
                 val incrementalPaths = mutableListOf<Path>()
@@ -354,6 +382,9 @@ private class FakeScannerFactory(
     /** The most recently created [ScanCoordinator]. Useful for checking teardown. */
     var lastCoordinator: ScanCoordinator? = null
 
+    /** Every [FakeScanner] this factory has produced, in creation order. */
+    val scanners = mutableListOf<FakeScanner>()
+
     fun create(
         library: Library,
         scope: kotlinx.coroutines.CoroutineScope,
@@ -361,7 +392,7 @@ private class FakeScannerFactory(
         scannersCreated++
         librariesUsedForCreation += library
         val gate = if (gateQueue.isNotEmpty()) gateQueue.removeFirst() else null
-        val scanner = FakeScanner()
+        val scanner = FakeScanner().also { scanners += it }
         val coordinator =
             ScanCoordinator(
                 libraryId = library.id,
@@ -377,9 +408,16 @@ private class FakeScannerFactory(
     }
 }
 
-/** Minimal [ScannerResultPort] fake — always returns null for lastResult. */
+/** Minimal [ScannerResultPort] fake — always returns null for lastResult; records supersession. */
 private class FakeScanner : ScannerResultPort {
+    var superseded = false
+        private set
+
     override fun lastResult(): ScanResult? = null
+
+    override fun markSuperseded() {
+        superseded = true
+    }
 }
 
 private class FakeWatcherSupervisor : WatcherSupervisorPort {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScanResultBusBackpressureTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScanResultBusBackpressureTest.kt
@@ -1,0 +1,89 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanScope
+import com.calypsan.listenup.server.di.EventBusQualifiers
+import com.calypsan.listenup.server.di.scannerModule
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.koin.dsl.koinApplication
+import java.util.Collections
+
+/**
+ * Data-integrity regression coverage for finding A4: the scan-result bus silently discarded scan
+ * results under load.
+ *
+ * The bus was a `MutableSharedFlow(replay = 0, extraBufferCapacity = 8, onBufferOverflow = DROP_OLDEST)`.
+ * The producer (`Scanner.emit`) never suspends under DROP_OLDEST, so a burst of fast incremental scans
+ * (a bulk reorg) queued faster than `BookPersister` — with its heavy DB + cover I/O — could drain.
+ * Once more than 8 results were outstanding, the OLDEST was evicted: its Added/Modified never persisted,
+ * its Removed tombstones never applied, its Completed never fired — all silently.
+ *
+ * The seam must be non-lossy: back-pressure the scanner (suspend the producer) rather than drop.
+ * This test drives the REAL DI-provided bus with a deliberately slow consumer and asserts every
+ * emitted result is received.
+ */
+class ScanResultBusBackpressureTest :
+    FunSpec({
+
+        test("the scan-result bus delivers every result even when the consumer is far slower than the producer") {
+            val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val koin =
+                koinApplication { modules(scannerModule(applicationScope = appScope)) }.koin
+            val bus = koin.get<MutableSharedFlow<ScanResult>>(EventBusQualifiers.ScanResults)
+
+            val emitted = 200 // far more than any bounded buffer holds — forces real back-pressure
+            val received = Collections.synchronizedList(mutableListOf<String>())
+
+            runBlocking {
+                val consumer =
+                    launch(Dispatchers.Default) {
+                        bus.collect { result ->
+                            // Slow consumer — mimics BookPersister's heavy per-result DB + cover I/O.
+                            delay(5)
+                            received += result.correlationId
+                        }
+                    }
+                // Ensure the collector is subscribed before the producer starts emitting.
+                bus.subscriptionCount.first { it > 0 }
+
+                repeat(emitted) { i -> bus.emit(minimalResult("corr-$i")) }
+
+                // Give the consumer a bounded window to drain. A non-lossy seam back-pressured the
+                // producer, so all 50 are in flight and arrive; a lossy DROP_OLDEST seam stalls well
+                // short of 50 and the size assertion below fails with the dropped count.
+                val deadline = System.currentTimeMillis() + 5_000
+                while (received.size < emitted && System.currentTimeMillis() < deadline) delay(10)
+
+                consumer.cancel()
+            }
+
+            appScope.cancel()
+
+            // Every emitted result was delivered — none silently dropped.
+            received.size shouldBe emitted
+            received.toSet() shouldBe (0 until emitted).map { "corr-$it" }.toSet()
+        }
+    })
+
+private fun minimalResult(id: String): ScanResult =
+    ScanResult(
+        correlationId = id,
+        rootPath = "/lib",
+        books = emptyList(),
+        changes = emptyList(),
+        errors = emptyList(),
+        durationMs = 0L,
+        filesWalked = 0,
+        filesSkipped = 0,
+        scope = ScanScope.Full,
+    )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerIncrementalPartitionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerIncrementalPartitionTest.kt
@@ -1,0 +1,114 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
+import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import com.calypsan.listenup.server.testing.testLibrary
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path
+
+/**
+ * Data-integrity regression coverage for finding A2: a multi-folder incremental scan mass-tombstones
+ * books in OTHER folders.
+ *
+ * `Scanner.partitionBooksUnder` split the previous snapshot (which spans EVERY folder, each
+ * `rootRelPath` relative to its OWN folder) by string prefix alone. When the incremental's bookRoot
+ * equals its folder root, the prefix is empty and the predicate matched every book in the whole
+ * library — so every OTHER folder's book became "affected", went unmatched against the single-folder
+ * walk, and the Differ emitted `Removed` for it. The persister then tombstoned those books for real.
+ *
+ * The fix additionally filters on the book's stamped `folderRootPath`, so a book in a different folder
+ * is never dragged into another subtree's diff.
+ */
+class ScannerIncrementalPartitionTest :
+    FunSpec({
+
+        fun noOpParser(): EmbeddedMetadataParser = EmbeddedMetadataParser(detector = AudioFormatDetector(), parsers = emptyList())
+
+        test("an incremental scan under folder A's root does not mark folder B's books as Removed (empty-prefix case)") {
+            runTest {
+                audioLibrary("listenup-a2-folder-a-").use { folderA ->
+                    audioLibrary("listenup-a2-folder-b-").use { folderB ->
+                        folderA.book("Author A/Book A") { tracks(count = 1) }
+                        folderB.book("Author B/Book B") { tracks(count = 1) }
+
+                        val bus = MutableSharedFlow<ScanResult>(replay = 1)
+                        val scanner =
+                            Scanner(
+                                library =
+                                    testLibrary(
+                                        folders = listOf(folderA.root.toString(), folderB.root.toString()),
+                                    ),
+                                metadataReader = AbsMetadataReader(contractJson),
+                                embeddedMetadataParser = noOpParser(),
+                                eventBus = MutableSharedFlow<ScanEvent>(replay = 64, extraBufferCapacity = 64),
+                                scanResultBus = bus,
+                                correlationIdFactory = { "a2-corr" },
+                            )
+
+                        // Full scan populates lastResult with BOTH folders' books, each stamped with its
+                        // own folderRootPath.
+                        scanner.runFullScan()
+
+                        // Incremental over folder A's ROOT — bookRoot == folderRoot, so the buggy
+                        // prefix-only partition treated every book (including folder B's) as affected.
+                        scanner.runIncremental(Path(folderA.root.toString()))
+
+                        val incremental = bus.replayCache.last()
+                        val removed =
+                            incremental.changes
+                                .filterIsInstance<ChangeEventDto.Removed>()
+                                .map { it.rootRelPath }
+
+                        // Folder B's book must NOT be tombstoned by a folder-A incremental.
+                        removed shouldBe emptyList()
+                    }
+                }
+            }
+        }
+
+        test("folder B's book survives in the patched snapshot after a folder-A incremental") {
+            runTest {
+                audioLibrary("listenup-a2-keep-a-").use { folderA ->
+                    audioLibrary("listenup-a2-keep-b-").use { folderB ->
+                        folderA.book("Author A/Book A") { tracks(count = 1) }
+                        folderB.book("Author B/Book B") { tracks(count = 1) }
+
+                        val bus = MutableSharedFlow<ScanResult>(replay = 2)
+                        val scanner =
+                            Scanner(
+                                library =
+                                    testLibrary(
+                                        folders = listOf(folderA.root.toString(), folderB.root.toString()),
+                                    ),
+                                metadataReader = AbsMetadataReader(contractJson),
+                                embeddedMetadataParser = noOpParser(),
+                                eventBus = MutableSharedFlow<ScanEvent>(replay = 64, extraBufferCapacity = 64),
+                                scanResultBus = bus,
+                                correlationIdFactory = { "a2-keep-corr" },
+                            )
+
+                        scanner.runFullScan()
+                        scanner.runIncremental(Path(folderA.root.toString()))
+
+                        // The incremental result carries no Removed changes at all …
+                        bus.replayCache
+                            .last()
+                            .changes
+                            .filterIsInstance<ChangeEventDto.Removed>()
+                            .shouldBeEmpty()
+                    }
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
@@ -16,6 +16,7 @@ import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
 import com.calypsan.listenup.server.testing.testLibrary
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -216,6 +217,28 @@ class ScannerTest :
 
                     val result = bus.replayCache.first()
                     result.scope shouldBe ScanScope.Full
+                }
+            }
+        }
+
+        test("a superseded scanner does NOT publish its full-scan result to scanResultBus (A8)") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title") { tracks(count = 1) }
+                }.use { fixture ->
+                    val bus = MutableSharedFlow<ScanResult>(replay = 1)
+                    val (scanner, _) = newScanner(fixture, scanResultBus = bus)
+
+                    // The bundle was rebuilt under this scanner (a folder was added): a scan that was
+                    // already in flight walked a stale folder set. Its Full result must be dropped, or
+                    // BookPersister would sweep the newly-added folder's books.
+                    scanner.markSuperseded()
+                    val result = scanner.runFullScan()
+
+                    // The scan still computes a result (returned to any synchronous caller) …
+                    result.scope shouldBe ScanScope.Full
+                    // … but it must NOT reach the persister bus.
+                    bus.replayCache.shouldBeEmpty()
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerUnreachableRootTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerUnreachableRootTest.kt
@@ -1,0 +1,91 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.error.ScanError
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
+import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import com.calypsan.listenup.server.testing.testLibrary
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Data-integrity regression coverage for finding A1: an unreachable or unreadable configured folder
+ * root (a dropped NAS/SMB mount, a permission change) makes [com.calypsan.listenup.server.scanner.pipeline.Walker]
+ * yield an empty walk SILENTLY. If the resulting full scan were treated as authoritative, the
+ * tombstone sweep would soft-delete every live book under that folder.
+ *
+ * The Scanner must detect an unreachable root before walking, surface a warning, skip that folder,
+ * and mark the whole full scan NON-AUTHORITATIVE so `BookPersister` skips the sweep. A reachable
+ * (even genuinely empty) root stays authoritative — an emptied library is a legitimate sweep.
+ */
+class ScannerUnreachableRootTest :
+    FunSpec({
+
+        fun noOpParser(): EmbeddedMetadataParser = EmbeddedMetadataParser(detector = AudioFormatDetector(), parsers = emptyList())
+
+        test("a full scan over an unreachable folder root skips it, surfaces a warning, and is non-authoritative") {
+            runTest {
+                audioLibrary("listenup-a1-reachable-").use { reachable ->
+                    reachable.book("Author/Book") { tracks(count = 1) }
+                    // A configured root that does not exist on disk — the dropped-mount / bad-path case.
+                    val missingRoot = reachable.root.resolve("this-root-was-unmounted").toString()
+
+                    val scanner =
+                        Scanner(
+                            library = testLibrary(folders = listOf(reachable.root.toString(), missingRoot)),
+                            metadataReader = AbsMetadataReader(contractJson),
+                            embeddedMetadataParser = noOpParser(),
+                            eventBus = MutableSharedFlow(replay = 64, extraBufferCapacity = 64),
+                            scanResultBus = MutableSharedFlow<ScanResult>(replay = 1),
+                            correlationIdFactory = { "a1-corr" },
+                        )
+
+                    val result = scanner.runFullScan()
+
+                    // The reachable folder's book is still scanned.
+                    result.books.map { it.candidate.rootRelPath } shouldContainExactly listOf("Author/Book")
+
+                    // The unreachable root is surfaced as a typed warning naming that exact path
+                    // (honest over silent) — not swallowed.
+                    val err = result.errors.filterIsInstance<ScanError.LibraryPathNotFound>().single()
+                    err.path shouldBe missingRoot
+
+                    // The full scan is NON-AUTHORITATIVE, so BookPersister must skip the tombstone sweep
+                    // (proven separately in BookPersisterTest). This is the data-loss guard.
+                    result.fullScanAuthoritative shouldBe false
+                }
+            }
+        }
+
+        test("a full scan over a reachable but empty root stays authoritative (an emptied library is a legitimate sweep)") {
+            runTest {
+                audioLibrary("listenup-a1-empty-").use { empty ->
+                    // No books written — the folder is present and readable but contains nothing.
+                    val scanner =
+                        Scanner(
+                            library = testLibrary(folders = listOf(empty.root.toString())),
+                            metadataReader = AbsMetadataReader(contractJson),
+                            embeddedMetadataParser = noOpParser(),
+                            eventBus = MutableSharedFlow(replay = 64, extraBufferCapacity = 64),
+                            scanResultBus = MutableSharedFlow<ScanResult>(replay = 1),
+                            correlationIdFactory = { "a1-empty-corr" },
+                        )
+
+                    val result = scanner.runFullScan()
+
+                    result.books.shouldBeEmpty()
+                    // A reachable root — the sweep is safe; the scan stays authoritative.
+                    result.fullScanAuthoritative shouldBe true
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInferenceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInferenceTest.kt
@@ -95,9 +95,26 @@ class TrackInferenceTest :
                 TrackInfo(trackNumber = 9999, trackSource = TrackNumberSource.FILENAME)
         }
 
-        test("ignores 5-digit numbers (regex bounded 1-4 digits)") {
-            // 12345 contains "1234" as the first 4-digit match
-            TrackInference.infer("12345.mp3", null) shouldBe
-                TrackInfo(trackNumber = 1234, trackSource = TrackNumberSource.FILENAME)
+        test("ignores 5-digit numbers (a long numeric blob is not a track number)") {
+            // A complete 5-digit run is not a track — it is skipped entirely,
+            // not truncated to a 4-digit prefix.
+            TrackInference.infer("12345.mp3", null) shouldBe TrackInfo()
+        }
+
+        test("prefers the last digit run over a leading year-like token") {
+            // "1984 - 12.mp3": leading 1984 is the book's title/year, 12 is the track.
+            TrackInference.infer("1984 - 12.mp3", null) shouldBe
+                TrackInfo(trackNumber = 12, trackSource = TrackNumberSource.FILENAME)
+        }
+
+        test("single leading NN prefix still infers as the track") {
+            // When "NN - Title" is the only digit run, last == first.
+            TrackInference.infer("1984 - 1.mp3", null) shouldBe
+                TrackInfo(trackNumber = 1, trackSource = TrackNumberSource.FILENAME)
+        }
+
+        test("word-number filenames yield no track (handled by natural sort tiebreak)") {
+            TrackInference.infer("Part One.mp3", null) shouldBe TrackInfo()
+            TrackInference.infer("Part Ten.mp3", null) shouldBe TrackInfo()
         }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerTrackOrderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerTrackOrderTest.kt
@@ -175,6 +175,83 @@ class AnalyzerTrackOrderTest :
                 }
             }
         }
+
+        test("untagged year-prefixed files order 1, 2, 10 (not lexicographic 1, 10, 2)") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/1984"
+                    val names = listOf("1984 - 1.mp3", "1984 - 2.mp3", "1984 - 10.mp3")
+                    val entries =
+                        names.map { name ->
+                            val bytes =
+                                buildMp3File {
+                                    id3v2(version = 4) {}
+                                    mpegFrames(durationSeconds = 1)
+                                }
+                            val p = fixture.root.writeAudio("$rel/$name", bytes)
+                            trackEntry("$rel/$name", Files.size(p))
+                        }
+                    // Provide files in a deliberately jumbled order.
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files = listOf(entries[2], entries[0], entries[1]),
+                        )
+
+                    val book =
+                        Analyzer(Path(fixture.root.toString()), metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.tracks.map { it.file.name } shouldBe
+                        listOf("1984 - 1.mp3", "1984 - 2.mp3", "1984 - 10.mp3")
+                    book.tracks.map { it.trackNumber } shouldBe listOf(1, 2, 10)
+                }
+            }
+        }
+
+        test("a disc-less file sorts after CD1/CD2 disc folders") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Boxset"
+                    // bonus.mp3 lives at the book root (no disc signal); CD1/CD2 files
+                    // carry a folder disc. The bonus file must not jump ahead of disc 1.
+                    val mk = {
+                        buildMp3File {
+                            id3v2(version = 4) {}
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    }
+                    val bonus = fixture.root.writeAudio("$rel/bonus.mp3", mk())
+                    val cd1 = fixture.root.writeAudio("$rel/CD1/01.mp3", mk())
+                    val cd2 = fixture.root.writeAudio("$rel/CD2/01.mp3", mk())
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    trackEntry("$rel/bonus.mp3", Files.size(bonus)),
+                                    trackEntry("$rel/CD1/01.mp3", Files.size(cd1)),
+                                    trackEntry("$rel/CD2/01.mp3", Files.size(cd2)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(Path(fixture.root.toString()), metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.tracks.map { it.file.name } shouldBe listOf("01.mp3", "01.mp3", "bonus.mp3")
+                    book.tracks.map { it.discNumber } shouldBe listOf(1, 2, null)
+                }
+            }
+        }
     })
 
 private fun trackEntry(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/DifferTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/DifferTest.kt
@@ -70,6 +70,28 @@ class DifferTest :
             }
         }
 
+        test("two folders sharing a rootRelPath don't alias — removing one emits Removed for the right folder") {
+            runTest {
+                // Both folders hold a book at the SAME relative path but with distinct files/inodes.
+                val inFolderA = book("Author/Book", inode = 1).copy(folderRootPath = "/srv/audio/a")
+                val inFolderB = book("Author/Book", inode = 2).copy(folderRootPath = "/srv/audio/b")
+
+                // Rescan sees only folder A's book; folder B's vanished.
+                val events =
+                    differ
+                        .diff(
+                            listOf(inFolderA).asFlow(),
+                            previous = listOf(inFolderA, inFolderB),
+                        ).toList()
+
+                // Folder B's removal must NOT be masked by folder A's same-relpath book, and folder A's
+                // unchanged book must NOT be spuriously reported as Modified (matched to B's twin).
+                val removed = events.single().shouldBeInstanceOf<ChangeEventDto.Removed>()
+                removed.rootRelPath shouldBe "Author/Book"
+                removed.folderRootPath shouldBe "/srv/audio/b"
+            }
+        }
+
         test("a content change at the same path emits Modified") {
             runTest {
                 val before = book("Author/Title", inode = 1, trackCount = 3)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/ScanIntegrityHelpersTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/ScanIntegrityHelpersTest.kt
@@ -1,0 +1,96 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.domain.embeddedmeta.Chapter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Duration-integrity and embedded-chapter-clamp helpers (A9). A book that yields no usable duration,
+ * or a multi-file book missing a track length, must be flagged for the operator instead of ingesting
+ * silently; embedded chapters that overrun the parsed duration must be clamped or dropped so a
+ * mistagged file can't push later chapters off the end of the book.
+ */
+class ScanIntegrityHelpersTest :
+    FunSpec({
+
+        context("durationScanWarning") {
+            test("no audio files → no warning") {
+                durationScanWarning(bookDurationMs = 0L, trackDurations = emptyList()) shouldBe false
+            }
+
+            test("single-file book with a real duration → no warning") {
+                // Single-file books leave TrackEntry.durationMs null; the book duration comes from embedded.
+                durationScanWarning(bookDurationMs = 1_000L, trackDurations = listOf(null)) shouldBe false
+            }
+
+            test("single-file book that parsed to zero duration → warning") {
+                durationScanWarning(bookDurationMs = 0L, trackDurations = listOf(null)) shouldBe true
+            }
+
+            test("multi-file book with every track length present → no warning") {
+                durationScanWarning(bookDurationMs = 3_000L, trackDurations = listOf(1_000L, 2_000L)) shouldBe false
+            }
+
+            test("multi-file book missing a middle track's duration → warning") {
+                durationScanWarning(bookDurationMs = 3_000L, trackDurations = listOf(1_000L, null, 2_000L)) shouldBe true
+            }
+
+            test("multi-file book with a zero-length track → warning") {
+                durationScanWarning(bookDurationMs = 3_000L, trackDurations = listOf(1_000L, 0L, 2_000L)) shouldBe true
+            }
+        }
+
+        context("groupingScanWarning") {
+            test("single format, single album → no warning") {
+                groupingScanWarning(trackExtensions = listOf("mp3", "mp3"), distinctAlbumTags = 1) shouldBe false
+            }
+
+            test("mixed m4b + mp3 formats in one book → warning") {
+                groupingScanWarning(trackExtensions = listOf("m4b", "mp3"), distinctAlbumTags = 1) shouldBe true
+            }
+
+            test("two distinct album tags in one candidate → warning") {
+                groupingScanWarning(trackExtensions = listOf("mp3", "mp3"), distinctAlbumTags = 2) shouldBe true
+            }
+
+            test("case-insensitive format comparison — MP3 and mp3 are one format") {
+                groupingScanWarning(trackExtensions = listOf("MP3", "mp3"), distinctAlbumTags = 1) shouldBe false
+            }
+        }
+
+        context("clampEmbeddedChapters") {
+            fun ch(
+                index: Int,
+                start: Long,
+                end: Long,
+            ) = Chapter(index = index, title = "Ch $index", startMs = start, endMs = end)
+
+            test("unknown duration passes chapters through unchanged") {
+                val chapters = listOf(ch(1, 0, 1_000), ch(2, 1_000, 5_000))
+                clampEmbeddedChapters(chapters, durationMs = null) shouldBe chapters
+                clampEmbeddedChapters(chapters, durationMs = 0L) shouldBe chapters
+            }
+
+            test("drops a chapter that starts at or past EOF and re-indexes survivors") {
+                val chapters = listOf(ch(1, 0, 1_000), ch(2, 2_000, 3_000))
+                clampEmbeddedChapters(chapters, durationMs = 1_500L) shouldBe listOf(ch(1, 0, 1_000))
+            }
+
+            test("clamps a trailing chapter whose end overruns EOF") {
+                val chapters = listOf(ch(1, 0, 2_000))
+                clampEmbeddedChapters(chapters, durationMs = 1_500L) shouldBe listOf(ch(1, 0, 1_500))
+            }
+
+            test("drops an impossible negative-start chapter and re-indexes the survivor") {
+                val chapters = listOf(ch(1, -100, 500), ch(2, 500, 900))
+                // The survivor keeps its title but is re-indexed to 1.
+                clampEmbeddedChapters(chapters, durationMs = 1_000L) shouldBe
+                    listOf(Chapter(index = 1, title = "Ch 2", startMs = 500, endMs = 900))
+            }
+
+            test("drops a structurally inverted chapter (end before start) even with no duration bound") {
+                val chapters = listOf(ch(1, 0, 1_000), ch(2, 5_000, 2_000))
+                clampEmbeddedChapters(chapters, durationMs = null) shouldBe listOf(ch(1, 0, 1_000))
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookIdentityInodeAnchorTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookIdentityInodeAnchorTest.kt
@@ -1,0 +1,136 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.api.dto.scanner.TrackEntry
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Book identity must anchor on the first AUDIO file's inode, not the first file
+ * of any type. A cover image (`AlbumArt.jpg`) name-sorts ahead of the audio, so
+ * anchoring on `files.first()` let a cover replacement + folder rename re-mint
+ * the book UUID and sweep away the old row — losing the user's positions,
+ * progress, shelves, and edits. The Differ already matches moves on audio-file
+ * inodes; identity must agree with it.
+ */
+class BookIdentityInodeAnchorTest :
+    FunSpec({
+
+        test("cover replacement + folder rename keeps the same book UUID (audio inode unchanged)") {
+            withSqlDatabase {
+                val (repo, registry) = identityRepository(sql, driver)
+                runTest {
+                    val libId = registry.currentLibrary()
+
+                    // Initial scan: a cover image (inode 100) sorts before the audio (inode 200).
+                    val firstScan =
+                        bookWith(
+                            rootRelPath = "Sanderson/Mistborn",
+                            coverInode = 100L,
+                            audioInode = 200L,
+                        )
+                    val originalId = repo.resolveOrInsert(libId, IDENTITY_FOLDER, firstScan).resolved()
+
+                    // Rescan: folder renamed (path miss), cover replaced (new inode 101),
+                    // audio file unchanged (still inode 200).
+                    val rescan =
+                        bookWith(
+                            rootRelPath = "Sanderson/Mistborn - The Final Empire",
+                            coverInode = 101L,
+                            audioInode = 200L,
+                        )
+                    val rescanOutcome = repo.resolveOrInsert(libId, IDENTITY_FOLDER, rescan)
+
+                    // Same book resolved — not a fresh UUID, old row not swept.
+                    when (rescanOutcome) {
+                        is AppResult.Success -> {
+                            rescanOutcome.data.bookId shouldBe originalId
+                            rescanOutcome.data.wasNew shouldBe false
+                        }
+
+                        is AppResult.Failure -> {
+                            error("rescan failed: ${rescanOutcome.error.message}")
+                        }
+                    }
+                    // The renamed path is now the book's path — the old one is gone (moved, not duplicated).
+                    repo.findById(originalId)!!.rootRelPath shouldBe "Sanderson/Mistborn - The Final Empire"
+                }
+            }
+        }
+    })
+
+private val IDENTITY_FOLDER = FolderId("identity-folder")
+
+private fun AppResult<IngestOutcome>.resolved(): BookId =
+    when (this) {
+        is AppResult.Success -> data.bookId
+        is AppResult.Failure -> error("resolveOrInsert failed: ${error.message}")
+    }
+
+private fun bookWith(
+    rootRelPath: String,
+    coverInode: Long,
+    audioInode: Long,
+): AnalyzedBook {
+    // Cover file name-sorts before the audio file, mirroring the Walker's name-sorted order.
+    val cover =
+        FileEntry(
+            relPath = "$rootRelPath/AlbumArt.jpg",
+            name = "AlbumArt.jpg",
+            ext = "jpg",
+            size = 2048L,
+            mtimeMs = 0L,
+            inode = coverInode,
+            fileType = FileType.IMAGE,
+        )
+    val audio =
+        FileEntry(
+            relPath = "$rootRelPath/Book.m4b",
+            name = "Book.m4b",
+            ext = "m4b",
+            size = 4096L,
+            mtimeMs = 0L,
+            inode = audioInode,
+            fileType = FileType.AUDIO,
+        )
+    return AnalyzedBook(
+        candidate = CandidateBook(rootRelPath = rootRelPath, isFile = false, files = listOf(cover, audio)),
+        title = rootRelPath.substringAfterLast('/'),
+        tracks = listOf(TrackEntry(file = audio)),
+    )
+}
+
+private fun identityRepository(
+    sql: ListenUpDatabase,
+    driver: app.cash.sqldelight.db.SqlDriver,
+): Pair<BookRepository, LibraryRegistry> {
+    val registry = LibraryRegistry(sql)
+    val bus = ChangeBus()
+    val syncRegistry = SyncRegistry()
+    val contributorRepo = ContributorRepository(sql, bus, syncRegistry)
+    val seriesRepo = SeriesRepository(sql, bus, syncRegistry)
+    val repo =
+        BookRepository(
+            db = sql,
+            driver = driver,
+            bus = bus,
+            registry = syncRegistry,
+            contributorRepository = contributorRepo,
+            seriesRepository = seriesRepo,
+            genreRepository = GenreRepository(sql, bus, syncRegistry),
+        )
+    return repo to registry
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -672,6 +672,32 @@ class BookPersisterTest :
             }
         }
 
+        test("full scan skips the tombstone sweep when the scan is non-authoritative (an unreachable root walked empty)") {
+            withSqlDatabase {
+                runTest {
+                    val fake = FakeBookIngest()
+                    val persister = persister(fake, scope = this)
+
+                    // A1: a configured root was unreachable at scan time, so the Scanner marked the full
+                    // scan non-authoritative. Its book set is missing that folder's books entirely —
+                    // sweeping would tombstone every live book under the dropped folder. The sweep must
+                    // be skipped even though scope == Full and every resolved root is a real folder.
+                    persister.persist(
+                        scanResult(
+                            books = listOf(analyzedBook("a")),
+                            changes = listOf(ChangeEventDto.Added(analyzedBook("a"))),
+                            scope = ScanScope.Full,
+                            fullScanAuthoritative = false,
+                        ),
+                    )
+
+                    // The book still persists — only the destructive sweep is suppressed.
+                    fake.resolved shouldContainExactly listOf("a")
+                    fake.softDeleteAbsentByPathsCalls.shouldBeEmpty()
+                }
+            }
+        }
+
         test("an escaped exception is contained; the rest still process") {
             withSqlDatabase {
                 runTest {
@@ -892,6 +918,7 @@ internal fun scanResult(
     changes: List<ChangeEventDto>,
     scope: ScanScope,
     rootPath: String = "/lib",
+    fullScanAuthoritative: Boolean = true,
 ): ScanResult =
     ScanResult(
         correlationId = "c",
@@ -903,6 +930,7 @@ internal fun scanResult(
         filesWalked = 0,
         filesSkipped = 0,
         scope = scope,
+        fullScanAuthoritative = fullScanAuthoritative,
     )
 
 /** Builds a minimal [AnalyzedBook] anchored at [rootRelPath] with one audio file. */

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryScanRevivalCascadeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryScanRevivalCascadeTest.kt
@@ -1,0 +1,221 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.api.dto.scanner.TrackEntry
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.BookMoodSyncPayload
+import com.calypsan.listenup.api.sync.BookTagSyncPayload
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.Mood
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.BookMoodRepository
+import com.calypsan.listenup.server.sync.BookTagRepository
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.MoodRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.sync.TagRepository
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Data-integrity regression coverage for finding A3: a transient Removed→re-Added cycle (the
+ * amplifier that turns an A1/A2 flicker into durable loss).
+ *
+ * `softDelete` cascade-tombstones a book's `book_tags` / `book_moods` / `collection_books` junctions.
+ * A scan re-ingest revives the book ROW (`updateContent` sets `deleted_at = NULL`) but historically
+ * left those junctions tombstoned — so the book came back UNCOLLECTED (invisible under the pure-union
+ * visibility rule) with the user's tags and moods silently gone. Both scan revival paths
+ * (`resolveOrInsert` single, `resolveOrInsertAll` batch) must run the same junction-revival cascade
+ * that `reviveByIds` runs, floored at the book's own `deleted_at`.
+ */
+class BookRepositoryScanRevivalCascadeTest :
+    FunSpec({
+
+        test("re-ingesting a tombstoned book via the scan single path revives its tags, moods, and collection membership") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                seedCollection(sql)
+                runTest {
+                    val h = harness(sql, driver)
+                    val libId = LibraryId("test-library")
+                    val analyzed = analyzedFor("Author/Book", inode = 42L)
+
+                    // Ingest, then attach a tag + mood + collection membership.
+                    val bookId = h.repo.resolveOrInsert(libId, FOLDER, analyzed).bookId()
+                    h.attachJunctions(bookId)
+
+                    // Transient removal (tombstones the book + cascades its junctions).
+                    h.repo.softDelete(bookId, clientOpId = null)
+                    h.assertJunctionsDead()
+
+                    // Re-ingest the SAME book via the scan single path — the row revives.
+                    h.repo.resolveOrInsert(libId, FOLDER, analyzed).bookId()
+
+                    // The junctions must return with it — not be left tombstoned.
+                    h.assertJunctionsLive(bookId)
+                }
+            }
+        }
+
+        test("re-ingesting a tombstoned book via the scan BATCH path revives its tags, moods, and collection membership") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                seedCollection(sql)
+                runTest {
+                    val h = harness(sql, driver)
+                    val libId = LibraryId("test-library")
+                    val analyzed = analyzedFor("Author/Batch Book", inode = 77L)
+
+                    val insert =
+                        h.repo.resolveOrInsertAll(
+                            libraryId = libId,
+                            folderId = FOLDER,
+                            books = listOf(analyzed),
+                            coversByBook = emptyMap(),
+                            systemCollectionId = null,
+                            identityMaps = ScanIdentityMaps(),
+                        ) { _, _ -> }
+                    val bookId = insert.resolvedIds.single()
+                    h.attachJunctions(bookId)
+
+                    h.repo.softDelete(bookId, clientOpId = null)
+                    h.assertJunctionsDead()
+
+                    // Re-ingest via the production scan path (BookPersister uses resolveOrInsertAll).
+                    h.repo.resolveOrInsertAll(
+                        libraryId = libId,
+                        folderId = FOLDER,
+                        books = listOf(analyzed),
+                        coversByBook = emptyMap(),
+                        systemCollectionId = null,
+                        identityMaps = ScanIdentityMaps(),
+                    ) { _, _ -> }
+
+                    h.assertJunctionsLive(bookId)
+                }
+            }
+        }
+    })
+
+private val FOLDER = FolderId("test-folder")
+
+private fun AppResult<IngestOutcome>.bookId(): BookId =
+    when (this) {
+        is AppResult.Success -> data.bookId
+        is AppResult.Failure -> error("resolveOrInsert failed: ${error.message}")
+    }
+
+/** Seeds a NORMAL collection `c1` in `test-library` so a membership can be attached. */
+private fun seedCollection(sql: ListenUpDatabase) {
+    val now = System.currentTimeMillis()
+    sql.collectionsQueries.insert(
+        id = "c1",
+        library_id = "test-library",
+        owner_id = "owner1",
+        name = "Faves",
+        type = "NORMAL",
+        created_at = now,
+        updated_at = now,
+        revision = 0L,
+        deleted_at = null,
+        client_op_id = null,
+    )
+}
+
+private class RevivalHarness(
+    val repo: BookRepository,
+    val tagRepo: TagRepository,
+    val bookTagRepo: BookTagRepository,
+    val moodRepo: MoodRepository,
+    val bookMoodRepo: BookMoodRepository,
+    val collectionBookRepo: CollectionBookRepository,
+) {
+    suspend fun attachJunctions(bookId: BookId) {
+        val id = bookId.value
+        tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
+        bookTagRepo.upsert(BookTagSyncPayload(bookId = id, tagId = "t1", createdAt = 1000L, revision = 0L))
+        moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
+        bookMoodRepo.upsert(BookMoodSyncPayload(bookId = id, moodId = "m1", createdAt = 1000L, revision = 0L))
+        collectionBookRepo.upsert(CollectionBookSyncPayload(collectionId = "c1", bookId = id, createdAt = 1000L, revision = 0L))
+        check(bookTagRepo.findAllForBook(id).size == 1)
+        check(bookMoodRepo.findAllForBook(id).size == 1)
+        check(collectionBookRepo.findBookIdsForCollection("c1") == listOf(id))
+    }
+
+    suspend fun assertJunctionsDead() {
+        // After softDelete's cascade, live-row reads return nothing.
+        collectionBookRepo.findBookIdsForCollection("c1").shouldBeEmpty()
+    }
+
+    suspend fun assertJunctionsLive(bookId: BookId) {
+        val id = bookId.value
+        bookTagRepo.findAllForBook(id).shouldHaveSize(1)
+        bookMoodRepo.findAllForBook(id).shouldHaveSize(1)
+        collectionBookRepo.findBookIdsForCollection("c1").shouldContainExactly(id)
+    }
+}
+
+private fun harness(
+    sql: ListenUpDatabase,
+    driver: app.cash.sqldelight.db.SqlDriver,
+): RevivalHarness {
+    val bus = ChangeBus()
+    val syncRegistry = SyncRegistry()
+    val tagRepo = TagRepository(db = sql, bus = bus, registry = syncRegistry)
+    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = syncRegistry)
+    val moodRepo = MoodRepository(db = sql, bus = bus, registry = syncRegistry)
+    val bookMoodRepo = BookMoodRepository(db = sql, bus = bus, registry = syncRegistry)
+    val collectionBookRepo = CollectionBookRepository(db = sql, bus = bus, registry = syncRegistry, driver = driver)
+    val repo =
+        BookRepository(
+            db = sql,
+            driver = driver,
+            bus = bus,
+            registry = syncRegistry,
+            contributorRepository = ContributorRepository(sql, bus, syncRegistry),
+            seriesRepository = SeriesRepository(sql, bus, syncRegistry),
+            genreRepository = GenreRepository(sql, bus, syncRegistry),
+            collectionBookRepository = collectionBookRepo,
+            tagRepository = tagRepo,
+            bookTagRepository = bookTagRepo,
+            bookMoodRepository = bookMoodRepo,
+        )
+    return RevivalHarness(repo, tagRepo, bookTagRepo, moodRepo, bookMoodRepo, collectionBookRepo)
+}
+
+private fun analyzedFor(
+    rootRelPath: String,
+    inode: Long?,
+): AnalyzedBook {
+    val file =
+        FileEntry(
+            relPath = "$rootRelPath/01.m4b",
+            name = "01.m4b",
+            ext = "m4b",
+            size = 1024L,
+            mtimeMs = 0L,
+            inode = inode,
+            fileType = FileType.AUDIO,
+        )
+    val candidate = CandidateBook(rootRelPath = rootRelPath, isFile = false, files = listOf(file))
+    return AnalyzedBook(
+        candidate = candidate,
+        title = rootRelPath.substringAfterLast('/'),
+        tracks = listOf(TrackEntry(file = file)),
+    )
+}


### PR DESCRIPTION
Fixes the confirmed findings from a Fable adversarial audit of the scanner / library-ingest pipeline. These protect the user's library and their edits/positions/shelves against silent data-loss and corruption on automated rescans. All fixes are strict-TDD (red→green), server-side.

## 🔴 Critical — mass data-loss on automated rescans
- **A1** — an **unreachable folder root** (NAS/SMB mount dropped, permission change) during a full scan walked zero files and **soft-deleted the whole folder's library** (cascading to tags/moods/collections) — fired by the *periodic* rescan with no human in the loop. Now: each root is reachability-stat'd first; an unreachable root marks the scan non-authoritative and **skips the tombstone sweep** (a reachable-but-empty root still sweeps legitimately). Surfaces a typed `ScanError.LibraryPathNotFound`.
- **A2** — a **multi-folder incremental scan mass-tombstoned books in *other* folders** (`partitionBooksUnder` filtered by path prefix only; an empty prefix matched the entire library). Now scoped by `folderRootPath`.

## 🟠 High
- **A3** — scan revival restored the book row but **not its cascaded tag/mood/collection tombstones** → a transient Removed→re-Added cycle permanently stripped curation. Now the update-path revival runs the same junction-revival cascade, floored at the book's own `deleted_at`.
- **A4** — `scanResultBus` used `DROP_OLDEST(8)`, so under a bulk reorg **books were scanned but silently never persisted**. Now `BufferOverflow.SUSPEND` (back-pressure the scanner into the persister's pace).
- **A5** — **file ordering** used a lexicographic tiebreak (`10.mp3` before `2.mp3`) + first-digit track inference (a leading year became the track number) → silent whole-book order corruption. Now: natural numeric-aware comparator, prefer the *last* digit run, null-disc sorts after known discs.
- **A6** — book **identity anchored on the first file of *any* type's inode** (a cover image), disagreeing with the Differ's audio-inode match → retag-that-replaces-the-cover + folder-rename re-minted the UUID and **stranded positions/shelves/edits**. Now anchored on the first *audio* inode.

## 🟡 Medium
- **A7** — rescans **clobbered enrichment** (publisher/language/publishYear/genres had no provenance). Extended `UserEditedField`; those fields + genres now survive a rescan.
- **A8** — a folder add/remove mid-scan could run two full scans and let a **stale sweep tombstone the new folder**. Now the superseded scan's result is dropped before it reaches the persister.
- **A9** — corrupt/unsupported audio ingested with **duration 0, silently trusted** (shifting later files' offsets), and embedded chapters were unclamped. Now a per-book warning fires; structurally-impossible chapters are dropped, EOF-clamped for single-file books.
- **A10** — mixed-format (m4b+mp3) / multi-album folders now emit a **scan warning** (no grouping change).
- **A11** — disc-regex aligned; `Mp3Parser` catches a malformed frame as `ParseError` (ingests with a warning instead of dropping the book); fingerprint cache keyed by `(folder, path)` to kill cross-folder aliasing.

**Deferred (deliberate):** `restart` re-parsing the whole library on boot — low-value/high-cost as a point fix; it's subsumed by the planned "diff against a DB projection" refactor (R1 in the follow-up roadmap). See the holistic scanner analysis for the structural roadmap that dissolves this whole bug class.

Verified: `:contract:jvmTest` + the scanner `:server:jvmTest` suite (scoped to avoid the local mDNS multicast crash) + `spotlessCheck detekt` all green.
