### PR TITLE
🔥 feat: Campfire is backgroundable — minimize + play-over-campfire guard (B1+B3)

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/calypsan/listenup/gradle/SwiftExportSourcePatcher.kt
+++ b/build-logic/convention/src/main/kotlin/com/calypsan/listenup/gradle/SwiftExportSourcePatcher.kt
@@ -358,6 +358,7 @@ object SwiftExportSourcePatcher {
             "com.calypsan.listenup.client.playback.SessionState" to 3,
             "com.calypsan.listenup.client.playback.SleepTimerMode" to 2,
             "com.calypsan.listenup.client.playback.SleepTimerState" to 3,
+            "com.calypsan.listenup.client.presentation.nowplaying.PlaybackGuardEvent" to 1,
             "com.calypsan.listenup.client.presentation.admin.ABSImportListUiState" to 3,
             "com.calypsan.listenup.client.presentation.admin.AdminBackupUiState" to 3,
             "com.calypsan.listenup.client.presentation.admin.AdminCategoriesUiState" to 3,

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -4541,6 +4541,36 @@
         }
       }
     },
+    "campfire.end_to_play_body": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playing another book will end the campfire for everyone. Continue?"
+          }
+        }
+      }
+    },
+    "campfire.end_to_play_confirm": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End & play"
+          }
+        }
+      }
+    },
+    "campfire.end_to_play_title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End the campfire?"
+          }
+        }
+      }
+    },
     "campfire.entry_point": {
       "localizations": {
         "en": {
@@ -4921,6 +4951,36 @@
         }
       }
     },
+    "campfire.leave_to_play_body": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playing another book will leave the campfire. Continue?"
+          }
+        }
+      }
+    },
+    "campfire.leave_to_play_confirm": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave & play"
+          }
+        }
+      }
+    },
+    "campfire.leave_to_play_title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave the campfire?"
+          }
+        }
+      }
+    },
     "campfire.listening_now": {
       "localizations": {
         "en": {
@@ -4977,6 +5037,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Catch up with the room"
+          }
+        }
+      }
+    },
+    "campfire.return": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Return to campfire"
           }
         }
       }

--- a/scripts/export-surface-baseline.txt
+++ b/scripts/export-surface-baseline.txt
@@ -366,6 +366,7 @@ PendingOperationUi
 PendingRegistration
 PlaybackController
 PlaybackDynamics
+PlaybackGuardEvent
 PlaybackManager
 PlaybackMediaItem
 PlaybackPosition

--- a/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
+++ b/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
 import com.calypsan.listenup.client.data.remote.BookRpcFactory
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
@@ -85,6 +86,7 @@ class KoinModuleVerifyTest :
                         DocumentRepository::class,
                         DownloadRepository::class,
                         PlaybackPositionRepository::class,
+                        ActiveCampfireCoordinator::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinator.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
  * @property bookId The book the campfire is on. Playing this same book is never guarded.
  * @property isHost Whether the local user hosts the session — selects the "end" vs "leave" confirm copy.
  */
-data class ActiveCampfire(
+internal data class ActiveCampfire(
     val sessionId: CampfireId,
     val bookId: String,
     val isHost: Boolean,
@@ -30,7 +30,7 @@ data class ActiveCampfire(
  * coexistence spec, B3). The per-session `CampfireViewModel` is the sole writer — it mirrors its
  * controller's hot state into [set]; readers observe [current]. Registered as a Koin `single`.
  */
-class ActiveCampfireCoordinator {
+internal class ActiveCampfireCoordinator {
     /** The live campfire, or `null` when no session is active. */
     val current: StateFlow<ActiveCampfire?>
         field = MutableStateFlow<ActiveCampfire?>(null)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinator.kt
@@ -1,0 +1,42 @@
+package com.calypsan.listenup.client.campfire
+
+import com.calypsan.listenup.api.dto.campfire.CampfireId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * A snapshot of the one live Campfire session, as the rest of the app needs to see it.
+ *
+ * Deliberately a flat value (no controller reference, no closures): the process-singleton
+ * [com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel] reads this to decide
+ * whether playing a *different* book must confirm-and-exit the campfire first (co-listening
+ * coexistence spec, B3). Only one campfire is live at a time, as everywhere else in the feature.
+ *
+ * @property sessionId The live session's id.
+ * @property bookId The book the campfire is on. Playing this same book is never guarded.
+ * @property isHost Whether the local user hosts the session — selects the "end" vs "leave" confirm copy.
+ */
+data class ActiveCampfire(
+    val sessionId: CampfireId,
+    val bookId: String,
+    val isHost: Boolean,
+)
+
+/**
+ * Process-scope holder for the currently-live [ActiveCampfire], or `null` when none.
+ *
+ * The seam that lets the process-singleton `NowPlayingViewModel` observe campfire liveness without
+ * depending on the per-session `CampfireSessionController`/`CampfireViewModel` factories (co-listening
+ * coexistence spec, B3). The per-session `CampfireViewModel` is the sole writer — it mirrors its
+ * controller's hot state into [set]; readers observe [current]. Registered as a Koin `single`.
+ */
+class ActiveCampfireCoordinator {
+    /** The live campfire, or `null` when no session is active. */
+    val current: StateFlow<ActiveCampfire?>
+        field = MutableStateFlow<ActiveCampfire?>(null)
+
+    /** Publishes the live campfire (or `null` to clear). Called by `CampfireViewModel` on every controller-state change. */
+    fun set(value: ActiveCampfire?) {
+        current.value = value
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
@@ -272,6 +272,27 @@ internal class CampfireSessionController(
         if (sessionId != null) transport.leaveSession(sessionId)
     }
 
+    /**
+     * Ends the session for everyone (host-only; the UI gates this behind [CampfireUiState.Active.isHost]).
+     * Twin of [leave] but calls [CampfireTransport.endSession] — used when the host chooses to play a
+     * different book, which tears the campfire down rather than migrating the host (co-listening
+     * coexistence spec, B3). Local state moves to [CampfireUiState.Idle] first so readers observe the
+     * teardown immediately, regardless of the network round-trip.
+     */
+    suspend fun endCampfire() {
+        val sessionId =
+            when (val current = state.value) {
+                is CampfireUiState.Active -> current.sessionId
+                is CampfireUiState.Disconnected -> current.sessionId
+                else -> null
+            }
+        observeJob?.cancel()
+        driftJob?.cancel()
+        pendingCommandIds.value = emptySet()
+        state.value = CampfireUiState.Idle
+        if (sessionId != null) transport.endSession(sessionId)
+    }
+
     /** Resumes room playback (optimistic local apply; denied via [CampfireSessionEvent.ControlDenied] without control). */
     fun play() = sendCommand { commandId -> PlaybackCommand.Play(commandId = commandId) }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CampfireClientModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CampfireClientModule.kt
@@ -86,6 +86,7 @@ internal val campfireClientModule: Module =
                 transport = get(),
                 errorBus = get(),
                 userRepository = get(),
+                coordinator = get(),
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CampfireClientModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CampfireClientModule.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.di
 
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.campfire.CampfireDiscoveryRepository
 import com.calypsan.listenup.client.campfire.CampfireRpcTransport
 import com.calypsan.listenup.client.campfire.CampfireSessionController
@@ -60,6 +61,9 @@ internal val campfireClientModule: Module =
                 refreshSignal = get(),
             )
         }
+
+        // ActiveCampfireCoordinator — process-scope liveness seam read by NowPlayingViewModel (B3).
+        single { ActiveCampfireCoordinator() }
 
         // CampfireSessionController — one per joined session (NOT a singleton). The UI/ViewModel
         // creates one via get() on join and retains it for the session's duration, calling

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
@@ -27,6 +27,7 @@ internal val playbackPresentationModule =
                 documentRepository = get(),
                 downloadRepository = get(),
                 playbackPositionRepository = get(),
+                activeCampfire = get(),
             )
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModel.kt
@@ -12,6 +12,8 @@ import com.calypsan.listenup.api.dto.campfire.CampfireSettings
 import com.calypsan.listenup.api.dto.campfire.ChatMessage
 import com.calypsan.listenup.api.error.AppError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.campfire.ActiveCampfire
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.campfire.CampfireSessionController
 import com.calypsan.listenup.client.campfire.CampfireSessionEvent
 import com.calypsan.listenup.client.campfire.CampfireTransport
@@ -59,13 +61,27 @@ private const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
  * @property userRepository Backs [hostDisplayName] — the full-screen Create flow's (task L3) default
  * campfire-name builder needs the caller's own display name reactively, independent of any joined
  * session (the create screen renders before [transport.createSession] is ever called).
+ * @property coordinator Process-scope liveness seam ([ActiveCampfireCoordinator]) mirrored from
+ * [controller]'s hot state so the singleton `NowPlayingViewModel` can guard "play a different book"
+ * against a live campfire (co-listening coexistence spec, B3).
  */
 class CampfireViewModel internal constructor(
     private val controller: CampfireSessionController,
     private val transport: CampfireTransport,
     private val errorBus: ErrorBus,
     private val userRepository: UserRepository,
+    private val coordinator: ActiveCampfireCoordinator,
 ) : ViewModel() {
+    init {
+        // Mirror the controller's hot session state into the process-scope coordinator so the
+        // singleton NowPlayingViewModel can guard "play a different book" against a live campfire
+        // (co-listening coexistence spec, B3). Always-on: liveness is independent of whether any
+        // campfire screen currently subscribes to [state].
+        viewModelScope.launch {
+            controller.state.collect { coordinator.set(it.toActiveCampfire()) }
+        }
+    }
+
     /**
      * Session id awaiting spoiler confirmation before [confirmSpoilerJoin] hands it to
      * [controller] (see [join]'s KDoc for why the gate lives here rather than in the controller).
@@ -206,6 +222,11 @@ class CampfireViewModel internal constructor(
         viewModelScope.launch { controller.leave() }
     }
 
+    /** Ends the campfire for everyone (host-only — see [CampfireSessionController.endCampfire]). */
+    fun endCampfire() {
+        viewModelScope.launch { controller.endCampfire() }
+    }
+
     /** Resumes room playback (optimistic; denied via [CampfireScreenEvent.ControlDenied] without control). */
     fun play() = controller.play()
 
@@ -297,6 +318,13 @@ private fun CampfireUiState.toScreenState(): CampfireScreenUiState =
         is CampfireUiState.Ended -> {
             CampfireScreenUiState.Ended(sessionId, reason)
         }
+    }
+
+private fun CampfireUiState.toActiveCampfire(): ActiveCampfire? =
+    when (this) {
+        is CampfireUiState.Active -> ActiveCampfire(sessionId = sessionId, bookId = bookId, isHost = isHost)
+        // Idle / Joining / Disconnected / Ended → not a guard-worthy live session.
+        else -> null
     }
 
 private fun CampfireSessionEvent.toScreenEvent(): CampfireScreenEvent =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModel.kt
@@ -321,10 +321,11 @@ private fun CampfireUiState.toScreenState(): CampfireScreenUiState =
     }
 
 private fun CampfireUiState.toActiveCampfire(): ActiveCampfire? =
-    when (this) {
-        is CampfireUiState.Active -> ActiveCampfire(sessionId = sessionId, bookId = bookId, isHost = isHost)
-        // Idle / Joining / Disconnected / Ended → not a guard-worthy live session.
-        else -> null
+    // Only a live/lobby session is guard-worthy; Idle / Joining / Disconnected / Ended → null.
+    if (this is CampfireUiState.Active) {
+        ActiveCampfire(sessionId = sessionId, bookId = bookId, isHost = isHost)
+    } else {
+        null
     }
 
 private fun CampfireSessionEvent.toScreenEvent(): CampfireScreenEvent =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -445,6 +445,13 @@ class NowPlayingViewModel(
      * (role-tagged so the shell picks "end" vs "leave" copy) and does not play; the shell re-drives
      * [playBookConfirmed] after the user exits the campfire. Playing the campfire's own book, or with
      * no campfire live, plays immediately.
+     *
+     * This is the guarded entry point for the app's in-UI "play" affordances (book detail, Home
+     * continue-listening, Library). It is NOT the only way playback can start: the Android
+     * media-session surfaces in `PlaybackService` (Android Auto browse, Assistant voice search,
+     * system playback-resumption) call `PlaybackManager.prepareForPlayback` directly and therefore
+     * bypass this guard — a dialog-based confirm has no UI on those surfaces. Guarding those paths
+     * needs a distinct (dialog-less) resolution and is a tracked follow-up, not part of this cut.
      */
     fun playBook(bookId: BookId) {
         val active = activeCampfire.current.value

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -75,7 +75,7 @@ private val logger = KotlinLogging.logger {}
  * the narrow [Suppress] (replaces the former file-level suppression).
  */
 @Suppress("TooManyFunctions")
-class NowPlayingViewModel(
+class NowPlayingViewModel internal constructor(
     private val playbackManager: PlaybackManager,
     private val bookRepository: BookRepository,
     private val sleepTimerManager: SleepTimerManager,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
@@ -84,6 +85,7 @@ class NowPlayingViewModel(
     private val documentRepository: DocumentRepository,
     private val downloadRepository: DownloadRepository,
     private val playbackPositionRepository: PlaybackPositionRepository,
+    private val activeCampfire: ActiveCampfireCoordinator,
 ) : ViewModel() {
     private companion object {
         const val FADE_DURATION_MS = 3000L
@@ -101,6 +103,11 @@ class NowPlayingViewModel(
 
     /** One-shot navigation events — the host collects these to trigger platform navigation. */
     val navActions: Flow<NowPlayingNavAction> = _navActions.receiveAsFlow()
+
+    private val _playbackGuardEvents = Channel<PlaybackGuardEvent>(Channel.BUFFERED)
+
+    /** One-shot playback-guard events — the shell collects these to raise the campfire confirm dialog (B3). */
+    val playbackGuardEvents: Flow<PlaybackGuardEvent> = _playbackGuardEvents.receiveAsFlow()
 
     /**
      * The id of the first PDF document for the currently-playing book, or null when the book has
@@ -432,7 +439,26 @@ class NowPlayingViewModel(
 
     // === Playback actions ===
 
+    /**
+     * Plays [bookId], guarding against silently stranding a live campfire (co-listening coexistence
+     * spec, B3). If a campfire is live for a *different* book, emits [PlaybackGuardEvent.ConfirmPlayOverCampfire]
+     * (role-tagged so the shell picks "end" vs "leave" copy) and does not play; the shell re-drives
+     * [playBookConfirmed] after the user exits the campfire. Playing the campfire's own book, or with
+     * no campfire live, plays immediately.
+     */
     fun playBook(bookId: BookId) {
+        val active = activeCampfire.current.value
+        if (active != null && active.bookId != bookId.value) {
+            _playbackGuardEvents.trySend(PlaybackGuardEvent.ConfirmPlayOverCampfire(bookId, active.isHost))
+            return
+        }
+        startPlayback(bookId)
+    }
+
+    /** Plays [bookId] unconditionally — the shell's continuation after the campfire confirm (B3). */
+    fun playBookConfirmed(bookId: BookId) = startPlayback(bookId)
+
+    private fun startPlayback(bookId: BookId) {
         viewModelScope.launch {
             val result = playbackManager.prepareForPlayback(bookId)
             if (result == null) {
@@ -597,4 +623,20 @@ sealed interface NowPlayingNavAction {
     data class OpenDocumentViewer(
         val localPath: String,
     ) : NowPlayingNavAction
+}
+
+/**
+ * One-shot playback-guard event: the user asked to play a book while a *different* book's campfire is
+ * live (co-listening coexistence spec, B3). The shell shows a confirm dialog — host copy ends the
+ * campfire, participant copy leaves it — then calls [NowPlayingViewModel.playBookConfirmed] on confirm.
+ */
+sealed interface PlaybackGuardEvent {
+    /**
+     * @property bookId The book the user asked to play.
+     * @property isHost Whether the local user hosts the live campfire — selects "end" vs "leave" copy.
+     */
+    data class ConfirmPlayOverCampfire(
+        val bookId: BookId,
+        val isHost: Boolean,
+    ) : PlaybackGuardEvent
 }

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -493,7 +493,14 @@
     "flow_room_invite": "Invite",
     "flow_room_system_joined": "%1$s joined the fire",
     "flow_room_system_left": "%1$s left the fire",
-    "flow_room_system_host_changed": "%1$s is now hosting"
+    "flow_room_system_host_changed": "%1$s is now hosting",
+    "return": "Return to campfire",
+    "end_to_play_title": "End the campfire?",
+    "end_to_play_body": "Playing another book will end the campfire for everyone. Continue?",
+    "end_to_play_confirm": "End & play",
+    "leave_to_play_title": "Leave the campfire?",
+    "leave_to_play_body": "Playing another book will leave the campfire. Continue?",
+    "leave_to_play_confirm": "Leave & play"
   },
   "series": {
     "book_sequence": "Book %1$s",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinatorTest.kt
@@ -1,0 +1,23 @@
+package com.calypsan.listenup.client.campfire
+
+import com.calypsan.listenup.api.dto.campfire.CampfireId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ActiveCampfireCoordinatorTest :
+    FunSpec({
+        test("current starts null") {
+            ActiveCampfireCoordinator().current.value shouldBe null
+        }
+
+        test("set publishes the active campfire, set(null) clears it") {
+            val coordinator = ActiveCampfireCoordinator()
+            val active = ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true)
+
+            coordinator.set(active)
+            coordinator.current.value shouldBe active
+
+            coordinator.set(null)
+            coordinator.current.value shouldBe null
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
@@ -506,6 +506,22 @@ class CampfireSessionControllerTest :
             }
         }
 
+        test("endCampfire stops the session and calls transport.endSession") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport = FakeCampfireTransport().apply { joinResult = AppResult.Success(snapshot()) }
+                val sut = controller(transport, backgroundScope, clock)
+                sut.join(sessionId)
+                runCurrent()
+
+                sut.endCampfire()
+                runCurrent()
+
+                sut.state.value shouldBe CampfireUiState.Idle
+                transport.endCalls shouldBe listOf(sessionId)
+            }
+        }
+
         // ── Lobby phase (2026-07-11 amendment) ───────────────────────────────
 
         test("join with a LOBBY snapshot does not touch local playback") {
@@ -772,6 +788,7 @@ private class FakeCampfireTransport : CampfireTransport {
     var joinResult: AppResult<CampfireSnapshot> = AppResult.Failure(CampfireError.CampfireNotFound())
     val joinCalls = mutableListOf<CampfireId>()
     val leaveCalls = mutableListOf<CampfireId>()
+    val endCalls = mutableListOf<CampfireId>()
     val sentCommands = mutableListOf<PlaybackCommand>()
     var sendCommandResult: AppResult<Unit> = AppResult.Success(Unit)
     val sentChat = mutableListOf<String>()
@@ -808,7 +825,10 @@ private class FakeCampfireTransport : CampfireTransport {
         return AppResult.Success(Unit)
     }
 
-    override suspend fun endSession(sessionId: CampfireId): AppResult<Unit> = throw NotImplementedError()
+    override suspend fun endSession(sessionId: CampfireId): AppResult<Unit> {
+        endCalls += sessionId
+        return AppResult.Success(Unit)
+    }
 
     override suspend fun startSession(sessionId: CampfireId): AppResult<Unit> {
         startSessionCalls += sessionId

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
@@ -19,6 +19,8 @@ import com.calypsan.listenup.api.error.CampfireError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.streaming.RpcEvent
+import com.calypsan.listenup.client.campfire.ActiveCampfire
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.campfire.CampfireSessionController
 import com.calypsan.listenup.client.campfire.CampfireTransport
 import com.calypsan.listenup.client.domain.model.User
@@ -80,6 +82,7 @@ class CampfireViewModelTest :
             val transport = FakeCampfireTransport()
             val errorBus = ErrorBus()
             val userRepository = FakeUserRepository("self-1")
+            val coordinator = ActiveCampfireCoordinator()
 
             fun build(scope: TestScope): CampfireViewModel {
                 val controller =
@@ -96,6 +99,7 @@ class CampfireViewModelTest :
                     transport = transport,
                     errorBus = errorBus,
                     userRepository = userRepository,
+                    coordinator = coordinator,
                 )
             }
         }
@@ -315,6 +319,55 @@ class CampfireViewModelTest :
                 fixture.transport.leaveCalls shouldBe listOf(sessionId)
             }
         }
+
+        test("publishes ActiveCampfire to the coordinator when the session goes Active") {
+            runTest {
+                val fixture = Fixture()
+                fixture.transport.joinResult = AppResult.Success(snapshot())
+                val viewModel = fixture.build(this)
+                keepStateHot(viewModel)
+
+                viewModel.join(sessionId)
+                advanceUntilIdle()
+
+                fixture.coordinator.current.value shouldBe
+                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false)
+            }
+        }
+
+        test("clears the coordinator when the session leaves") {
+            runTest {
+                val fixture = Fixture()
+                fixture.transport.joinResult = AppResult.Success(snapshot())
+                val viewModel = fixture.build(this)
+                keepStateHot(viewModel)
+
+                viewModel.join(sessionId)
+                advanceUntilIdle()
+
+                viewModel.leave()
+                advanceUntilIdle()
+
+                fixture.coordinator.current.value shouldBe null
+            }
+        }
+
+        test("endCampfire delegates to the controller's endSession") {
+            runTest {
+                val fixture = Fixture()
+                fixture.transport.joinResult = AppResult.Success(snapshot())
+                val viewModel = fixture.build(this)
+                keepStateHot(viewModel)
+
+                viewModel.join(sessionId)
+                advanceUntilIdle()
+
+                viewModel.endCampfire()
+                advanceUntilIdle()
+
+                fixture.transport.endCalls shouldBe listOf(sessionId)
+            }
+        }
     })
 
 /** Fixed [Clock] — this VM's tests don't exercise drift-loop timing, only state mapping/delegation. */
@@ -329,6 +382,7 @@ private class FakeCampfireTransport : CampfireTransport {
     var invitableUsersResult: AppResult<List<CampfireInvitableUser>> = AppResult.Success(emptyList())
     val joinCalls = mutableListOf<CampfireId>()
     val leaveCalls = mutableListOf<CampfireId>()
+    val endCalls = mutableListOf<CampfireId>()
 
     private val frameFlow = MutableSharedFlow<RpcEvent<CampfireFrame>>(extraBufferCapacity = 64)
 
@@ -347,7 +401,10 @@ private class FakeCampfireTransport : CampfireTransport {
         return AppResult.Success(Unit)
     }
 
-    override suspend fun endSession(sessionId: CampfireId): AppResult<Unit> = throw NotImplementedError()
+    override suspend fun endSession(sessionId: CampfireId): AppResult<Unit> {
+        endCalls += sessionId
+        return AppResult.Success(Unit)
+    }
 
     override suspend fun startSession(sessionId: CampfireId): AppResult<Unit> = throw NotImplementedError()
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
@@ -335,6 +335,24 @@ class CampfireViewModelTest :
             }
         }
 
+        // Proves the coordinator collector is ALWAYS-ON (viewModelScope), independent of any
+        // WhileSubscribed subscriber to viewModel.state — deliberately NO keepStateHot. This is the
+        // whole point of the seam: the process-singleton NowPlayingViewModel must see liveness even
+        // when no campfire screen is observing the VM's public state.
+        test("publishes to the coordinator with no subscriber to the VM's public state") {
+            runTest {
+                val fixture = Fixture()
+                fixture.transport.joinResult = AppResult.Success(snapshot())
+                val viewModel = fixture.build(this)
+
+                viewModel.join(sessionId)
+                advanceUntilIdle()
+
+                fixture.coordinator.current.value shouldBe
+                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false)
+            }
+        }
+
         test("clears the coordinator when the session leaves") {
             runTest {
                 val fixture = Fixture()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
@@ -3,6 +3,7 @@
 package com.calypsan.listenup.client.presentation.nowplaying
 
 import app.cash.turbine.test
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.repository.BookRepository
@@ -83,6 +84,7 @@ class NowPlayingProgressIsolationTest :
                 playbackPositionRepository =
                     com.calypsan.listenup.client.test.fake
                         .FakePlaybackPositionRepository(),
+                activeCampfire = ActiveCampfireCoordinator(),
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingTeardownTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingTeardownTest.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.presentation.nowplaying
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.BookListItem
@@ -100,6 +101,7 @@ class NowPlayingTeardownTest :
                 documentRepository = documentRepository,
                 downloadRepository = downloadRepository,
                 playbackPositionRepository = positionRepository,
+                activeCampfire = ActiveCampfireCoordinator(),
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -1,7 +1,10 @@
 package com.calypsan.listenup.client.presentation.nowplaying
 
+import com.calypsan.listenup.api.dto.campfire.CampfireId
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.client.campfire.ActiveCampfire
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.domain.model.BookDocument
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
@@ -72,6 +75,7 @@ class NowPlayingViewModelTest :
             val networkMonitor: NetworkMonitor = mock()
             val documentRepository: DocumentRepository = mock()
             val sleepTimerManager: SleepTimerManager = SleepTimerManager(CoroutineScope(Job()))
+            val activeCampfire = ActiveCampfireCoordinator()
 
             init {
                 // Default: networkMonitor.isOnline() returns true. Tests override to false where needed.
@@ -108,6 +112,7 @@ class NowPlayingViewModelTest :
                     playbackPositionRepository =
                         com.calypsan.listenup.client.test.fake
                             .FakePlaybackPositionRepository(),
+                    activeCampfire = activeCampfire,
                 )
         }
 
@@ -279,6 +284,89 @@ class NowPlayingViewModelTest :
                 verifySuspend(VerifyMode.exactly(0)) {
                     fixture.playbackController.startPlayback(any())
                 }
+            }
+        }
+
+        // ========== playBook campfire play-guard (B3) ==========
+
+        test("playBook plays directly when no campfire is live") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                val bookId = BookId("book-1")
+                fixture.fakePm.stubbedPrepareResult = stubPrepareResult(bookId)
+                everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
+
+                val vm = fixture.newVm()
+                vm.playBook(bookId)
+                advanceUntilIdle()
+
+                fixture.fakePm.activatedBookIds shouldBe listOf(bookId)
+            }
+        }
+
+        test("playBook plays directly when the campfire is on the same book") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                val bookId = BookId("book-1")
+                fixture.activeCampfire.set(ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true))
+                fixture.fakePm.stubbedPrepareResult = stubPrepareResult(bookId)
+                everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
+
+                val vm = fixture.newVm()
+                vm.playBook(bookId)
+                advanceUntilIdle()
+
+                fixture.fakePm.activatedBookIds shouldBe listOf(bookId)
+            }
+        }
+
+        test("playBook on a different book as host emits an end-confirm and does not play") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                fixture.activeCampfire.set(ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true))
+
+                val vm = fixture.newVm()
+                vm.playbackGuardEvents.test {
+                    vm.playBook(BookId("book-2"))
+                    awaitItem() shouldBe PlaybackGuardEvent.ConfirmPlayOverCampfire(BookId("book-2"), isHost = true)
+                }
+                advanceUntilIdle()
+
+                withClue("must NOT activate when guarded by a different book's campfire") {
+                    fixture.fakePm.activatedBookIds.isEmpty() shouldBe true
+                }
+                verifySuspend(VerifyMode.exactly(0)) {
+                    fixture.playbackController.startPlayback(any())
+                }
+            }
+        }
+
+        test("playBook on a different book as participant emits a leave-confirm") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                fixture.activeCampfire.set(ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = false))
+
+                val vm = fixture.newVm()
+                vm.playbackGuardEvents.test {
+                    vm.playBook(BookId("book-2"))
+                    awaitItem() shouldBe PlaybackGuardEvent.ConfirmPlayOverCampfire(BookId("book-2"), isHost = false)
+                }
+            }
+        }
+
+        test("playBookConfirmed plays unconditionally even while a campfire is live") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                val bookId = BookId("book-2")
+                fixture.activeCampfire.set(ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true))
+                fixture.fakePm.stubbedPrepareResult = stubPrepareResult(bookId)
+                everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
+
+                val vm = fixture.newVm()
+                vm.playBookConfirmed(bookId)
+                advanceUntilIdle()
+
+                fixture.fakePm.activatedBookIds shouldBe listOf(bookId)
             }
         }
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/CampfireVisibilityTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/CampfireVisibilityTest.kt
@@ -1,0 +1,22 @@
+package com.calypsan.listenup.client.features.nowplaying
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CampfireVisibilityTest :
+    FunSpec({
+        test("solo player: full screen shows only when expanded with an active book") {
+            campfireFullScreenVisible(isExpanded = true, hasActiveBook = true, hasSession = false, minimized = false) shouldBe true
+            campfireFullScreenVisible(isExpanded = false, hasActiveBook = true, hasSession = false, minimized = false) shouldBe false
+            campfireFullScreenVisible(isExpanded = true, hasActiveBook = false, hasSession = false, minimized = false) shouldBe false
+        }
+
+        test("live campfire takes over full screen unless minimized") {
+            campfireFullScreenVisible(isExpanded = false, hasActiveBook = false, hasSession = true, minimized = false) shouldBe true
+            campfireFullScreenVisible(isExpanded = false, hasActiveBook = false, hasSession = true, minimized = true) shouldBe false
+        }
+
+        test("minimizing the campfire does not suppress an independently-expanded solo player") {
+            campfireFullScreenVisible(isExpanded = true, hasActiveBook = true, hasSession = true, minimized = true) shouldBe true
+        }
+    })

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.features.nowplaying
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
@@ -87,6 +88,8 @@ fun NowPlayingHost(
     onNavigateToDocument: (localPath: String) -> Unit,
     viewModel: NowPlayingViewModel,
     campfireViewModel: CampfireViewModel,
+    campfireMinimized: Boolean,
+    onMinimizeCampfire: () -> Unit,
     onBarFootprintChanged: (Dp) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -131,13 +134,23 @@ fun NowPlayingHost(
     val activeState = state as? NowPlayingState.Active
 
     Box(modifier = modifier.fillMaxSize()) {
+        // System back minimizes a foregrounded campfire rather than leaving it (B1). Leave stays an
+        // explicit action inside the room. Only active while the campfire is actually foreground.
+        BackHandler(enabled = campfire.session != null && !campfireMinimized) { onMinimizeCampfire() }
+
         // Full screen (slides up when expanded). Only renders when we have an Active book —
         // expanding into Idle/Error has no meaningful UI. A Campfire session for this book takes
         // over unconditionally (Lobby/Room are the full-screen Campfire experience, task L3) —
         // independent of screenState.isExpanded, since a just-created/joined session should land
         // full-screen immediately rather than waiting for the ordinary mini-player expand gesture.
         AnimatedVisibility(
-            visible = (screenState.isExpanded && activeState != null) || campfire.session != null,
+            visible =
+                campfireFullScreenVisible(
+                    isExpanded = screenState.isExpanded,
+                    hasActiveBook = activeState != null,
+                    hasSession = campfire.session != null,
+                    minimized = campfireMinimized,
+                ),
             enter =
                 slideInVertically(
                     initialOffsetY = { it },

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -16,11 +16,15 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -39,6 +43,14 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
+import listenup.composeapp.generated.resources.campfire_end_to_play_body
+import listenup.composeapp.generated.resources.campfire_end_to_play_confirm
+import listenup.composeapp.generated.resources.campfire_end_to_play_title
+import listenup.composeapp.generated.resources.campfire_leave_to_play_body
+import listenup.composeapp.generated.resources.campfire_leave_to_play_confirm
+import listenup.composeapp.generated.resources.campfire_leave_to_play_title
+import listenup.composeapp.generated.resources.campfire_return
+import listenup.composeapp.generated.resources.common_cancel
 import listenup.composeapp.generated.resources.common_retry
 import listenup.composeapp.generated.resources.error_book_not_connected
 import listenup.composeapp.generated.resources.error_book_wrong_server
@@ -75,8 +87,10 @@ import com.calypsan.listenup.client.features.invite.JoinScreen
 import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.features.nowplaying.NowPlayingHost
 import com.calypsan.listenup.client.playback.NowPlayingState
+import com.calypsan.listenup.client.presentation.campfire.CampfireScreenUiState
 import com.calypsan.listenup.client.presentation.campfire.CampfireViewModel
 import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel
+import com.calypsan.listenup.client.presentation.nowplaying.PlaybackGuardEvent
 import com.calypsan.listenup.client.features.nowplaying.DockedNowPlayingBarHeight
 import com.calypsan.listenup.client.features.shell.ShellDestination
 import com.calypsan.listenup.client.features.shell.components.ConnectionHealthBanner
@@ -793,6 +807,99 @@ private fun authenticatedNavEntries(
 }
 
 /**
+ * Presentation state for the B1 campfire-minimize affordance — held once here since the
+ * full-screen host and the return FAB below both react to it. A dead session resets the flag
+ * so the next campfire always opens foreground.
+ */
+private class CampfireMinimizeState(
+    val sessionActive: Boolean,
+    val minimized: Boolean,
+    val setMinimized: (Boolean) -> Unit,
+)
+
+@Composable
+private fun rememberCampfireMinimizeState(campfireViewModel: CampfireViewModel): CampfireMinimizeState {
+    var minimized by rememberSaveable { mutableStateOf(false) }
+    val campfireState by campfireViewModel.state.collectAsStateWithLifecycle()
+    val sessionActive = campfireState is CampfireScreenUiState.Active
+    LaunchedEffect(sessionActive) {
+        if (!sessionActive) minimized = false
+    }
+    return CampfireMinimizeState(sessionActive, minimized) { minimized = it }
+}
+
+/** Return-to-campfire affordance (B1 non-stranding placeholder; styled ember FAB is deferred). */
+@Composable
+private fun BoxScope.CampfireReturnFab(state: CampfireMinimizeState) {
+    if (state.sessionActive && state.minimized) {
+        FloatingActionButton(
+            onClick = { state.setMinimized(false) },
+            modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
+        ) {
+            Icon(Icons.Default.LocalFireDepartment, contentDescription = stringResource(Res.string.campfire_return))
+        }
+    }
+}
+
+/**
+ * Confirm dialog for [NowPlayingViewModel.playbackGuardEvents] (B3) — playing a book while a
+ * campfire is live for a different book must end/leave the campfire first, never play silently
+ * over it.
+ */
+@Composable
+private fun PlayOverCampfireDialog(
+    nowPlayingViewModel: NowPlayingViewModel,
+    campfireViewModel: CampfireViewModel,
+) {
+    var playOverCampfire by remember { mutableStateOf<PlaybackGuardEvent.ConfirmPlayOverCampfire?>(null) }
+    LaunchedEffect(nowPlayingViewModel) {
+        nowPlayingViewModel.playbackGuardEvents.collect { event ->
+            when (event) {
+                is PlaybackGuardEvent.ConfirmPlayOverCampfire -> playOverCampfire = event
+            }
+        }
+    }
+    val event = playOverCampfire ?: return
+    AlertDialog(
+        onDismissRequest = { playOverCampfire = null },
+        title = {
+            Text(
+                stringResource(
+                    if (event.isHost) Res.string.campfire_end_to_play_title else Res.string.campfire_leave_to_play_title,
+                ),
+            )
+        },
+        text = {
+            Text(
+                stringResource(
+                    if (event.isHost) Res.string.campfire_end_to_play_body else Res.string.campfire_leave_to_play_body,
+                ),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                if (event.isHost) campfireViewModel.endCampfire() else campfireViewModel.leave()
+                nowPlayingViewModel.playBookConfirmed(event.bookId)
+                playOverCampfire = null
+            }) {
+                Text(
+                    stringResource(
+                        if (event.isHost) {
+                            Res.string.campfire_end_to_play_confirm
+                        } else {
+                            Res.string.campfire_leave_to_play_confirm
+                        },
+                    ),
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { playOverCampfire = null }) { Text(stringResource(Res.string.common_cancel)) }
+        },
+    )
+}
+
+/**
  * Overlays rendered inside the authenticated [Box]: the NowPlaying host, the app-wide snackbar,
  * and the single readiness gate that covers non-shell startup states.
  *
@@ -808,6 +915,8 @@ private fun BoxScope.AuthenticatedNavOverlays(
     onRetryLibrarySetupCheck: () -> Unit,
     onBarFootprintChanged: (Dp) -> Unit,
 ) {
+    val campfireMinimize = rememberCampfireMinimizeState(campfireViewModel)
+
     // Now Playing overlay - persistent across all navigation
     // Position adjusts based on whether bottom nav is visible (Shell vs detail screens)
     // Also animates up when snackbar is visible
@@ -830,8 +939,13 @@ private fun BoxScope.AuthenticatedNavOverlays(
         },
         viewModel = nowPlayingViewModel,
         campfireViewModel = campfireViewModel,
+        campfireMinimized = campfireMinimize.minimized,
+        onMinimizeCampfire = { campfireMinimize.setMinimized(true) },
         onBarFootprintChanged = onBarFootprintChanged,
     )
+
+    CampfireReturnFab(campfireMinimize)
+    PlayOverCampfireDialog(nowPlayingViewModel, campfireViewModel)
 
     // App-wide snackbar - positioned at bottom, mini player animates up when visible
     SnackbarHost(

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -455,6 +455,9 @@ One beautiful library.</string>
     <string name="campfire_discover_gathering_listening_count">Gathering · %1$d listening</string>
     <string name="campfire_discover_live_listening_count">Live · %1$d listening</string>
     <string name="campfire_discover_start_a_campfire">Start a campfire</string>
+    <string name="campfire_end_to_play_body">Playing another book will end the campfire for everyone. Continue?</string>
+    <string name="campfire_end_to_play_confirm">End &amp; play</string>
+    <string name="campfire_end_to_play_title">End the campfire?</string>
     <string name="campfire_entry_point">Campfire</string>
     <string name="campfire_flow_create_eyebrow">New Campfire</string>
     <string name="campfire_flow_create_title">Start a Campfire</string>
@@ -493,12 +496,16 @@ One beautiful library.</string>
     <string name="campfire_invite_only">Invite only</string>
     <string name="campfire_invite_only_no_users">No one else can access this book yet.</string>
     <string name="campfire_join">Join</string>
+    <string name="campfire_leave_to_play_body">Playing another book will leave the campfire. Continue?</string>
+    <string name="campfire_leave_to_play_confirm">Leave &amp; play</string>
+    <string name="campfire_leave_to_play_title">Leave the campfire?</string>
     <string name="campfire_listening_now">Listening now</string>
     <string name="campfire_listening_now_count">%1$d listening now</string>
     <string name="campfire_rejoin_confirm">Jump to sync</string>
     <string name="campfire_rejoin_dismiss">Keep my place</string>
     <string name="campfire_rejoin_message">The room has moved on without you. Jump to where everyone else is listening.</string>
     <string name="campfire_rejoin_title">Catch up with the room</string>
+    <string name="campfire_return">Return to campfire</string>
     <string name="campfire_spoiler_cancel">Not yet</string>
     <string name="campfire_spoiler_confirm">Join anyway</string>
     <string name="campfire_spoiler_message">This room is further along in the story than you are. Joining will move your progress forward.</string>

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/CampfireVisibility.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/CampfireVisibility.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.client.features.nowplaying
+
+/**
+ * Whether the full-screen slide-up container should be visible — solo player *or* campfire flow.
+ *
+ * Extracted as a pure predicate so the "minimize" decoupling is unit-tested without a device
+ * (co-listening coexistence spec, B1). A live campfire ([hasSession]) takes over full-screen unless
+ * [minimized]; independently, the solo player shows when [isExpanded] with an active book. The two
+ * terms are OR-ed: minimizing a campfire never hides a solo player the user expanded on purpose.
+ */
+fun campfireFullScreenVisible(
+    isExpanded: Boolean,
+    hasActiveBook: Boolean,
+    hasSession: Boolean,
+    minimized: Boolean,
+): Boolean = (isExpanded && hasActiveBook) || (hasSession && !minimized)


### PR DESCRIPTION
Builds the **underlying layer** of the Campfire ↔ app coexistence design (spec: `2026-07-12-campfire-coexistence-design.md`). A live campfire is now *backgroundable*, and playing a different book can no longer silently strand it. Device-independent + unit-tested; the visual polish (B2) is a deliberate follow-up.

## What's in

**B3 — play-over-campfire guard (the core logic)**
- `NowPlayingViewModel.playBook` consults a new liveness seam; if a campfire is live for a *different* book it emits a one-shot `PlaybackGuardEvent.ConfirmPlayOverCampfire(bookId, isHost)` and does **not** play. `playBookConfirmed` is the shell's continuation after the user exits the campfire.
- `ActiveCampfireCoordinator` — process-scope `StateFlow<ActiveCampfire?>` seam. Needed because the campfire VM/controller are per-session factories while `NowPlayingViewModel` is a process `single`; the campfire VM mirrors its controller's hot state into it via an **always-on** collector.
- Host confirm → `endCampfire()` (`transport.endSession`, tears down for all); participant confirm → existing `leave()`.
- 6 unit-tested guard cases + an always-on-publish test.

**B1 — minimize (decoupling)**
- `campfireFullScreenVisible(...)` pure predicate: `session != null` no longer *forces* full-screen — it's gated by a remembered `campfireMinimized` flag. System back minimizes (not leaves); a placeholder return FAB + the confirm dialog live in the shell overlay.
- This is the real fix for the `session != null`↔now-playing couplings patched three times in #1101.

## Gates
`verifyLocal` (lint + all JVM tests) ✅ · `:androidApp:assembleDebug` ✅. Server-native + iOS lanes unaffected (no `:server` changes); iOS runs on CI.

## Deferred (not defects)
- **B2 visual** — styled ember FAB, now-playing-bar-as-dock, in-room collapse chevron. Verify on-device (Fold) next session.
- **Swift-Export baseline** — 3 new public `:sharedLogic` types (`ActiveCampfire`, `ActiveCampfireCoordinator`, `PlaybackGuardEvent`) may need a Mac baseline regen.

## Follow-ups surfaced by code review
- **`PlaybackService` bypass** — Android Auto browse / Assistant voice / system resume call `prepareForPlayback` directly, bypassing the guard (a dialog-less confirm design is needed). KDoc now states this honestly rather than claiming a single choke point.
- **Teardown/replay race** — narrow, self-limited (stray drift-seek lands on the outgoing book); worth a structural pass with B2.
- **Product calls to confirm:** LOBBY currently triggers the end-for-all confirm; a transient disconnect disarms the guard.