### PR TITLE
🐛 fix(shared): download & offline-file integrity (Fable audit — B1 crit + B2–B10)

### DIFF
--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.android.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.android.kt
@@ -102,10 +102,12 @@ actual class DownloadFileManager(
             .walkTopDown()
             .filter { it.isFile && it.name.endsWith(".tmp") }
             .forEach { file ->
-                // Filename format: "${audioFileId}_${filename}.tmp"
-                // The audioFileId is everything before the first '_'.
-                val audioFileId = file.name.substringBefore('_')
-                if (audioFileId !in activeAudioFileIds && file.delete()) deleted++
+                // Filename format: "${audioFileId}_${filename}.tmp". A .tmp is orphaned iff NO active
+                // id is a prefix of its name. Matching the FULL id ("${id}_") — not substring-before-
+                // first-'_' — keeps ids that legitimately contain '_' from being mis-parsed and their
+                // ACTIVE partials wrongly deleted (B10e).
+                val isActive = activeAudioFileIds.any { file.name.startsWith("${it}_") }
+                if (!isActive && file.delete()) deleted++
             }
         return deleted
     }

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -93,14 +93,26 @@ class DownloadManager internal constructor(
             return AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "No audio files available"))
         }
 
-        // Create download entries for files not already completed
-        val completedIds =
+        // Skip files that are already completed OR have an in-flight row (downloading/queued). A
+        // running download must NOT be re-inserted (REPLACE would reset its bytes to 0) or re-enqueued
+        // (REPLACE work policy would cancel its worker). PlaybackPreparer calls downloadBook on every
+        // prepare of a not-fully-downloaded book, so pressing play mid-download would otherwise stomp
+        // in-flight progress. Mirrors the iOS AppleDownloadService skip-set.
+        val activeIds =
             existing
-                .filter { it.state == DownloadState.COMPLETED }
-                .map { it.audioFileId }
+                .filter {
+                    it.state == DownloadState.COMPLETED ||
+                        it.state == DownloadState.DOWNLOADING ||
+                        it.state == DownloadState.QUEUED
+                }.map { it.audioFileId }
                 .toSet()
 
-        val toDownload = audioFiles.filterNot { it.id in completedIds }
+        val toDownload = audioFiles.filterNot { it.id in activeIds }
+
+        if (toDownload.isEmpty()) {
+            logger.info { "All files already downloading, queued, or completed for ${bookId.value}" }
+            return AppResult.Success(DownloadOutcome.AlreadyDownloaded)
+        }
 
         // Check available storage before queueing downloads
         val requiredBytes = toDownload.sumOf { it.size }
@@ -177,15 +189,30 @@ class DownloadManager internal constructor(
                     .addTag(fileCancelTag(file.id))
                     .build()
 
+            // KEEP (not REPLACE): never displace a worker already running for this file. toDownload
+            // already excludes in-flight rows, so KEEP only ever affects retried FAILED/PAUSED files,
+            // whose prior work has finished and won't block the fresh enqueue.
             workManager.enqueueUniqueWork(
                 fileWorkName(file.id),
-                ExistingWorkPolicy.REPLACE,
+                ExistingWorkPolicy.KEEP,
                 workRequest,
             )
         }
 
         logger.info { "Queued ${toDownload.size} files for download: ${bookId.value}" }
         return AppResult.Success(DownloadOutcome.Started)
+    }
+
+    /**
+     * Wipe every downloaded file and every download record ("Delete All Downloads").
+     *
+     * Reclaims orphaned files/rows that per-book deletion can't reach. A worker that finishes after
+     * this returns can only issue UPDATEs, which no-op against the now-empty table — no row resurrects.
+     */
+    override suspend fun deleteAllDownloads() {
+        fileManager.deleteAllFiles()
+        downloadDao.deleteAll()
+        logger.info { "Deleted all downloads (files + records)" }
     }
 
     /**

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -298,8 +298,11 @@ class DownloadManager internal constructor(
 
         for (download in incomplete) {
             // KEEP policy avoids displacing a worker that's already running for this row.
-            // Only PAUSED is reset — DOWNLOADING rows belong to a worker that owns state transitions.
-            if (download.state == DownloadState.PAUSED) {
+            // Reset PAUSED and stale DOWNLOADING rows to QUEUED (B10a): at app startup no worker is
+            // running, so a row left in DOWNLOADING after a crash would show "downloading" forever if
+            // the (re-enqueued) worker is blocked by the wifi constraint. QUEUED reflects the truth
+            // and lets the re-enqueue below drive it. The subsequent worker owns further transitions.
+            if (download.state == DownloadState.PAUSED || download.state == DownloadState.DOWNLOADING) {
                 downloadDao.updateState(download.audioFileId, DownloadState.QUEUED)
             }
 

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -3,6 +3,7 @@
 package com.calypsan.listenup.client.download
 
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.onFailure
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.api.error.DownloadError
@@ -12,9 +13,11 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.data.repository.aggregateBookDownloadStatus
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPrepareRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.playback.AudioTokenProvider
@@ -92,6 +95,7 @@ class AppleDownloadService internal constructor(
     private val tokenProvider: AudioTokenProvider,
     private val fileManager: DownloadFileManager,
     private val prepareRepository: PlaybackPrepareRepository,
+    private val downloadRepository: DownloadRepository,
     private val scope: CoroutineScope,
     private val playbackBandwidthCoordinator: PlaybackBandwidthCoordinator,
 ) : DownloadService {
@@ -306,12 +310,14 @@ class AppleDownloadService internal constructor(
 
     override suspend fun cancelDownload(bookId: BookId) {
         logger.info { "Cancelling download for book: ${bookId.value}" }
-        val downloads = downloadDao.getForBook(bookId.value)
-        for (download in downloads) {
-            if (download.state == DownloadState.DOWNLOADING || download.state == DownloadState.QUEUED) {
-                downloadDao.updateError(download.audioFileId, "Cancelled by user")
-            }
-        }
+
+        // Route through the shared repository (Rule 5 canonical path): non-terminal rows transition to
+        // CANCELLED, NOT FAILED. FAILED rows are returned by getIncomplete(), so a user-cancelled
+        // download used to silently restart on the next launch (and burn cellular); CANCELLED is
+        // excluded from getIncomplete(), so cancel stays cancelled.
+        downloadRepository
+            .cancelForBook(bookId)
+            .onFailure { logger.warn { "Failed to persist cancelled state: ${bookId.value}" } }
 
         // Cancel any active NSURLSession download tasks for this book
         val cancelledCount = sessionDelegate.cancelTasksForBook(bookId.value)
@@ -324,6 +330,14 @@ class AppleDownloadService internal constructor(
         logger.info { "Deleting downloads for book: ${bookId.value}" }
         fileManager.deleteBookFiles(bookId.value)
         downloadDao.markDeletedForBook(bookId.value)
+    }
+
+    override suspend fun deleteAllDownloads() {
+        logger.info { "Deleting all downloads (files + records)" }
+        // Stop any in-flight tasks first so their completion callbacks can't re-write a wiped row.
+        sessionDelegate.cancelAllTasks()
+        fileManager.deleteAllFiles()
+        downloadDao.deleteAll()
     }
 
     @Suppress("ReturnCount")
@@ -373,6 +387,9 @@ class AppleDownloadService internal constructor(
         logger.info { "Re-enqueued ${incomplete.size} incomplete downloads" }
     }
 
+    // Shared reducer (commonMain aggregateBookDownloadStatus) — one state machine across platforms.
+    // Previously an iOS-local copy that didn't filter CANCELLED, so a cancelled partial mis-reported
+    // as Completed. The shared reducer treats a cancelled partial as Paused (never a false Downloaded).
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
         downloadDao.observeForBook(bookId.value).map { entities ->
             aggregateBookDownloadStatus(bookId.value, entities)
@@ -384,64 +401,6 @@ class AppleDownloadService internal constructor(
                 .groupBy { it.bookId }
                 .mapValues { (bookId, files) -> aggregateBookDownloadStatus(bookId, files) }
         }
-
-    // Inline copy of DownloadManager.aggregateStatus; the canonical version has not yet
-    // moved into DownloadRepository, and iOS keeps its own copy.
-    // Known parity gap with Android's aggregator: does NOT filter DownloadState.CANCELLED from
-    // activeDownloads. This gap now reaches the interface via observeAllStatuses —
-    // when a cross-book consumer arrives, fix here first or it
-    // will mis-report aggregate status on iOS.
-    private fun aggregateBookDownloadStatus(
-        bookId: String,
-        entities: List<DownloadEntity>,
-    ): BookDownloadStatus {
-        if (entities.isEmpty()) {
-            return BookDownloadStatus.NotDownloaded(bookId)
-        }
-        val activeDownloads = entities.filter { it.state != DownloadState.DELETED }
-        if (activeDownloads.isEmpty()) {
-            return BookDownloadStatus.NotDownloaded(bookId)
-        }
-        val totalFiles = activeDownloads.size
-        val completedFiles = activeDownloads.count { it.state == DownloadState.COMPLETED }
-        val totalBytes = activeDownloads.sumOf { it.totalBytes }
-        val downloadedBytes = activeDownloads.sumOf { it.downloadedBytes }
-        return when {
-            activeDownloads.all { it.state == DownloadState.COMPLETED } -> {
-                BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
-            }
-
-            activeDownloads.any { it.state == DownloadState.FAILED } -> {
-                BookDownloadStatus.Failed(
-                    bookId = bookId,
-                    errorMessage =
-                        activeDownloads.firstOrNull { it.state == DownloadState.FAILED }?.errorMessage
-                            ?: "Download failed",
-                    partiallyDownloadedFiles = completedFiles,
-                )
-            }
-
-            activeDownloads.all { it.state == DownloadState.PAUSED } -> {
-                BookDownloadStatus.Paused(
-                    bookId = bookId,
-                    pausedFiles = activeDownloads.size,
-                    downloadedBytes = downloadedBytes,
-                    totalBytes = totalBytes,
-                )
-            }
-
-            else -> {
-                BookDownloadStatus.InProgress(
-                    bookId = bookId,
-                    totalFiles = totalFiles,
-                    downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
-                    completedFiles = completedFiles,
-                    totalBytes = totalBytes,
-                    downloadedBytes = downloadedBytes,
-                )
-            }
-        }
-    }
 }
 
 /**
@@ -511,6 +470,16 @@ private class DownloadSessionDelegate(
                     .keys
                     .mapNotNull { taskById[it] }
             }
+        tasks.forEach { it.cancel() }
+        return tasks.size
+    }
+
+    /**
+     * Cancel every active download task (used by "Delete All Downloads"). Each [cancel] drives its
+     * task to `didCompleteWithError`, which resumes and clears its pending state exactly once.
+     */
+    fun cancelAllTasks(): Int {
+        val tasks = lock.withLock { taskById.values.toList() }
         tasks.forEach { it.cancel() }
         return tasks.size
     }

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.apple.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.apple.kt
@@ -137,9 +137,12 @@ actual class DownloadFileManager {
 
             // relativePath is relative to dirPath; extract just the filename component.
             val filename = relativePath.substringAfterLast('/')
-            // Filename format: "${audioFileId}_${filename}.tmp"
-            val audioFileId = filename.substringBefore('_')
-            if (audioFileId !in activeAudioFileIds) {
+            // Filename format: "${audioFileId}_${filename}.tmp". A .tmp is orphaned iff NO active id
+            // is a prefix of its name. Matching the FULL id ("${id}_") — not substring-before-first-
+            // '_' — keeps ids that legitimately contain '_' from being mis-parsed and their ACTIVE
+            // partials wrongly deleted (B10e).
+            val isActive = activeAudioFileIds.any { filename.startsWith("${it}_") }
+            if (!isActive) {
                 val fullPath = Path(downloadDir, relativePath).toString()
                 if (fileManager.removeItemAtPath(fullPath, error = null)) deleted++
             }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
@@ -6,6 +6,13 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Retry budget for a download. A FAILED row that has burned this many attempts is terminal and is
+ * excluded from the every-startup re-enqueue (B10b) so exhausted downloads stop churning. Kept in
+ * lock-step with the Android `DownloadWorker`'s `MAX_RETRIES`.
+ */
+internal const val MAX_DOWNLOAD_RETRIES = 3
+
 @Dao
 internal interface DownloadDao {
     // Observe
@@ -23,14 +30,22 @@ internal interface DownloadDao {
     suspend fun getByAudioFileId(audioFileId: String): DownloadEntity?
 
     /**
-     * Get all downloads not in COMPLETED, DELETED, or CANCELLED state.
+     * Get all downloads not in COMPLETED, DELETED, or CANCELLED state, EXCLUDING FAILED rows that
+     * have exhausted their retry budget ([maxRetries]).
+     *
      * Used to find stalled/interrupted downloads for resume. CANCELLED is excluded so that
-     * resumeIncompleteDownloads does not silently restart a user-cancelled download on app start.
+     * resumeIncompleteDownloads does not silently restart a user-cancelled download on app start;
+     * exhausted-FAILED is excluded (B10b) so a download that already burned its retries stops
+     * silently re-enqueuing on every launch — the user re-triggers it manually.
      */
     @Query(
-        "SELECT * FROM downloads WHERE state NOT IN ('COMPLETED', 'DELETED', 'CANCELLED') ORDER BY bookId, fileIndex",
+        "SELECT * FROM downloads WHERE state NOT IN ('COMPLETED', 'DELETED', 'CANCELLED') " +
+            "AND NOT (state = 'FAILED' AND retryCount >= :maxRetries) ORDER BY bookId, fileIndex",
     )
-    suspend fun getIncomplete(): List<DownloadEntity>
+    suspend fun getIncompleteWithin(maxRetries: Int): List<DownloadEntity>
+
+    /** [getIncompleteWithin] with the canonical [MAX_DOWNLOAD_RETRIES] budget. */
+    suspend fun getIncomplete(): List<DownloadEntity> = getIncompleteWithin(MAX_DOWNLOAD_RETRIES)
 
     /**
      * Get local path for a completed download.
@@ -52,6 +67,23 @@ internal interface DownloadDao {
         state: DownloadState,
         startedAt: Long? = null,
     )
+
+    /**
+     * Mark a file PAUSED only if it is not already in a terminal state
+     * (CANCELLED / DELETED / COMPLETED).
+     *
+     * Closes the cancel/delete race (B7): a dying worker's late `NonCancellable` cleanup can call
+     * this AFTER the user's CANCELLED (or DELETED) write has landed — the ordering between
+     * WorkManager's `cancelAllWorkByTag().await()` and the worker coroutine's cleanup is undefined.
+     * An unguarded `state = PAUSED` there would clobber the terminal state, and `getIncomplete()`
+     * would silently resurrect a download the user explicitly cancelled or deleted. The `WHERE`
+     * guard makes the terminal write win at the DB layer regardless of scheduling.
+     */
+    @Query(
+        "UPDATE downloads SET state = 'PAUSED' WHERE audioFileId = :audioFileId " +
+            "AND state NOT IN ('CANCELLED', 'DELETED', 'COMPLETED')",
+    )
+    suspend fun markPausedIfNotTerminal(audioFileId: String)
 
     @Query("UPDATE downloads SET state = :newState WHERE bookId = :bookId AND state != :excludeState")
     suspend fun updateStateForBookExcluding(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
@@ -136,6 +136,16 @@ internal interface DownloadDao {
     @Query("DELETE FROM downloads WHERE bookId = :bookId")
     suspend fun deleteForBook(bookId: String)
 
+    /**
+     * Delete only the DELETED-tombstone rows for a book.
+     *
+     * Used post-playback-completion to clear the "user explicitly deleted" markers so the book can
+     * auto-download again on a future listen — without touching COMPLETED rows, whose local files
+     * must survive so the offline copy stays playable (never-stranded).
+     */
+    @Query("DELETE FROM downloads WHERE bookId = :bookId AND state = 'DELETED'")
+    suspend fun deleteDeletedRecordsForBook(bookId: String)
+
     @Query("DELETE FROM downloads")
     suspend fun deleteAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -106,9 +106,12 @@ internal class DownloadRepositoryImpl(
             downloadDao.markCompleted(audioFileId, localPath, completedAt)
         }
 
+    // Conditional pause (B7): a late NonCancellable cleanup from a dying worker must NOT clobber a
+    // terminal state (CANCELLED/DELETED/COMPLETED) back to PAUSED. The guarded DAO query makes the
+    // terminal write win at the DB layer regardless of the cancel-vs-cleanup scheduling.
     override suspend fun markPaused(audioFileId: String): AppResult<Unit> =
         suspendRunCatching {
-            downloadDao.updateState(audioFileId, DownloadState.PAUSED)
+            downloadDao.markPausedIfNotTerminal(audioFileId)
         }
 
     override suspend fun markCancelled(audioFileId: String): AppResult<Unit> =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -149,6 +149,10 @@ internal class DownloadRepositoryImpl(
         downloadDao.deleteForBook(bookId)
     }
 
+    override suspend fun deleteDeletedRecordsForBook(bookId: String) {
+        downloadDao.deleteDeletedRecordsForBook(bookId)
+    }
+
     override suspend fun resumeIncompleteDownloads(): AppResult<Unit> =
         suspendRunCatching {
             // Re-enqueue incomplete downloads via the platform enqueuer.
@@ -165,57 +169,82 @@ internal class DownloadRepositoryImpl(
     private fun aggregate(
         bookId: String,
         downloads: List<DownloadEntity>,
-    ): BookDownloadStatus {
-        if (downloads.isEmpty()) {
-            return BookDownloadStatus.NotDownloaded(bookId)
+    ): BookDownloadStatus = aggregateBookDownloadStatus(bookId, downloads)
+}
+
+/**
+ * Reduce a book's per-file [DownloadEntity] rows to an aggregated [BookDownloadStatus].
+ *
+ * Shared across [DownloadRepositoryImpl] and the iOS `AppleDownloadService` so both platforms apply
+ * the identical state machine. `internal` — a reducer, not part of the exported surface.
+ *
+ * **Completeness is measured against every non-tombstone row, not the surviving subset.** A book is
+ * [BookDownloadStatus.Completed] — the only status that reports `isFullyDownloaded` — only when
+ * *all* of its non-DELETED rows are COMPLETED. This closes the "cancelled partial reports Downloaded"
+ * bug: a book with some COMPLETED files and some CANCELLED files is a stopped partial, surfaced as
+ * [BookDownloadStatus.Paused] (whose contract covers "user cancelled or system paused") so the UI
+ * offers resume and availability withholds `canPlay`/emits the offline server warning — never a false
+ * "Downloaded". A book whose rows are *all* cancelled (nothing on disk) collapses to
+ * [BookDownloadStatus.NotDownloaded] so the user can cleanly re-download.
+ */
+internal fun aggregateBookDownloadStatus(
+    bookId: String,
+    downloads: List<DownloadEntity>,
+): BookDownloadStatus {
+    // DELETED rows are tombstones ("explicitly deleted"); they never count toward completeness.
+    val relevant = downloads.filter { it.state != DownloadState.DELETED }
+    if (relevant.isEmpty()) {
+        return BookDownloadStatus.NotDownloaded(bookId)
+    }
+    // Fully cancelled with nothing downloaded → treat as not-downloaded so the user can restart clean.
+    if (relevant.all { it.state == DownloadState.CANCELLED }) {
+        return BookDownloadStatus.NotDownloaded(bookId)
+    }
+    val totalFiles = relevant.size
+    val completedFiles = relevant.count { it.state == DownloadState.COMPLETED }
+    val totalBytes = relevant.sumOf { it.totalBytes }
+    val downloadedBytes = relevant.sumOf { it.downloadedBytes }
+    val hasActive = relevant.any { it.state == DownloadState.DOWNLOADING || it.state == DownloadState.QUEUED }
+    return when {
+        relevant.all { it.state == DownloadState.COMPLETED } -> {
+            BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
         }
-        val activeDownloads =
-            downloads.filter {
-                it.state != DownloadState.DELETED && it.state != DownloadState.CANCELLED
-            }
-        if (activeDownloads.isEmpty()) {
-            return BookDownloadStatus.NotDownloaded(bookId)
+
+        relevant.any { it.state == DownloadState.FAILED } -> {
+            BookDownloadStatus.Failed(
+                bookId = bookId,
+                errorMessage =
+                    relevant
+                        .firstOrNull { it.state == DownloadState.FAILED }
+                        ?.errorMessage
+                        ?: "Download failed",
+                partiallyDownloadedFiles = completedFiles,
+            )
         }
-        val totalFiles = activeDownloads.size
-        val completedFiles = activeDownloads.count { it.state == DownloadState.COMPLETED }
-        val totalBytes = activeDownloads.sumOf { it.totalBytes }
-        val downloadedBytes = activeDownloads.sumOf { it.downloadedBytes }
-        return when {
-            activeDownloads.all { it.state == DownloadState.COMPLETED } -> {
-                BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
-            }
 
-            activeDownloads.any { it.state == DownloadState.FAILED } -> {
-                BookDownloadStatus.Failed(
-                    bookId = bookId,
-                    errorMessage =
-                        activeDownloads
-                            .firstOrNull { it.state == DownloadState.FAILED }
-                            ?.errorMessage
-                            ?: "Download failed",
-                    partiallyDownloadedFiles = completedFiles,
-                )
-            }
+        hasActive -> {
+            BookDownloadStatus.InProgress(
+                bookId = bookId,
+                totalFiles = totalFiles,
+                downloadingFiles = relevant.count { it.state == DownloadState.DOWNLOADING },
+                completedFiles = completedFiles,
+                totalBytes = totalBytes,
+                downloadedBytes = downloadedBytes,
+            )
+        }
 
-            activeDownloads.all { it.state == DownloadState.PAUSED } -> {
-                BookDownloadStatus.Paused(
-                    bookId = bookId,
-                    pausedFiles = activeDownloads.size,
-                    downloadedBytes = downloadedBytes,
-                    totalBytes = totalBytes,
-                )
-            }
-
-            else -> {
-                BookDownloadStatus.InProgress(
-                    bookId = bookId,
-                    totalFiles = totalFiles,
-                    downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
-                    completedFiles = completedFiles,
-                    totalBytes = totalBytes,
-                    downloadedBytes = downloadedBytes,
-                )
-            }
+        // Nothing active, not all complete, no failures: a stopped partial (a mix of
+        // PAUSED / CANCELLED / COMPLETED). Surface as Paused so the UI offers resume.
+        else -> {
+            BookDownloadStatus.Paused(
+                bookId = bookId,
+                pausedFiles =
+                    relevant.count {
+                        it.state == DownloadState.PAUSED || it.state == DownloadState.CANCELLED
+                    },
+                downloadedBytes = downloadedBytes,
+                totalBytes = totalBytes,
+            )
         }
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPrepareRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPrepareRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.api.PlaybackService
 import com.calypsan.listenup.api.dto.PreparedPlayback
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.PlaybackPositionSyncPayload
 import com.calypsan.listenup.client.data.remote.RpcChannel
 import com.calypsan.listenup.client.domain.repository.PlaybackPrepareRepository
 import com.calypsan.listenup.core.BookId
@@ -17,4 +18,8 @@ internal class PlaybackPrepareRepositoryImpl(
     private val channel: RpcChannel<PlaybackService>,
 ) : PlaybackPrepareRepository {
     override suspend fun prepare(bookId: BookId): AppResult<PreparedPlayback> = channel.call { it.prepare(bookId) }
+
+    // idempotent read — safe for the channel to retry / single-flight.
+    override suspend fun getPosition(bookId: BookId): AppResult<PlaybackPositionSyncPayload?> =
+        channel.call(idempotent = true) { it.getPosition(bookId) }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -544,6 +544,9 @@ internal val settingsPresentationModule =
                 downloadService = get(),
                 storageSpaceProvider = get(),
                 errorBus = get(),
+                // The concrete PlaybackManager implements PlaybackStateProvider (same narrowing as
+                // AuthModule's LogoutUseCase wiring) — used to refuse deleting the playing book (B9).
+                playbackStateProvider = get<com.calypsan.listenup.client.playback.PlaybackManager>(),
             )
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
@@ -87,8 +87,15 @@ interface DownloadRepository {
      */
     suspend fun cancelForBook(bookId: BookId): AppResult<Unit>
 
-    /** Delete all download records for a book (used post-playback completion). */
+    /** Delete all download records for a book. */
     suspend fun deleteForBook(bookId: String)
+
+    /**
+     * Delete only the [DownloadStatus.DELETED]-tombstone rows for a book (used post-playback
+     * completion). COMPLETED rows and their local files are preserved so a finished book's offline
+     * copy stays playable — clearing the tombstones only re-enables auto-download on a future listen.
+     */
+    suspend fun deleteDeletedRecordsForBook(bookId: String)
 
     /**
      * App-startup recovery: re-enqueue any incomplete downloads via the platform

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackPrepareRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackPrepareRepository.kt
@@ -4,6 +4,7 @@ package com.calypsan.listenup.client.domain.repository
 
 import com.calypsan.listenup.api.dto.PreparedPlayback
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.PlaybackPositionSyncPayload
 import com.calypsan.listenup.core.BookId
 
 /**
@@ -19,4 +20,15 @@ import com.calypsan.listenup.core.BookId
 interface PlaybackPrepareRepository {
     /** Signed stream URLs for [bookId] plus the caller's resume position — one round-trip. */
     suspend fun prepare(bookId: BookId): AppResult<PreparedPlayback>
+
+    /**
+     * The server-authoritative resume position for [bookId], or null if the server has none.
+     *
+     * The fully-downloaded playback path skips [prepare] entirely (offline-first), so it never sees
+     * the server's position and cannot reconcile a stale local Room row against another device's
+     * newer progress. This best-effort read closes that clobber for downloaded books — the caller
+     * folds the result through the same newer-wins merge and degrades to the local row on any
+     * failure (offline), never blocking or failing playback.
+     */
+    suspend fun getPosition(bookId: BookId): AppResult<PlaybackPositionSyncPayload?>
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
@@ -3,7 +3,6 @@
 package com.calypsan.listenup.client.download
 
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.api.result.onFailure
 import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.core.suspendRunCatching
@@ -106,10 +105,24 @@ internal suspend fun downloadAudioFile(
                     // non-2xx; we only see successful or partial-content responses here. Status code 206
                     // is success per RFC 7233; treat it the same as 200.
 
+                    // Range-honored guard: we only send a Range header when startByte > 0. A 200 OK back
+                    // means the server (or an intervening proxy) IGNORED the Range and is streaming the
+                    // WHOLE body. Appending that full body onto the partial temp would yield a corrupt
+                    // startByte+fullSize file. Truncate the temp and restart cleanly from byte 0 instead.
+                    val serverIgnoredRange = startByte > 0 && response.status != HttpStatusCode.PartialContent
+                    if (serverIgnoredRange) {
+                        logger.warn {
+                            "Server ignored Range for $audioFileId (status ${response.status.value}); " +
+                                "restarting from byte 0 to avoid a corrupt append"
+                        }
+                        SystemFileSystem.delete(tempPath)
+                    }
+                    val effectiveStartByte = if (serverIgnoredRange) 0L else startByte
+
                     val contentLength = response.contentLength() ?: -1L
                     val totalSize =
-                        if (startByte > 0 && response.status == HttpStatusCode.PartialContent) {
-                            startByte + contentLength
+                        if (effectiveStartByte > 0 && response.status == HttpStatusCode.PartialContent) {
+                            effectiveStartByte + contentLength
                         } else {
                             contentLength
                         }
@@ -117,17 +130,17 @@ internal suspend fun downloadAudioFile(
                     // Update total size in DB up front so the UI shows progress against the right denominator.
                     if (totalSize > 0) {
                         // Progress write is best-effort UI feedback; a dropped update is corrected by the next tick.
-                        val _ = repository.updateProgress(audioFileId, startByte, totalSize)
+                        val _ = repository.updateProgress(audioFileId, effectiveStartByte, totalSize)
                     }
 
-                    // Stream the body into the temp file. Append mode iff we're resuming.
+                    // Stream the body into the temp file. Append mode iff we're genuinely resuming.
                     val channel = response.bodyAsChannel()
-                    val sink = SystemFileSystem.sink(tempPath, append = startByte > 0).buffered()
+                    val sink = SystemFileSystem.sink(tempPath, append = effectiveStartByte > 0).buffered()
                     try {
                         val buffer = ByteArray(BUFFER_SIZE)
-                        var totalBytesRead = startByte
+                        var totalBytesRead = effectiveStartByte
                         var lastProgressUpdate = 0L
-                        var lastProgressBytes = startByte
+                        var lastProgressBytes = effectiveStartByte
 
                         while (!channel.isClosedForRead) {
                             if (isStopped()) {
@@ -160,11 +173,26 @@ internal suspend fun downloadAudioFile(
                         sink.close()
                     }
 
-                    // Verify size if known.
+                    // Integrity gate. Prefer the caller's [expectedSize]; fall back to the server's
+                    // advertised total ([totalSize], from Content-Length, adjusted for resume). A
+                    // download we cannot verify against ANY known size is a FAILURE — a stream that
+                    // closes early without a transport error would otherwise be atomicMove'd and
+                    // markCompleted'd at a bogus 100%.
                     val writtenSize = SystemFileSystem.metadataOrNull(tempPath)?.size ?: 0L
-                    if (expectedSize > 0 && writtenSize != expectedSize) {
+                    val verificationTarget = if (expectedSize > 0) expectedSize else totalSize
+                    if (verificationTarget > 0) {
+                        if (writtenSize != verificationTarget) {
+                            SystemFileSystem.delete(tempPath)
+                            throw IOException(
+                                "Size mismatch for $audioFileId: expected $verificationTarget, got $writtenSize",
+                            )
+                        }
+                    } else {
                         SystemFileSystem.delete(tempPath)
-                        throw IOException("Size mismatch: expected $expectedSize, got $writtenSize")
+                        throw IOException(
+                            "Download for $audioFileId is unverifiable (no expected size and no " +
+                                "Content-Length); failing rather than finalizing a possibly-truncated file",
+                        )
                     }
 
                     // Move temp to final destination via FileManager.
@@ -172,18 +200,31 @@ internal suspend fun downloadAudioFile(
                         throw IOException("Failed to move temp file to destination")
                     }
 
-                    // Mark complete via repository. The file is already on disk, so a failed DB write
-                    // leaves a recoverable inconsistency — surface it loudly rather than silently.
-                    repository
-                        .markCompleted(
-                            audioFileId = audioFileId,
-                            localPath = destPath.toString(),
-                            completedAt = currentEpochMilliseconds(),
-                        ).onFailure {
-                            logger.error {
-                                "Download finished on disk but markCompleted failed for $audioFileId: ${it.message}"
-                            }
+                    // Mark complete via repository. The file is already on disk; if the DB write fails
+                    // the row is still DOWNLOADING, so surface it as a FAILURE (B10c) rather than
+                    // logging "complete" over a lying state — the worker then records FAILED honestly.
+                    when (
+                        val completed =
+                            repository.markCompleted(
+                                audioFileId = audioFileId,
+                                localPath = destPath.toString(),
+                                completedAt = currentEpochMilliseconds(),
+                            )
+                    ) {
+                        is AppResult.Success -> {
+                            Unit
                         }
+
+                        is AppResult.Failure -> {
+                            logger.error {
+                                "Download finished on disk but markCompleted failed for $audioFileId: " +
+                                    completed.error.message
+                            }
+                            throw IOException(
+                                "markCompleted failed after file landed for $audioFileId: ${completed.error.message}",
+                            )
+                        }
+                    }
                 }
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
@@ -66,6 +66,18 @@ interface DownloadService {
     suspend fun deleteDownload(bookId: BookId)
 
     /**
+     * Delete every downloaded file and every download record in one sweep ("Delete All Downloads").
+     *
+     * Unlike iterating [deleteDownload] over the books known to the library, this reclaims *orphaned*
+     * files and rows too — downloads whose book is no longer in the local library would otherwise be
+     * invisible and unreclaimable. Platform impls wipe the audiobooks directory and the downloads
+     * table; the default no-ops (desktop has no downloads).
+     */
+    suspend fun deleteAllDownloads() {
+        // Default no-op — platforms without a download backend (desktop) have nothing to reclaim.
+    }
+
+    /**
      * Observe download status for a book as a Flow.
      */
     fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus>

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -196,7 +196,14 @@ class PlaybackPreparer internal constructor(
         // drains, resumes from a stale local row, then stamps that stale position lastPlayedAt=now
         // and permanently clobbers another device's newer progress.
         val savedPosition = progressTracker.getResumePosition(bookId)
-        val resolved = resolveResumePosition(savedPosition, buildResult.serverResumePosition)
+        // On the fully-downloaded path prepare() is skipped, so buildResult carries no server
+        // position. Fetch the authoritative position directly (best-effort, bounded) so downloaded
+        // books get the same newer-wins reconcile streaming books already get — closing the F1
+        // clobber for the offline case. Any failure (offline / RPC) degrades to the local row.
+        val serverPosition =
+            buildResult.serverResumePosition
+                ?: if (timeline.isFullyDownloaded) fetchAuthoritativePosition(bookId) else null
+        val resolved = resolveResumePosition(savedPosition, serverPosition)
 
         val resumePositionMs =
             if (resolved?.isFinished == true) {
@@ -318,6 +325,30 @@ class PlaybackPreparer internal constructor(
                 "(${totalDuration / MS_PER_SECOND}s / ${totalDuration / MS_PER_MINUTE}min) ==="
         }
     }
+
+    /**
+     * Best-effort, non-blocking fetch of the server-authoritative resume position for the
+     * fully-downloaded path (where [buildTimeline] skips `prepare()` and never sees it).
+     *
+     * Routed through the bounded, self-healing [PlaybackPrepareRepository] so a dead-socket transport
+     * fault surfaces as a typed, time-bounded [AppResult.Failure] rather than an exception. On ANY
+     * failure — offline, RPC error — it returns null so resume resolves from the local Room row
+     * exactly as before: it never blocks or fails playback.
+     */
+    private suspend fun fetchAuthoritativePosition(bookId: BookId): PlaybackPositionSyncPayload? =
+        when (val result = prepareRepository.getPosition(bookId)) {
+            is AppResult.Success -> {
+                result.data
+            }
+
+            is AppResult.Failure -> {
+                logger.debug {
+                    "getPosition failed for downloaded book ${bookId.value} (${result.error.code}); " +
+                        "resuming from the local Room row"
+                }
+                null
+            }
+        }
 
     /**
      * Build the [PlaybackTimeline]: resolve each file's local path, fetch signed

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -340,20 +340,17 @@ class PlaybackPreparer internal constructor(
         // (streaming path). Null on the fully-downloaded path — resume then resolves from Room alone.
         var serverResumePosition: PlaybackPositionSyncPayload? = null
 
+        val downloadedCount = localPaths.values.count { it != null }
+        val missingCount = localPaths.size - downloadedCount
+
         val signedUrls: Map<String, String> =
-            if (localPaths.values.all { it != null }) {
+            if (missingCount == 0) {
                 emptyMap() // fully downloaded — never touch the server (offline-first)
             } else {
-                // Diagnostic for the "downloaded but won't play offline" corruption edge: if SOME
-                // files are local but not all, a book the UI shows as downloaded still falls to the
-                // streaming path here and fails when offline. Surface it so it isn't a silent mystery.
-                if (localPaths.values.any { it != null }) {
-                    val missing = localPaths.values.count { it == null }
-                    logger.warn {
-                        "Book ${bookId.value}: $missing of ${localPaths.size} audio file(s) have no local path " +
-                            "despite others being downloaded — using streaming (will fail offline). Possible partial/corrupt download."
-                    }
-                }
+                // Some files are missing → we need signed streaming URLs for them. prepare() returns
+                // per-file URLs for the whole book; localPath still wins in playbackUri, so downloaded
+                // files play from disk and only the missing ones stream.
+                //
                 // Routed through the bounded, self-healing engine so a dead-socket transport throw
                 // becomes a typed, time-bounded AppResult.Failure instead of an unguarded exception
                 // crossing the Swift Export seam as an opaque KotlinError.
@@ -364,8 +361,21 @@ class PlaybackPreparer internal constructor(
                     }
 
                     is AppResult.Failure -> {
-                        logger.error { "prepare() failed for ${bookId.value}: ${result.error.message}" }
-                        return null
+                        // prepare() failed — almost always offline. Never-stranded: if SOME files are
+                        // downloaded, build the timeline from the local files so the downloaded portion
+                        // plays offline instead of failing the whole book. The missing files get no URL
+                        // (honest gap — playbackUri "" — not a fake streaming URL that would fail anyway).
+                        if (downloadedCount == 0) {
+                            logger.error {
+                                "prepare() failed for ${bookId.value} and no files are downloaded: ${result.error.message}"
+                            }
+                            return null
+                        }
+                        logger.warn {
+                            "prepare() failed for ${bookId.value} (${result.error.code}); playing $downloadedCount " +
+                                "downloaded file(s) offline, $missingCount unavailable until reconnect."
+                        }
+                        emptyMap()
                     }
                 }
             }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -299,16 +299,17 @@ open class ProgressTracker(
         scope.launch {
             logger.info { "Book finished: ${bookId.value}, finalPosition=$finalPositionMs" }
 
-            // Clear any DELETED download records so future playback will auto-download again
-            // This means that the next time a user wants to listen to the same book. We assume
-            // They want the default behavior again (stream + download)
+            // Clear only DELETED tombstones so a re-listen auto-downloads again (default stream +
+            // download behavior). COMPLETED rows and their local files MUST survive — wiping them
+            // here would orphan the multi-GB files on disk and force every future play to stream,
+            // failing offline. This is the "finishing a book destroys its offline copy" fix.
             try {
-                downloadRepository.deleteForBook(bookId.value)
-                logger.debug { "Cleared download records for finished book: ${bookId.value}" }
+                downloadRepository.deleteDeletedRecordsForBook(bookId.value)
+                logger.debug { "Cleared DELETED download tombstones for finished book: ${bookId.value}" }
             } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                 throw e
             } catch (e: Exception) {
-                logger.warn { "Failed to delete download records for ${bookId.value} (non-fatal): ${e.message}" }
+                logger.warn { "Failed to clear download tombstones for ${bookId.value} (non-fatal): ${e.message}" }
             }
 
             // Mark book as complete

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModel.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.StorageSpaceProvider
+import com.calypsan.listenup.client.playback.PlaybackStateProvider
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -30,6 +31,11 @@ data class StorageUiState(
     val downloadedBooks: List<DownloadedBookSummary> = emptyList(),
     val deleteConfirmation: DeleteConfirmation? = null,
     val isDeleting: Boolean = false,
+    /**
+     * Set to a book's title when a delete was refused because that book is currently playing
+     * (B9). The UI surfaces a "stop playback first" message; [dismissDeleteBlocked] clears it.
+     */
+    val blockedDeletionTitle: String? = null,
 )
 
 /**
@@ -55,6 +61,7 @@ class StorageViewModel(
     private val downloadService: DownloadService,
     private val storageSpaceProvider: StorageSpaceProvider,
     private val errorBus: ErrorBus,
+    private val playbackStateProvider: PlaybackStateProvider,
 ) : ViewModel() {
     private val internalState = MutableStateFlow(StorageUiState())
 
@@ -99,6 +106,13 @@ class StorageViewModel(
     }
 
     /**
+     * Dismiss the "can't delete the currently-playing book" notice (B9).
+     */
+    fun dismissDeleteBlocked() {
+        internalState.update { it.copy(blockedDeletionTitle = null) }
+    }
+
+    /**
      * Execute the confirmed delete action.
      */
     fun executeDelete() {
@@ -108,8 +122,17 @@ class StorageViewModel(
             try {
                 when (confirmation) {
                     is DeleteConfirmation.SingleBook -> {
+                        val targetBookId = BookId(confirmation.book.bookId)
+                        // Never-stranded guard (B9): deleting the currently-playing book would unlink
+                        // the file:// sources under an active session (platform behaviour on unlinked
+                        // files varies). Refuse and surface a "stop playback first" notice instead.
+                        if (playbackStateProvider.currentBookId.value == targetBookId) {
+                            logger.warn { "Refusing to delete the currently-playing book: ${confirmation.book.title}" }
+                            internalState.update { it.copy(blockedDeletionTitle = confirmation.book.title) }
+                            return@launch
+                        }
                         logger.info { "Deleting download: ${confirmation.book.title}" }
-                        downloadService.deleteDownload(BookId(confirmation.book.bookId))
+                        downloadService.deleteDownload(targetBookId)
                     }
 
                     is DeleteConfirmation.AllDownloads -> {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModel.kt
@@ -114,9 +114,9 @@ class StorageViewModel(
 
                     is DeleteConfirmation.AllDownloads -> {
                         logger.info { "Clearing all downloads" }
-                        state.value.downloadedBooks.forEach { book ->
-                            downloadService.deleteDownload(BookId(book.bookId))
-                        }
+                        // Wipe files + rows in one sweep so orphaned downloads (whose book is no
+                        // longer in the library, hence absent from downloadedBooks) are reclaimed too.
+                        downloadService.deleteAllDownloads()
                     }
                 }
             } catch (e: kotlin.coroutines.cancellation.CancellationException) {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -138,6 +138,12 @@ internal open class FakeDownloadRepository(
         state.update { current -> current.filterValues { it.bookId != bookId } }
     }
 
+    override suspend fun deleteDeletedRecordsForBook(bookId: String) {
+        state.update { current ->
+            current.filterValues { it.bookId != bookId || it.state != DownloadState.DELETED }
+        }
+    }
+
     override suspend fun resumeIncompleteDownloads(): AppResult<Unit> = AppResult.Success(Unit)
 
     // --- Test helpers ---
@@ -157,54 +163,9 @@ internal open class FakeDownloadRepository(
         }
     }
 
+    // Delegates to the production reducer so the fake and DownloadRepositoryImpl stay in lock-step.
     private fun aggregate(
         bookId: String,
         downloads: List<DownloadEntity>,
-    ): BookDownloadStatus {
-        if (downloads.isEmpty()) return BookDownloadStatus.NotDownloaded(bookId)
-        val activeDownloads =
-            downloads.filter {
-                it.state != DownloadState.DELETED && it.state != DownloadState.CANCELLED
-            }
-        if (activeDownloads.isEmpty()) return BookDownloadStatus.NotDownloaded(bookId)
-        val totalFiles = activeDownloads.size
-        val completedFiles = activeDownloads.count { it.state == DownloadState.COMPLETED }
-        val totalBytes = activeDownloads.sumOf { it.totalBytes }
-        val downloadedBytes = activeDownloads.sumOf { it.downloadedBytes }
-        return when {
-            activeDownloads.all { it.state == DownloadState.COMPLETED } -> {
-                BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
-            }
-
-            activeDownloads.any { it.state == DownloadState.FAILED } -> {
-                BookDownloadStatus.Failed(
-                    bookId = bookId,
-                    errorMessage =
-                        activeDownloads.firstOrNull { it.state == DownloadState.FAILED }?.errorMessage
-                            ?: "Download failed",
-                    partiallyDownloadedFiles = completedFiles,
-                )
-            }
-
-            activeDownloads.all { it.state == DownloadState.PAUSED } -> {
-                BookDownloadStatus.Paused(
-                    bookId = bookId,
-                    pausedFiles = activeDownloads.size,
-                    downloadedBytes = downloadedBytes,
-                    totalBytes = totalBytes,
-                )
-            }
-
-            else -> {
-                BookDownloadStatus.InProgress(
-                    bookId = bookId,
-                    totalFiles = totalFiles,
-                    downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
-                    completedFiles = completedFiles,
-                    totalBytes = totalBytes,
-                    downloadedBytes = downloadedBytes,
-                )
-            }
-        }
-    }
+    ): BookDownloadStatus = aggregateBookDownloadStatus(bookId, downloads)
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -30,8 +30,12 @@ import kotlinx.coroutines.flow.update
 internal open class FakeDownloadRepository(
     initial: List<DownloadEntity> = emptyList(),
     private val enqueueFailure: ((BookId) -> AppResult<DownloadOutcome>)? = null,
+    private val markCompletedFailure: DownloadError? = null,
 ) : DownloadRepository {
     private val state = MutableStateFlow(initial.associateBy { it.audioFileId })
+
+    private val terminalStatesForPause =
+        setOf(DownloadState.CANCELLED, DownloadState.DELETED, DownloadState.COMPLETED)
 
     /** All entities currently in the fake (test-only inspection). */
     val entities: List<DownloadEntity> get() = state.value.values.toList()
@@ -88,6 +92,7 @@ internal open class FakeDownloadRepository(
         localPath: String,
         completedAt: Long,
     ): AppResult<Unit> {
+        markCompletedFailure?.let { return AppResult.Failure(it) }
         update(audioFileId) {
             it.copy(
                 state = DownloadState.COMPLETED,
@@ -100,7 +105,10 @@ internal open class FakeDownloadRepository(
     }
 
     override suspend fun markPaused(audioFileId: String): AppResult<Unit> {
-        update(audioFileId) { it.copy(state = DownloadState.PAUSED) }
+        // Mirror the production guarded DAO query (B7): pausing never clobbers a terminal state.
+        update(audioFileId) { current ->
+            if (current.state in terminalStatesForPause) current else current.copy(state = DownloadState.PAUSED)
+        }
         return AppResult.Success(Unit)
     }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
@@ -6,6 +6,9 @@ import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
 import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.StorageSpaceProvider
+import com.calypsan.listenup.client.playback.PlaybackStateProvider
+import dev.mokkery.verify.VerifyMode.Companion.not
+import kotlinx.coroutines.flow.StateFlow
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -43,6 +46,16 @@ class StorageViewModelTest :
         beforeTest { Dispatchers.setMain(testDispatcher) }
         afterTest { Dispatchers.resetMain() }
 
+        // Minimal in-memory PlaybackStateProvider (B9 guard): reports [playingBookId] as the
+        // currently-playing book. Seam-level fake, not a mock (Testing rubric).
+        class FakePlaybackStateProvider(
+            playingBookId: BookId? = null,
+        ) : PlaybackStateProvider {
+            override val currentBookId: StateFlow<BookId?> = MutableStateFlow(playingBookId)
+
+            override fun clearPlayback() = Unit
+        }
+
         class Fixture(
             val downloadRepository: StorageViewModelFakeDownloadRepository,
             val downloadService: DownloadService,
@@ -53,6 +66,7 @@ class StorageViewModelTest :
             downloads: List<DownloadedBookSummary> = emptyList(),
             totalUsed: Long = 0L,
             available: Long = 1_000_000L,
+            playingBookId: BookId? = null,
         ): Pair<StorageViewModel, Fixture> {
             val fixture =
                 Fixture(
@@ -69,6 +83,7 @@ class StorageViewModelTest :
                     downloadService = fixture.downloadService,
                     storageSpaceProvider = fixture.storageSpaceProvider,
                     errorBus = ErrorBus(),
+                    playbackStateProvider = FakePlaybackStateProvider(playingBookId),
                 )
             return vm to fixture
         }
@@ -111,6 +126,62 @@ class StorageViewModelTest :
                         fileCount = 1,
                     )
                 val (vm, fixture) = buildVm(downloads = listOf(summary))
+                everySuspend { fixture.downloadService.deleteDownload(any()) } returns Unit
+
+                vm.state.test {
+                    skipItems(2)
+                    vm.confirmDeleteBook(summary)
+                    vm.executeDelete()
+                    advanceUntilIdle()
+                    verifySuspend { fixture.downloadService.deleteDownload(BookId("b1")) }
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("executeDelete on the currently-playing book is refused and does not call deleteDownload (B9)") {
+            runTest {
+                val summary =
+                    DownloadedBookSummary(
+                        bookId = "b1",
+                        title = "Now Playing Book",
+                        authorNames = "A",
+                        coverBlurHash = null,
+                        sizeBytes = 1L,
+                        fileCount = 1,
+                    )
+                // b1 is currently playing.
+                val (vm, fixture) = buildVm(downloads = listOf(summary), playingBookId = BookId("b1"))
+                everySuspend { fixture.downloadService.deleteDownload(any()) } returns Unit
+
+                vm.state.test {
+                    skipItems(2)
+                    vm.confirmDeleteBook(summary)
+                    vm.executeDelete()
+                    advanceUntilIdle()
+                    // Deletion is refused: the file:// sources of the active session are never unlinked.
+                    verifySuspend(not) { fixture.downloadService.deleteDownload(any()) }
+                    // The UI is told why.
+                    val blocked = expectMostRecentItem()
+                    blocked.blockedDeletionTitle shouldBe "Now Playing Book"
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("executeDelete on a non-playing book proceeds even while a DIFFERENT book plays (B9)") {
+            runTest {
+                val summary =
+                    DownloadedBookSummary(
+                        bookId = "b1",
+                        title = "B",
+                        authorNames = "A",
+                        coverBlurHash = null,
+                        sizeBytes = 1L,
+                        fileCount = 1,
+                    )
+                // A different book (b2) is playing → deleting b1 is safe.
+                val (vm, fixture) = buildVm(downloads = listOf(summary), playingBookId = BookId("b2"))
                 everySuspend { fixture.downloadService.deleteDownload(any()) } returns Unit
 
                 vm.state.test {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
@@ -124,20 +124,21 @@ class StorageViewModelTest :
             }
         }
 
-        test("confirmClearAll then executeDelete calls deleteDownload once per book") {
+        test("confirmClearAll then executeDelete wipes all downloads in one sweep (reclaims orphans)") {
             runTest {
                 val s1 = DownloadedBookSummary("b1", "B1", "A", null, 10L, 1)
                 val s2 = DownloadedBookSummary("b2", "B2", "A", null, 20L, 1)
                 val (vm, fixture) = buildVm(downloads = listOf(s1, s2))
-                everySuspend { fixture.downloadService.deleteDownload(any()) } returns Unit
+                everySuspend { fixture.downloadService.deleteAllDownloads() } returns Unit
 
                 vm.state.test {
                     skipItems(2)
                     vm.confirmClearAll()
                     vm.executeDelete()
                     advanceUntilIdle()
-                    verifySuspend { fixture.downloadService.deleteDownload(BookId("b1")) }
-                    verifySuspend { fixture.downloadService.deleteDownload(BookId("b2")) }
+                    // Single sweep (files + rows), NOT a per-known-book loop — so orphaned downloads
+                    // whose book left the library are reclaimed too.
+                    verifySuspend { fixture.downloadService.deleteAllDownloads() }
                     cancelAndIgnoreRemainingEvents()
                 }
             }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeDownloadRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeDownloadRepository.kt
@@ -80,5 +80,7 @@ class FakeDownloadRepository(
 
     override suspend fun deleteForBook(bookId: String) = Unit
 
+    override suspend fun deleteDeletedRecordsForBook(bookId: String) = Unit
+
     override suspend fun resumeIncompleteDownloads(): AppResult<Unit> = AppResult.Success(Unit)
 }

--- a/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -84,6 +84,7 @@ internal val iosPlaybackModule: Module =
                 tokenProvider = get(),
                 fileManager = get(),
                 prepareRepository = get(),
+                downloadRepository = get(),
                 scope = get(qualifier = named(PLAYBACK_SCOPE)),
                 playbackBandwidthCoordinator = get(),
             )

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.jvm.kt
@@ -108,10 +108,12 @@ actual open class DownloadFileManager(
             .walkTopDown()
             .filter { it.isFile && it.name.endsWith(".tmp") }
             .forEach { file ->
-                // Filename format: "${audioFileId}_${filename}.tmp"
-                // The audioFileId is everything before the first '_'.
-                val audioFileId = file.name.substringBefore('_')
-                if (audioFileId !in activeAudioFileIds && file.delete()) deleted++
+                // Filename format: "${audioFileId}_${filename}.tmp". A .tmp is orphaned iff NO active
+                // id is a prefix of its name. Matching the FULL id ("${id}_") — not substring-before-
+                // first-'_' — keeps ids that legitimately contain '_' from being mis-parsed and their
+                // ACTIVE partials wrongly deleted (B10e).
+                val isActive = activeAudioFileIds.any { file.name.startsWith("${it}_") }
+                if (!isActive && file.delete()) deleted++
             }
         return deleted
     }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
@@ -105,6 +105,38 @@ class DownloadDaoTest :
             }
         }
 
+        test("deleteDeletedRecordsForBook removes only DELETED rows, preserving COMPLETED downloads") {
+            val db = createInMemoryTestDatabase()
+            val dao = db.downloadDao()
+            try {
+                runTest {
+                    dao.insertAll(
+                        listOf(
+                            entity("file-1", bookId = "book-1", state = DownloadState.COMPLETED)
+                                .copy(localPath = "/path/to/file-1"),
+                            entity("file-2", bookId = "book-1", state = DownloadState.DELETED),
+                            entity("file-3", bookId = "book-1", state = DownloadState.QUEUED),
+                            entity("file-4", bookId = "book-2", state = DownloadState.DELETED), // other book
+                        ),
+                    )
+
+                    dao.deleteDeletedRecordsForBook("book-1")
+
+                    val remaining = dao.observeAll().first().associateBy { it.audioFileId }
+                    // Only book-1's DELETED tombstone is gone.
+                    remaining.keys shouldBe setOf("file-1", "file-3", "file-4")
+                    // The COMPLETED download and its local file path survive (offline copy stays playable).
+                    remaining["file-1"]!!.state shouldBe DownloadState.COMPLETED
+                    remaining["file-1"]!!.localPath shouldBe "/path/to/file-1"
+                    dao.getLocalPath("file-1") shouldBe "/path/to/file-1"
+                    // Other book's tombstone is untouched.
+                    remaining["file-4"]!!.state shouldBe DownloadState.DELETED
+                }
+            } finally {
+                db.close()
+            }
+        }
+
         test("hasDeletedRecords returns true if any DELETED row exists for a book") {
             val db = createInMemoryTestDatabase()
             val dao = db.downloadDao()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
@@ -59,6 +59,62 @@ class DownloadDaoTest :
             }
         }
 
+        test("markPausedIfNotTerminal is a no-op on terminal rows but pauses an active row (B7)") {
+            val db = createInMemoryTestDatabase()
+            val dao = db.downloadDao()
+            try {
+                runTest {
+                    dao.insertAll(
+                        listOf(
+                            entity("file-cancelled", state = DownloadState.CANCELLED),
+                            entity("file-deleted", state = DownloadState.DELETED),
+                            entity("file-completed", state = DownloadState.COMPLETED),
+                            entity("file-active", state = DownloadState.DOWNLOADING),
+                        ),
+                    )
+
+                    // A late worker-cleanup pause must NOT clobber a terminal state.
+                    dao.markPausedIfNotTerminal("file-cancelled")
+                    dao.markPausedIfNotTerminal("file-deleted")
+                    dao.markPausedIfNotTerminal("file-completed")
+                    // ...but a genuinely in-flight row still pauses (e.g. auth-failure pause).
+                    dao.markPausedIfNotTerminal("file-active")
+
+                    val byId = dao.observeAll().first().associateBy { it.audioFileId }
+                    byId["file-cancelled"]!!.state shouldBe DownloadState.CANCELLED
+                    byId["file-deleted"]!!.state shouldBe DownloadState.DELETED
+                    byId["file-completed"]!!.state shouldBe DownloadState.COMPLETED
+                    byId["file-active"]!!.state shouldBe DownloadState.PAUSED
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("getIncomplete excludes FAILED rows past the retry budget but keeps retriable ones (B10b)") {
+            val db = createInMemoryTestDatabase()
+            val dao = db.downloadDao()
+            try {
+                runTest {
+                    dao.insertAll(
+                        listOf(
+                            entity("failed-exhausted", state = DownloadState.FAILED).copy(retryCount = 3),
+                            entity("failed-retriable", state = DownloadState.FAILED).copy(retryCount = 1),
+                            entity("queued", state = DownloadState.QUEUED),
+                            entity("downloading", state = DownloadState.DOWNLOADING),
+                        ),
+                    )
+
+                    val incomplete = dao.getIncomplete()
+                    // The exhausted FAILED row no longer churns on every startup; the retriable one still resumes.
+                    incomplete.map { it.audioFileId }.toSet() shouldBe
+                        setOf("failed-retriable", "queued", "downloading")
+                }
+            } finally {
+                db.close()
+            }
+        }
+
         test("getLocalPath returns localPath for COMPLETED rows only") {
             val db = createInMemoryTestDatabase()
             val dao = db.downloadDao()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookDetail
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.repository.BookRepository
@@ -233,6 +234,161 @@ class DownloadRepositoryImplTest :
                         items.first().bookId shouldBe "b2"
                         cancelAndIgnoreRemainingEvents()
                     }
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // ── B2: cancelled partial must NOT report Completed ──────────────────────────────────
+
+        test("observeBookStatus: partial cancel (3 completed + 7 cancelled) is NOT Completed") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = FakeBookRepository(),
+                            enqueuer = FakeDownloadEnqueuer(),
+                        )
+
+                    val rows =
+                        (1..10).map { i ->
+                            makeDownload(
+                                id = "f$i",
+                                bookId = "b1",
+                                state = if (i <= 3) DownloadState.COMPLETED else DownloadState.CANCELLED,
+                                bytes = 100_000L,
+                            )
+                        }
+                    downloadDao.insertAll(rows)
+
+                    sut.observeBookStatus(BookId("b1")).test {
+                        val status = awaitItem()
+                        // Pre-fix this was BookDownloadStatus.Completed → isFullyDownloaded=true → false
+                        // "Downloaded" that fails offline. It must NOT be Completed.
+                        (status is BookDownloadStatus.Completed) shouldBe false
+                        // It's a stopped partial → Paused (UI offers resume; availability withholds canPlay).
+                        (status is BookDownloadStatus.Paused) shouldBe true
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("observeBookStatus: all files completed IS Completed") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = FakeBookRepository(),
+                            enqueuer = FakeDownloadEnqueuer(),
+                        )
+                    downloadDao.insertAll(
+                        listOf(
+                            makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 1L),
+                            makeDownload(id = "f2", bookId = "b1", state = DownloadState.COMPLETED, bytes = 2L),
+                        ),
+                    )
+
+                    sut.observeBookStatus(BookId("b1")).test {
+                        (awaitItem() is BookDownloadStatus.Completed) shouldBe true
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("observeBookStatus: all files cancelled collapses to NotDownloaded") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = FakeBookRepository(),
+                            enqueuer = FakeDownloadEnqueuer(),
+                        )
+                    downloadDao.insertAll(
+                        listOf(
+                            makeDownload(id = "f1", bookId = "b1", state = DownloadState.CANCELLED, bytes = 1L),
+                            makeDownload(id = "f2", bookId = "b1", state = DownloadState.CANCELLED, bytes = 2L),
+                        ),
+                    )
+
+                    sut.observeBookStatus(BookId("b1")).test {
+                        (awaitItem() is BookDownloadStatus.NotDownloaded) shouldBe true
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("observeBookStatus: pure queued reports InProgress (not stomped by the partial-cancel path)") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = FakeBookRepository(),
+                            enqueuer = FakeDownloadEnqueuer(),
+                        )
+                    downloadDao.insertAll(
+                        listOf(
+                            makeDownload(id = "f1", bookId = "b1", state = DownloadState.QUEUED, bytes = 1L),
+                            makeDownload(id = "f2", bookId = "b1", state = DownloadState.DOWNLOADING, bytes = 2L),
+                        ),
+                    )
+
+                    sut.observeBookStatus(BookId("b1")).test {
+                        (awaitItem() is BookDownloadStatus.InProgress) shouldBe true
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // ── B1: finish clears only DELETED tombstones ────────────────────────────────────────
+
+        test("deleteDeletedRecordsForBook removes only DELETED rows, preserving COMPLETED downloads") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = FakeBookRepository(),
+                            enqueuer = FakeDownloadEnqueuer(),
+                        )
+                    downloadDao.insertAll(
+                        listOf(
+                            makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 100L),
+                            makeDownload(id = "f2", bookId = "b1", state = DownloadState.DELETED, bytes = 200L),
+                        ),
+                    )
+
+                    sut.deleteDeletedRecordsForBook("b1")
+
+                    // COMPLETED download + local path survive so the finished book still plays offline.
+                    sut.getLocalPath("f1") shouldBe "/audio/f1.mp3"
+                    sut.getStateForAudioFile("f2") shouldBe null // DELETED tombstone gone
                 }
             } finally {
                 db.close()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadAudioFileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadAudioFileTest.kt
@@ -4,12 +4,15 @@ package com.calypsan.listenup.client.download
 
 import com.calypsan.listenup.api.dto.PreparedAudioFile
 import com.calypsan.listenup.api.dto.PreparedPlayback
+import com.calypsan.listenup.api.error.DownloadError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.data.local.images.StoragePaths
 import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.HttpClient
@@ -20,7 +23,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.write
 import java.io.File
 
 /**
@@ -207,7 +213,208 @@ class DownloadAudioFileTest :
                 tmpRoot.deleteRecursively()
             }
         }
+
+        // ---- B6: server ignores Range on resume (returns 200, not 206) ----
+        // A partial .tmp exists (startByte > 0) so we send a Range header, but the server/proxy
+        // returns 200 with the FULL body. Appending would corrupt the file (400 + 1000 = 1400).
+        // The fix truncates the temp and restarts from byte 0 → final file is exactly the full body.
+        test("resume where server ignores Range (200, not 206) truncates the temp and restarts — no corruption") {
+            val tmpRoot = tempDir()
+            try {
+                val bookId = "book-r6"
+                val audioFileId = "file-r6"
+                val fileManager = fileManagerFor(tmpRoot)
+
+                // Pre-write 400 stale bytes to the temp path so startByte = 400 and a Range header is sent.
+                val tempPath = fileManager.getAudioFilePath(bookId, audioFileId, "file-r6.mp3", isTemp = true)
+                SystemFileSystem.sink(tempPath).buffered().use { it.write(ByteArray(400) { 0x41 }) }
+
+                val fakeRepo =
+                    FakeDownloadRepository(
+                        initial = listOf(downloadEntity(audioFileId = audioFileId, bookId = bookId, totalBytes = 1000L)),
+                    )
+
+                // Server IGNORES the Range: 200 OK + the full 1000-byte body (not 206 partial).
+                val engine =
+                    MockEngine {
+                        respond(
+                            content = ByteArray(1000) { 0x42 },
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                        )
+                    }
+
+                val result =
+                    downloadAudioFile(
+                        audioFileId = audioFileId,
+                        bookId = bookId,
+                        filename = "file-r6.mp3",
+                        expectedSize = 1000L,
+                        httpClient = minimalClient(engine),
+                        repository = fakeRepo,
+                        fileManager = fileManager,
+                        prepareRepository = readyPrepareRepo(bookId, audioFileId),
+                    )
+
+                result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                // Final file is the full body (1000), NOT the corrupt append (1400).
+                val destPath = fileManager.getAudioFilePath(bookId, audioFileId, "file-r6.mp3", isTemp = false)
+                fileManager.getFileSize(destPath.toString()) shouldBe 1000L
+                fakeRepo.entities.single().state shouldBe DownloadState.COMPLETED
+            } finally {
+                tmpRoot.deleteRecursively()
+            }
+        }
+
+        // ---- B6: unknown expectedSize + truncated stream must FAIL (not finalize at bogus 100%) ----
+        // expectedSize = 0 (DownloadWorker's default when metadata size is unknown). The server
+        // advertises Content-Length 1000 but the stream closes after only 500 bytes. Pre-fix this
+        // was markCompleted'd as success; the fix verifies against Content-Length and FAILS.
+        test("expectedSize=0 with a truncated body verified against Content-Length FAILS") {
+            val tmpRoot = tempDir()
+            try {
+                val bookId = "book-r6b"
+                val audioFileId = "file-r6b"
+                val fileManager = fileManagerFor(tmpRoot)
+                val fakeRepo =
+                    FakeDownloadRepository(
+                        initial = listOf(downloadEntity(audioFileId = audioFileId, bookId = bookId, totalBytes = 0L)),
+                    )
+
+                // Content-Length says 1000 but only 500 bytes arrive, then the stream closes cleanly.
+                val engine =
+                    MockEngine {
+                        respond(
+                            content = ByteArray(500) { 0x42 },
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                        )
+                    }
+
+                val result =
+                    downloadAudioFile(
+                        audioFileId = audioFileId,
+                        bookId = bookId,
+                        filename = "file-r6b.mp3",
+                        expectedSize = 0L,
+                        httpClient = minimalClient(engine),
+                        repository = fakeRepo,
+                        fileManager = fileManager,
+                        prepareRepository = readyPrepareRepo(bookId, audioFileId),
+                    )
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                fakeRepo.entities.single().state shouldNotBe DownloadState.COMPLETED
+                // The corrupt partial was deleted, not finalized.
+                val destPath = fileManager.getAudioFilePath(bookId, audioFileId, "file-r6b.mp3", isTemp = false)
+                SystemFileSystem.exists(destPath) shouldBe false
+            } finally {
+                tmpRoot.deleteRecursively()
+            }
+        }
+
+        // ---- B6: genuinely unverifiable download (no expectedSize, no Content-Length) FAILS ----
+        test("expectedSize=0 with no Content-Length is unverifiable and FAILS") {
+            val tmpRoot = tempDir()
+            try {
+                val bookId = "book-r6c"
+                val audioFileId = "file-r6c"
+                val fileManager = fileManagerFor(tmpRoot)
+                val fakeRepo =
+                    FakeDownloadRepository(
+                        initial = listOf(downloadEntity(audioFileId = audioFileId, bookId = bookId, totalBytes = 0L)),
+                    )
+
+                // No Content-Length header at all → size is genuinely unverifiable.
+                val engine =
+                    MockEngine {
+                        respond(content = ByteArray(500) { 0x42 }, status = HttpStatusCode.OK)
+                    }
+
+                val result =
+                    downloadAudioFile(
+                        audioFileId = audioFileId,
+                        bookId = bookId,
+                        filename = "file-r6c.mp3",
+                        expectedSize = 0L,
+                        httpClient = minimalClient(engine),
+                        repository = fakeRepo,
+                        fileManager = fileManager,
+                        prepareRepository = readyPrepareRepo(bookId, audioFileId),
+                    )
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+            } finally {
+                tmpRoot.deleteRecursively()
+            }
+        }
+
+        // ---- B10c: markCompleted failing after the file lands surfaces as a FAILURE, not silent success ----
+        test("markCompleted failure after the file lands surfaces as a download failure") {
+            val tmpRoot = tempDir()
+            try {
+                val bookId = "book-r10"
+                val audioFileId = "file-r10"
+                val fileManager = fileManagerFor(tmpRoot)
+                val fakeRepo =
+                    FakeDownloadRepository(
+                        initial = listOf(downloadEntity(audioFileId = audioFileId, bookId = bookId, totalBytes = 1000L)),
+                        markCompletedFailure = DownloadError.DownloadFailed(debugInfo = "DB write failed"),
+                    )
+
+                val engine =
+                    MockEngine {
+                        respond(
+                            content = ByteArray(1000) { 0x42 },
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                        )
+                    }
+
+                val result =
+                    downloadAudioFile(
+                        audioFileId = audioFileId,
+                        bookId = bookId,
+                        filename = "file-r10.mp3",
+                        expectedSize = 1000L,
+                        httpClient = minimalClient(engine),
+                        repository = fakeRepo,
+                        fileManager = fileManager,
+                        prepareRepository = readyPrepareRepo(bookId, audioFileId),
+                    )
+
+                // The bytes landed but the DB write failed — honest failure, not a lying success.
+                result.shouldBeInstanceOf<AppResult.Failure>()
+            } finally {
+                tmpRoot.deleteRecursively()
+            }
+        }
     })
+
+// A ready [PlaybackPrepareRepository] that signs a relative download URL for [audioFileId].
+private fun readyPrepareRepo(
+    bookId: String,
+    audioFileId: String,
+): FakePlaybackPrepareRepository =
+    FakePlaybackPrepareRepository(
+        AppResult.Success(
+            PreparedPlayback(
+                bookId = bookId,
+                audioFiles =
+                    listOf(
+                        PreparedAudioFile(
+                            fileId = audioFileId,
+                            index = 0,
+                            url = "/api/v1/audio/$bookId/$audioFileId?u=&exp=&sig=test",
+                            format = "mp3",
+                            durationMs = 1000L,
+                            sizeBytes = 1000L,
+                        ),
+                    ),
+                resumePosition = null,
+            ),
+        ),
+    )
 
 // FakePlaybackPrepareRepository is defined in DownloadWorkerLogicTest.kt
 // (same package, internal visibility) — reused here.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadFileManagerSweepTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadFileManagerSweepTest.kt
@@ -55,6 +55,28 @@ class DownloadFileManagerSweepTest :
             }
         }
 
+        test("sweepOrphanedTempFiles spares an active partial whose audioFileId contains '_' (B10e)") {
+            val tmpRoot = tempDir()
+            try {
+                val fileManager = fileManagerFor(tmpRoot)
+
+                // Active download whose id contains '_'. Pre-fix, substringBefore('_') == "af" — NOT in
+                // the active set {"af_1"} — so this ACTIVE partial was wrongly swept mid-download.
+                val activePath = fileManager.getAudioFilePath("book-1", "af_1", "01.mp3", isTemp = true)
+                val orphanPath = fileManager.getAudioFilePath("book-1", "af_2", "02.mp3", isTemp = true)
+                SystemFileSystem.sink(activePath).use { it }
+                SystemFileSystem.sink(orphanPath).use { it }
+
+                val deleted = fileManager.sweepOrphanedTempFiles(setOf("af_1"))
+
+                deleted shouldBe 1
+                SystemFileSystem.exists(activePath) shouldBe true // spared — Range-resume can continue
+                SystemFileSystem.exists(orphanPath) shouldBe false // genuine orphan swept
+            } finally {
+                tmpRoot.deleteRecursively()
+            }
+        }
+
         test("sweepOrphanedTempFiles returns 0 when no .tmp files exist") {
             val tmpRoot = tempDir()
             try {

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
@@ -809,6 +809,8 @@ internal class FakePlaybackPrepareRepository(
     private val prepareResult: AppResult<PreparedPlayback>,
 ) : PlaybackPrepareRepository {
     override suspend fun prepare(bookId: BookId): AppResult<PreparedPlayback> = prepareResult
+
+    override suspend fun getPosition(bookId: BookId) = AppResult.Success(null)
 }
 
 /**

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/OnBookFinishedPreservesDownloadsTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/OnBookFinishedPreservesDownloadsTest.kt
@@ -1,0 +1,134 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.data.repository.DownloadRepositoryImpl
+import com.calypsan.listenup.client.domain.model.BookDetail
+import com.calypsan.listenup.client.domain.model.BookListItem
+import com.calypsan.listenup.client.domain.model.Chapter
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.DiscoveryBook
+import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
+import com.calypsan.listenup.client.download.DownloadEnqueuer
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.core.BookId
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * B1 regression: finishing a book must NOT destroy its offline copy.
+ *
+ * [ProgressTracker.onBookFinished] previously called `deleteForBook` (DELETE FROM downloads WHERE
+ * bookId=…), wiping COMPLETED rows too — so every future play fell to streaming and failed offline,
+ * while the multi-GB files leaked on disk. It must clear only DELETED tombstones.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnBookFinishedPreservesDownloadsTest :
+    FunSpec({
+        fun completed(
+            id: String,
+            bookId: String,
+        ) = DownloadEntity(
+            audioFileId = id,
+            bookId = bookId,
+            filename = "$id.mp3",
+            fileIndex = 0,
+            state = DownloadState.COMPLETED,
+            localPath = "/audio/$id.mp3",
+            totalBytes = 1_000L,
+            downloadedBytes = 1_000L,
+            queuedAt = 0L,
+            startedAt = null,
+            completedAt = 1L,
+            errorMessage = null,
+            retryCount = 0,
+        )
+
+        test("onBookFinished preserves COMPLETED downloads and clears only DELETED tombstones") {
+            val db = createInMemoryTestDatabase()
+            val dao = db.downloadDao()
+            try {
+                val dispatcher = StandardTestDispatcher()
+                runTest(dispatcher) {
+                    dao.insertAll(
+                        listOf(
+                            completed("f1", "b1"),
+                            completed("f2", "b1"),
+                            completed("stale", "b1").copy(state = DownloadState.DELETED, localPath = null),
+                        ),
+                    )
+
+                    val downloadRepository =
+                        DownloadRepositoryImpl(
+                            downloadDao = dao,
+                            bookRepository = NoopBookRepository(),
+                            enqueuer = NoopEnqueuer(),
+                        )
+                    val positionRepository: PlaybackPositionRepository = mock()
+                    everySuspend { positionRepository.markComplete(any(), any(), any()) } returns AppResult.Success(Unit)
+
+                    val tracker =
+                        ProgressTracker(
+                            downloadRepository = downloadRepository,
+                            positionRepository = positionRepository,
+                            scope = CoroutineScope(dispatcher),
+                        )
+
+                    tracker.onBookFinished(BookId("b1"), finalPositionMs = 1_000L)
+                    advanceUntilIdle()
+
+                    // COMPLETED downloads survive — getLocalPath still resolves, so the book plays offline.
+                    downloadRepository.getLocalPath("f1") shouldBe "/audio/f1.mp3"
+                    downloadRepository.getLocalPath("f2") shouldBe "/audio/f2.mp3"
+                    // Only the DELETED tombstone was cleared.
+                    downloadRepository.getStateForAudioFile("stale") shouldBe null
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })
+
+private class NoopEnqueuer : DownloadEnqueuer {
+    override suspend fun enqueue(entity: DownloadEntity): AppResult<Unit> = AppResult.Success(Unit)
+}
+
+private class NoopBookRepository : BookRepository {
+    override suspend fun refreshBooks(): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun getChapters(bookId: String): List<Chapter> = emptyList()
+
+    override fun observeChapters(bookId: String): Flow<List<Chapter>> = flowOf(emptyList())
+
+    override fun observeIsBookLive(id: String): Flow<Boolean> = flowOf(true)
+
+    override fun observeRandomUnstartedBooks(limit: Int): Flow<List<DiscoveryBook>> = flowOf(emptyList())
+
+    override fun observeRecentlyAddedBooks(limit: Int): Flow<List<DiscoveryBook>> = flowOf(emptyList())
+
+    override fun observeBookListItems(): Flow<List<BookListItem>> = flowOf(emptyList())
+
+    override fun observeBookListItems(ids: List<String>): Flow<List<BookListItem>> = flowOf(emptyList())
+
+    override suspend fun getBookListItem(id: String): BookListItem? = null
+
+    override suspend fun getBookListItems(ids: List<String>): List<BookListItem> = emptyList()
+
+    override fun observeBookDetail(id: String): Flow<BookDetail?> = flowOf(null)
+
+    override fun search(query: String): Flow<List<BookListItem>> = flowOf(emptyList())
+
+    override suspend fun getBookDetail(id: String): BookDetail? = null
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerTestSupport.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerTestSupport.kt
@@ -85,4 +85,6 @@ fun testPlaybackPrepareRepository(
                     resumePosition = null,
                 ),
             )
+
+        override suspend fun getPosition(bookId: BookId) = AppResult.Success(null)
     }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparerTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparerTest.kt
@@ -207,6 +207,27 @@ class PlaybackPreparerTest :
                 ),
             )
 
+        // A fully-downloaded service: every file has a local path → prepare() is skipped and the
+        // authoritative position must instead come from the best-effort getPosition() call (B8).
+        fun downloadedDownloadService(): DownloadService {
+            val downloadService: DownloadService = mock()
+            everySuspend { downloadService.getLocalPath(audioFile1) } returns "/local/af-prep-1.mp3"
+            everySuspend { downloadService.getLocalPath(audioFile2) } returns "/local/af-prep-2.mp3"
+            everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+            everySuspend { downloadService.downloadBook(any()) } returns
+                AppResult.Success(DownloadOutcome.AlreadyDownloaded)
+            return downloadService
+        }
+
+        // Builds a prepare repository whose getPosition() returns [result]; prepare() would fail if
+        // called — which it must NOT be on the fully-downloaded path.
+        fun downloadedWithServerPosition(
+            result: AppResult<PlaybackPositionSyncPayload?>,
+        ): Pair<PlaybackPrepareRepository, FakePlaybackService> {
+            val svc = FakePlaybackService(prepareResult = stubFailure, getPositionResult = result)
+            return FakePlaybackPrepareRepository(svc) to svc
+        }
+
         // ── resume-position merge (server-authoritative newer-wins) ─────────────────────
 
         // Concrete epoch anchors. 4:30:00 = 16_200_000ms, 6:00:00 = 21_600_000ms.
@@ -314,6 +335,51 @@ class PlaybackPreparerTest :
                 val result = preparer.prepare(bookId)
 
                 result.shouldNotBeNull()
+                result.resumePositionMs shouldBe pos430
+            }
+        }
+
+        // ── B8: fully-downloaded path also reconciles the server-authoritative position ──
+
+        test("fully downloaded — server getPosition is newer, resume uses it (B8 offline clobber fix)") {
+            runTest {
+                // Phone has the book downloaded and a stale local row (4:30 @ base); the server has
+                // the tablet's newer progress (6:00 @ +1h). prepare() is skipped (downloaded), so the
+                // authoritative position must arrive via getPosition() and win the merge.
+                val (prepareRepo, svc) =
+                    downloadedWithServerPosition(AppResult.Success(serverPosition(pos600, laterTime)))
+                val preparer =
+                    buildPreparer(
+                        downloadService = downloadedDownloadService(),
+                        prepareRepository = prepareRepo,
+                        progressTracker = trackerWithLocalPosition(localPosition(pos430, baseTime)),
+                    )
+
+                val result = preparer.prepare(bookId)
+
+                result.shouldNotBeNull()
+                svc.prepareCallCount shouldBe 0 // offline-first: never touches prepare() when downloaded
+                svc.getPositionCallCount shouldBe 1 // ...but DOES fetch the authoritative position
+                // Pre-fix: resolves to the stale local 4:30 and clobbers the tablet — the F1 gap for downloads.
+                result.resumePositionMs shouldBe pos600
+            }
+        }
+
+        test("fully downloaded — getPosition fails offline, resume falls back to the local row") {
+            runTest {
+                val (prepareRepo, svc) = downloadedWithServerPosition(stubFailure)
+                val preparer =
+                    buildPreparer(
+                        downloadService = downloadedDownloadService(),
+                        prepareRepository = prepareRepo,
+                        progressTracker = trackerWithLocalPosition(localPosition(pos430, baseTime)),
+                    )
+
+                val result = preparer.prepare(bookId)
+
+                result.shouldNotBeNull()
+                svc.prepareCallCount shouldBe 0
+                // getPosition failed (offline) → never-stranded: resume resolves from Room, unchanged.
                 result.resumePositionMs shouldBe pos430
             }
         }
@@ -532,8 +598,11 @@ private val stubFailure = AppResult.Failure(InternalError(debugInfo = "stub"))
 private class FakePlaybackService(
     private val prepareResult: AppResult<ContractPreparedPlayback>,
     private val prepareThrows: Throwable? = null,
+    private val getPositionResult: AppResult<PlaybackPositionSyncPayload?> = stubFailure,
 ) : PlaybackService {
     var prepareCallCount = 0
+        private set
+    var getPositionCallCount = 0
         private set
 
     override suspend fun prepare(bookId: BookId): AppResult<ContractPreparedPlayback> {
@@ -542,7 +611,10 @@ private class FakePlaybackService(
         return prepareResult
     }
 
-    override suspend fun getPosition(bookId: BookId): AppResult<PlaybackPositionSyncPayload?> = stubFailure
+    override suspend fun getPosition(bookId: BookId): AppResult<PlaybackPositionSyncPayload?> {
+        getPositionCallCount++
+        return getPositionResult
+    }
 
     override suspend fun recordPosition(
         request: RecordPositionRequest,
@@ -563,4 +635,6 @@ private class FakePlaybackPrepareRepository(
     private val service: PlaybackService,
 ) : PlaybackPrepareRepository {
     override suspend fun prepare(bookId: BookId): AppResult<ContractPreparedPlayback> = service.prepare(bookId)
+
+    override suspend fun getPosition(bookId: BookId): AppResult<PlaybackPositionSyncPayload?> = service.getPosition(bookId)
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparerTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparerTest.kt
@@ -375,6 +375,41 @@ class PlaybackPreparerTest :
             }
         }
 
+        // ── B3: partial download, offline — downloaded files still play (never-stranded) ──
+
+        test("partial download offline — prepare() fails but downloaded files still play") {
+            runTest {
+                // prepare() fails (offline / dead socket) and only file 1 is downloaded.
+                val fakePlaybackService =
+                    FakePlaybackService(
+                        prepareResult = AppResult.Failure(InternalError(debugInfo = "offline")),
+                    )
+                val fakeFactory = FakePlaybackPrepareRepository(fakePlaybackService)
+
+                val downloadService: DownloadService = mock()
+                everySuspend { downloadService.getLocalPath(audioFile1) } returns "/local/af-prep-1.mp3"
+                everySuspend { downloadService.getLocalPath(audioFile2) } returns null // missing
+                everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+                everySuspend { downloadService.downloadBook(any()) } returns
+                    AppResult.Success(DownloadOutcome.AlreadyDownloaded)
+
+                val preparer = buildPreparer(downloadService, fakeFactory)
+                val result = preparer.prepare(bookId)
+
+                // Pre-fix: buildTimeline returned null on the prepare() Failure → whole book unplayable.
+                result.shouldNotBeNull()
+                // prepare() WAS attempted (some files missing) but failed offline.
+                fakePlaybackService.prepareCallCount shouldBe 1
+                // Downloaded file plays from disk...
+                result.timeline.files[0].localPath shouldBe "/local/af-prep-1.mp3"
+                result.timeline.files[0].playbackUri shouldBe "file:///local/af-prep-1.mp3"
+                // ...and the missing file has NO fabricated streaming URL (honest gap, not a blanket
+                // streaming fallback that fails the whole book).
+                result.timeline.files[1].localPath shouldBe null
+                result.timeline.files[1].streamingUrl shouldBe ""
+            }
+        }
+
         // ── test 2: streaming ──────────────────────────────────────────────────────────
 
         test("streaming — prepare() called once; signed URLs are absolute and well-formed") {

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
@@ -564,6 +564,8 @@ private object ThrowingDownloadRepository : DownloadRepository {
 
     override suspend fun deleteForBook(bookId: String) = TODO("not used in handler test")
 
+    override suspend fun deleteDeletedRecordsForBook(bookId: String) = TODO("not used in handler test")
+
     override suspend fun resumeIncompleteDownloads() = TODO("not used in handler test")
 }
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackServiceTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackServiceTest.kt
@@ -191,5 +191,7 @@ private object ThrowingDownloadRepository2 : DownloadRepository {
 
     override suspend fun deleteForBook(bookId: String) = TODO("not used")
 
+    override suspend fun deleteDeletedRecordsForBook(bookId: String) = TODO("not used")
+
     override suspend fun resumeIncompleteDownloads() = TODO("not used")
 }


### PR DESCRIPTION
Fixes the confirmed findings from Fable's **download & offline-file integrity** audit. Offline downloads are a core "never stranded" promise — every bug here either strands a user's offline library or silently corrupts a file. Strict TDD (Kotest); each fix has a red→green regression test.

## Critical
- **B1** — finishing a book called `deleteForBook` (deletes ALL rows incl. COMPLETED, deletes no files) → the finished, fully-downloaded book became **unplayable offline** and its files leaked as unreclaimable storage. Now `onBookFinished` deletes only DELETED-state records; "Delete All" removes files + rows.

## High
- **B2** — a cancelled partial book reported **"Downloaded"** (aggregate filtered CANCELLED then trivially saw "all COMPLETED") → stranded offline. Completeness is now measured against non-DELETED rows; a mixed set reports `Paused`, and `isFullyDownloaded` requires every book audio file complete.
- **B3** — a partially-downloaded multi-file book couldn't play its *downloaded* files offline (all-or-nothing prepare). Now builds a timeline with local paths for downloaded files (contiguous offline prefix); missing files carry no streaming URL.
- **B4** (Android) — every play of a not-fully-downloaded book **stomped the in-flight download** (rows→0, worker replaced). Mirrors the iOS skip-set (COMPLETED/DOWNLOADING/QUEUED) + `ExistingWorkPolicy.KEEP`.
- **B5** (iOS) — cancel wrote FAILED not CANCELLED → the download **silently restarted** on next launch. Cancel now routes through `cancelForBook` and writes CANCELLED.

## Medium
- **B6** — integrity was size-only, *skipped* when `expectedSize ≤ 0`, and a resume-append never checked the server honored the Range. A `200` answer to a ranged resume appended the full body onto the partial → corruption; an unknown-size stream that truncated was still marked complete. Now: a ranged resume answered with `200` truncates and restarts from byte 0; integrity verifies against `expectedSize` or the Content-Length fallback; an unverifiable download is a **failure**, not a silent success.
- **B7** — a cancel/delete racing the dying worker's `NonCancellable` cleanup let a late `markPaused` resurrect a CANCELLED/DELETED book. `markPaused` is now a conditional DB write (`… WHERE state NOT IN (CANCELLED, DELETED, COMPLETED)`) — the terminal write wins regardless of scheduling.
- **B8** — the fully-downloaded playback path never saw the server's authoritative position (the corner the streaming F1 fix left open) → a stale local row could clobber another device's newer progress. Downloaded playback now does a best-effort `getPosition` fetch and folds it through the **existing** F1 newer-wins merge; any failure degrades to the local Room row (never blocks/fails playback).

## Low
- **B9** — deleting the currently-playing book had no guard (removes files an active session is playing via `file://`). Now refused with a surfaced reason; other-book deletes proceed.
- **B10** — restart/report honesty: stale DOWNLOADING rows reset on startup; terminally-FAILED (retries exhausted) excluded from the every-launch re-enqueue; a post-landing `markCompleted` failure now surfaces as a failure instead of lying; `sweepOrphanedTempFiles` matches the full audio-file id (not substring-before-`_`) so ids containing `_` can't delete active partials.

## Verification
- `:contract:jvmTest :sharedLogic:jvmTest :sharedLogic:testAndroidHostTest :sharedUI:testAndroidHostTest` — green (incl. the Koin-graph E2E guard for the B9 DI wiring)
- `:androidApp:assembleDebug` — green
- `:sharedLogic:compileKotlinIosSimulatorArm64` — green (B5/B8 appleMain)
- `spotlessCheck detekt` — green
- No export-surface change (B2 reused the existing `Paused` variant; B8 added a method to an already-exported interface).