### PR TITLE
🐛 fix: Campfire coexistence follow-ups — minimize dead-end, lobby play, off-main Media3 (F4/F6/F1)

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/calypsan/listenup/gradle/SwiftExportSourcePatcher.kt
+++ b/build-logic/convention/src/main/kotlin/com/calypsan/listenup/gradle/SwiftExportSourcePatcher.kt
@@ -358,7 +358,7 @@ object SwiftExportSourcePatcher {
             "com.calypsan.listenup.client.playback.SessionState" to 3,
             "com.calypsan.listenup.client.playback.SleepTimerMode" to 2,
             "com.calypsan.listenup.client.playback.SleepTimerState" to 3,
-            "com.calypsan.listenup.client.presentation.nowplaying.PlaybackGuardEvent" to 1,
+            "com.calypsan.listenup.client.presentation.nowplaying.PlaybackGuardEvent" to 2,
             "com.calypsan.listenup.client.presentation.admin.ABSImportListUiState" to 3,
             "com.calypsan.listenup.client.presentation.admin.AdminBackupUiState" to 3,
             "com.calypsan.listenup.client.presentation.admin.AdminCategoriesUiState" to 3,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinator.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.campfire
 
 import com.calypsan.listenup.api.dto.campfire.CampfireId
+import com.calypsan.listenup.api.dto.campfire.CampfirePhase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -15,11 +16,15 @@ import kotlinx.coroutines.flow.StateFlow
  * @property sessionId The live session's id.
  * @property bookId The book the campfire is on. Playing this same book is never guarded.
  * @property isHost Whether the local user hosts the session — selects the "end" vs "leave" confirm copy.
+ * @property phase Whether the fire has been lit yet. Playing the campfire's own book while still in
+ * [CampfirePhase.LOBBY] re-expands the lobby instead of starting solo playback (F6 — "no playback
+ * before the fire is lit" per PR #1101).
  */
 internal data class ActiveCampfire(
     val sessionId: CampfireId,
     val bookId: String,
     val isHost: Boolean,
+    val phase: CampfirePhase,
 )
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
@@ -16,7 +16,9 @@ import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.core.BookId
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -27,6 +29,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.math.abs
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -104,6 +107,7 @@ internal class CampfireSessionController(
     private val userRepository: UserRepository,
     private val scope: CoroutineScope,
     private val clock: Clock = Clock.System,
+    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
 ) {
     /** Current session UI state. See the class KDoc for why this is a plain hot flow, not `stateIn`. */
     val state: StateFlow<CampfireUiState>
@@ -253,8 +257,8 @@ internal class CampfireSessionController(
     fun confirmRejoinSync() {
         val current = state.value as? CampfireUiState.Active ?: return
         val pendingAnchor = current.pendingRejoinSync ?: return
-        applyAnchorToPlayback(pendingAnchor, nowMs())
         state.value = current.copy(pendingRejoinSync = null)
+        scope.launch { applyAnchorToPlayback(pendingAnchor, nowMs()) }
     }
 
     /** Leaves the session: stops the frame stream + drift loop and notifies the server. */
@@ -430,7 +434,7 @@ internal class CampfireSessionController(
                     val expectedPositionMs = current.anchor.posAt(nowMs())
                     val actualPositionMs = playbackManager.currentPositionMs.value
                     if (abs(expectedPositionMs - actualPositionMs) > DRIFT_TOLERANCE_MS) {
-                        playbackController.seekTo(expectedPositionMs)
+                        withContext(mainDispatcher) { playbackController.seekTo(expectedPositionMs) }
                     }
                 }
             }
@@ -461,8 +465,8 @@ internal class CampfireSessionController(
 
             is CampfireFrame.AnchorChanged -> {
                 val isOwnEcho = consumePendingCommand(frame.commandId)
-                if (!isOwnEcho) applyAnchorToPlayback(frame.anchor, nowMs())
                 state.value = current.copy(anchor = frame.anchor)
+                if (!isOwnEcho) scope.launch { applyAnchorToPlayback(frame.anchor, nowMs()) }
             }
 
             is CampfireFrame.MemberJoined -> {
@@ -542,16 +546,18 @@ internal class CampfireSessionController(
         if (playbackManager.currentBookId.value == target) return
         val prepared = playbackManager.prepareForPlayback(target) ?: return
         playbackManager.activateBook(target)
-        playbackController.startPlayback(prepared)
+        withContext(mainDispatcher) { playbackController.startPlayback(prepared) }
     }
 
-    private fun applyAnchorToPlayback(
+    private suspend fun applyAnchorToPlayback(
         anchor: CampfireAnchor,
         nowMs: Long,
     ) {
-        playbackController.seekTo(anchor.posAt(nowMs))
-        if (anchor.isPlaying) playbackController.play() else playbackController.pause()
-        playbackController.setPlaybackSpeed(anchor.speed)
+        withContext(mainDispatcher) {
+            playbackController.seekTo(anchor.posAt(nowMs))
+            if (anchor.isPlaying) playbackController.play() else playbackController.pause()
+            playbackController.setPlaybackSpeed(anchor.speed)
+        }
     }
 
     private fun hasControl(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModel.kt
@@ -323,7 +323,7 @@ private fun CampfireUiState.toScreenState(): CampfireScreenUiState =
 private fun CampfireUiState.toActiveCampfire(): ActiveCampfire? =
     // Only a live/lobby session is guard-worthy; Idle / Joining / Disconnected / Ended → null.
     if (this is CampfireUiState.Active) {
-        ActiveCampfire(sessionId = sessionId, bookId = bookId, isHost = isHost)
+        ActiveCampfire(sessionId = sessionId, bookId = bookId, isHost = isHost, phase = phase)
     } else {
         null
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.presentation.nowplaying
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.calypsan.listenup.api.dto.campfire.CampfirePhase
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
@@ -443,8 +444,11 @@ class NowPlayingViewModel internal constructor(
      * Plays [bookId], guarding against silently stranding a live campfire (co-listening coexistence
      * spec, B3). If a campfire is live for a *different* book, emits [PlaybackGuardEvent.ConfirmPlayOverCampfire]
      * (role-tagged so the shell picks "end" vs "leave" copy) and does not play; the shell re-drives
-     * [playBookConfirmed] after the user exits the campfire. Playing the campfire's own book, or with
-     * no campfire live, plays immediately.
+     * [playBookConfirmed] after the user exits the campfire. Playing the campfire's own book while it
+     * is still in [com.calypsan.listenup.api.dto.campfire.CampfirePhase.LOBBY] emits
+     * [PlaybackGuardEvent.ReturnToCampfire] instead of starting solo playback (F6 — the fire hasn't
+     * been lit yet, so nobody's playback should start). With the campfire LIVE on the same book, or
+     * with no campfire live at all, plays immediately.
      *
      * This is the guarded entry point for the app's in-UI "play" affordances (book detail, Home
      * continue-listening, Library). It is NOT the only way playback can start: the Android
@@ -455,9 +459,15 @@ class NowPlayingViewModel internal constructor(
      */
     fun playBook(bookId: BookId) {
         val active = activeCampfire.current.value
-        if (active != null && active.bookId != bookId.value) {
-            _playbackGuardEvents.trySend(PlaybackGuardEvent.ConfirmPlayOverCampfire(bookId, active.isHost))
-            return
+        if (active != null) {
+            if (active.bookId != bookId.value) {
+                _playbackGuardEvents.trySend(PlaybackGuardEvent.ConfirmPlayOverCampfire(bookId, active.isHost))
+                return
+            }
+            if (active.phase == CampfirePhase.LOBBY) {
+                _playbackGuardEvents.trySend(PlaybackGuardEvent.ReturnToCampfire)
+                return
+            }
         }
         startPlayback(bookId)
     }
@@ -646,4 +656,11 @@ sealed interface PlaybackGuardEvent {
         val bookId: BookId,
         val isHost: Boolean,
     ) : PlaybackGuardEvent
+
+    /**
+     * The user asked to play the book of a campfire they are already in, while it is still in the
+     * lobby (fire not lit). Rather than start premature solo playback, the shell re-expands the
+     * campfire lobby (co-listening coexistence spec — no playback before the fire is lit).
+     */
+    data object ReturnToCampfire : PlaybackGuardEvent
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinatorTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.campfire
 
 import com.calypsan.listenup.api.dto.campfire.CampfireId
+import com.calypsan.listenup.api.dto.campfire.CampfirePhase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -12,7 +13,7 @@ class ActiveCampfireCoordinatorTest :
 
         test("set publishes the active campfire, set(null) clears it") {
             val coordinator = ActiveCampfireCoordinator()
-            val active = ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true)
+            val active = ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE)
 
             coordinator.set(active)
             coordinator.current.value shouldBe active

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
@@ -29,12 +29,17 @@ import com.calypsan.listenup.core.BookId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.time.Clock
@@ -92,6 +97,7 @@ class CampfireSessionControllerTest :
             selfUserId: String = "self-1",
             playbackManager: FakePlaybackManager = FakePlaybackManager(),
             playbackController: FakePlaybackController = FakePlaybackController(),
+            mainDispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
         ) = CampfireSessionController(
             transport = transport,
             playbackManager = playbackManager,
@@ -99,6 +105,7 @@ class CampfireSessionControllerTest :
             userRepository = FakeUserRepository(selfUserId),
             scope = scope,
             clock = clock,
+            mainDispatcher = mainDispatcher,
         )
 
         fun stubPrepareResult(bookId: BookId = BookId("book-1")) =
@@ -394,8 +401,27 @@ class CampfireSessionControllerTest :
                 playbackController.seekCalls.size shouldBe seekCountAfterDisconnect
 
                 sut.confirmRejoinSync()
+                runCurrent()
                 (sut.state.value as CampfireUiState.Active).pendingRejoinSync shouldBe null
                 playbackController.seekCalls.last() shouldBe 600_000L
+            }
+        }
+
+        test("applies a live anchor to the player through the main dispatcher") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport = FakeCampfireTransport().apply { joinResult = AppResult.Success(snapshot()) }
+                val playbackController = FakePlaybackController()
+                val main = CountingDispatcher(StandardTestDispatcher(testScheduler))
+                val sut = controller(transport, backgroundScope, clock, playbackController = playbackController, mainDispatcher = main)
+
+                sut.join(sessionId) // snapshot() is LIVE → applies the anchor to the player
+                advanceUntilIdle()
+
+                // the anchor apply happened AND it was dispatched through the injected main dispatcher
+                main.count shouldBeGreaterThan 0
+                playbackController.seekCalls shouldBe listOf(0L)
+                playbackController.pauseCount shouldBe 1
             }
         }
 
@@ -781,6 +807,22 @@ private class VirtualClock(
     private val scheduler: TestCoroutineScheduler,
 ) : Clock {
     override fun now(): Instant = Instant.fromEpochMilliseconds(scheduler.currentTime)
+}
+
+/** Counts every dispatch through [delegate] — proves a call was actually marshalled through the injected main dispatcher. */
+private class CountingDispatcher(
+    private val delegate: CoroutineDispatcher,
+) : CoroutineDispatcher() {
+    var count = 0
+        private set
+
+    override fun dispatch(
+        context: kotlin.coroutines.CoroutineContext,
+        block: Runnable,
+    ) {
+        count++
+        delegate.dispatch(context, block)
+    }
 }
 
 /** In-memory [FakeCampfireTransport] — records every call, replays a hot frame flow for [observeSession]. */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
@@ -93,6 +93,7 @@ class CampfireViewModelTest :
                         userRepository = userRepository,
                         scope = scope.backgroundScope,
                         clock = FixedClock,
+                        mainDispatcher = Dispatchers.Unconfined,
                     )
                 return CampfireViewModel(
                     controller = controller,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
@@ -331,7 +331,7 @@ class CampfireViewModelTest :
                 advanceUntilIdle()
 
                 fixture.coordinator.current.value shouldBe
-                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false)
+                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false, phase = CampfirePhase.LIVE)
             }
         }
 
@@ -349,7 +349,7 @@ class CampfireViewModelTest :
                 advanceUntilIdle()
 
                 fixture.coordinator.current.value shouldBe
-                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false)
+                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false, phase = CampfirePhase.LIVE)
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.presentation.nowplaying
 
 import com.calypsan.listenup.api.dto.campfire.CampfireId
+import com.calypsan.listenup.api.dto.campfire.CampfirePhase
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.campfire.ActiveCampfire
@@ -304,11 +305,13 @@ class NowPlayingViewModelTest :
             }
         }
 
-        test("playBook plays directly when the campfire is on the same book") {
+        test("playBook plays directly when the campfire is on the same book and LIVE") {
             runTest(testDispatcher) {
                 val fixture = TestFixture()
                 val bookId = BookId("book-1")
-                fixture.activeCampfire.set(ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true))
+                fixture.activeCampfire.set(
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE),
+                )
                 fixture.fakePm.stubbedPrepareResult = stubPrepareResult(bookId)
                 everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
 
@@ -320,10 +323,36 @@ class NowPlayingViewModelTest :
             }
         }
 
+        test("playBook of the campfire's own book while in LOBBY re-expands, does not play") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                val bookId = BookId("book-1")
+                fixture.activeCampfire.set(
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LOBBY),
+                )
+
+                val vm = fixture.newVm()
+                vm.playbackGuardEvents.test {
+                    vm.playBook(bookId)
+                    awaitItem() shouldBe PlaybackGuardEvent.ReturnToCampfire
+                }
+                advanceUntilIdle()
+
+                withClue("must NOT activate when the campfire's own book is played from the lobby") {
+                    fixture.fakePm.activatedBookIds.isEmpty() shouldBe true
+                }
+                verifySuspend(VerifyMode.exactly(0)) {
+                    fixture.playbackController.startPlayback(any())
+                }
+            }
+        }
+
         test("playBook on a different book as host emits an end-confirm and does not play") {
             runTest(testDispatcher) {
                 val fixture = TestFixture()
-                fixture.activeCampfire.set(ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true))
+                fixture.activeCampfire.set(
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE),
+                )
 
                 val vm = fixture.newVm()
                 vm.playbackGuardEvents.test {
@@ -344,7 +373,9 @@ class NowPlayingViewModelTest :
         test("playBook on a different book as participant emits a leave-confirm") {
             runTest(testDispatcher) {
                 val fixture = TestFixture()
-                fixture.activeCampfire.set(ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = false))
+                fixture.activeCampfire.set(
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = false, phase = CampfirePhase.LIVE),
+                )
 
                 val vm = fixture.newVm()
                 vm.playbackGuardEvents.test {
@@ -358,7 +389,9 @@ class NowPlayingViewModelTest :
             runTest(testDispatcher) {
                 val fixture = TestFixture()
                 val bookId = BookId("book-2")
-                fixture.activeCampfire.set(ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true))
+                fixture.activeCampfire.set(
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE),
+                )
                 fixture.fakePm.stubbedPrepareResult = stubPrepareResult(bookId)
                 everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/CampfireVisibilityTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/CampfireVisibilityTest.kt
@@ -19,4 +19,11 @@ class CampfireVisibilityTest :
         test("minimizing the campfire does not suppress an independently-expanded solo player") {
             campfireFullScreenVisible(isExpanded = true, hasActiveBook = true, hasSession = true, minimized = true) shouldBe true
         }
+
+        test("campfire flow fills the container only when a session+book exist and it is not minimized") {
+            campfireFlowShown(hasSession = true, hasBook = true, minimized = false) shouldBe true
+            campfireFlowShown(hasSession = true, hasBook = true, minimized = true) shouldBe false
+            campfireFlowShown(hasSession = false, hasBook = true, minimized = false) shouldBe false
+            campfireFlowShown(hasSession = true, hasBook = false, minimized = false) shouldBe false
+        }
     })

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
@@ -173,6 +173,7 @@ fun NowPlayingHost(
             NowPlayingFullScreenContent(
                 campfire = campfire,
                 campfireViewModel = campfireViewModel,
+                campfireMinimized = campfireMinimized,
                 activeState = activeState,
                 isTv = isTv,
                 hasPdf = firstPdfDocId != null,
@@ -270,6 +271,7 @@ fun NowPlayingHost(
 private fun NowPlayingFullScreenContent(
     campfire: CampfireHostUi,
     campfireViewModel: CampfireViewModel,
+    campfireMinimized: Boolean,
     activeState: NowPlayingState.Active?,
     isTv: Boolean,
     hasPdf: Boolean,
@@ -281,10 +283,10 @@ private fun NowPlayingFullScreenContent(
 ) {
     val session = campfire.session
     val book = campfire.book
-    if (session != null && book != null) {
+    if (campfireFlowShown(hasSession = session != null, hasBook = book != null, minimized = campfireMinimized)) {
         CampfireLobbyOrRoomContent(
-            session = session,
-            book = book,
+            session = session!!,
+            book = book!!,
             campfire = campfire,
             campfireViewModel = campfireViewModel,
             activeState = activeState,

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -844,18 +844,22 @@ private fun BoxScope.CampfireReturnFab(state: CampfireMinimizeState) {
 /**
  * Confirm dialog for [NowPlayingViewModel.playbackGuardEvents] (B3) — playing a book while a
  * campfire is live for a different book must end/leave the campfire first, never play silently
- * over it.
+ * over it. Also handles [PlaybackGuardEvent.ReturnToCampfire] (F6) — playing the campfire's own
+ * book while it's still in the lobby re-expands the lobby via [onReturnToCampfire] instead of
+ * showing a dialog.
  */
 @Composable
 private fun PlayOverCampfireDialog(
     nowPlayingViewModel: NowPlayingViewModel,
     campfireViewModel: CampfireViewModel,
+    onReturnToCampfire: () -> Unit,
 ) {
     var playOverCampfire by remember { mutableStateOf<PlaybackGuardEvent.ConfirmPlayOverCampfire?>(null) }
     LaunchedEffect(nowPlayingViewModel) {
         nowPlayingViewModel.playbackGuardEvents.collect { event ->
             when (event) {
                 is PlaybackGuardEvent.ConfirmPlayOverCampfire -> playOverCampfire = event
+                PlaybackGuardEvent.ReturnToCampfire -> onReturnToCampfire()
             }
         }
     }
@@ -945,7 +949,11 @@ private fun BoxScope.AuthenticatedNavOverlays(
     )
 
     CampfireReturnFab(campfireMinimize)
-    PlayOverCampfireDialog(nowPlayingViewModel, campfireViewModel)
+    PlayOverCampfireDialog(
+        nowPlayingViewModel = nowPlayingViewModel,
+        campfireViewModel = campfireViewModel,
+        onReturnToCampfire = { campfireMinimize.setMinimized(false) },
+    )
 
     // App-wide snackbar - positioned at bottom, mini player animates up when visible
     SnackbarHost(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/CampfireVisibility.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/CampfireVisibility.kt
@@ -14,3 +14,15 @@ fun campfireFullScreenVisible(
     hasSession: Boolean,
     minimized: Boolean,
 ): Boolean = (isExpanded && hasActiveBook) || (hasSession && !minimized)
+
+/**
+ * Whether the full-screen campfire flow (lobby/room) — as opposed to the solo player — should fill
+ * the visible container. A minimized campfire yields the solo player instead: tapping the mini-bar
+ * (which expands the container) while minimized must NOT drop the user into the room with the
+ * collapse gesture disabled (co-listening coexistence spec, B1 — Never Stranded).
+ */
+fun campfireFlowShown(
+    hasSession: Boolean,
+    hasBook: Boolean,
+    minimized: Boolean,
+): Boolean = hasSession && hasBook && !minimized


### PR DESCRIPTION
Adversarial-review follow-ups to the Campfire coexistence B1+B3 work (#1103). Three correctness fixes, all device-independent and unit-tested. Structural items (F2 process-scoped ownership, F7/F8 hardenings) are deliberately held for the post-RPC-rebase controller pass.

## Fixes

**F4 — minimized campfire no longer strands you in a full-screen room.** Tapping the mini-bar while a campfire was minimized latched `isExpanded`, showing the room with its collapse gesture disabled (a Never-Stranded violation on a mainline tap). The content dispatch now gates on a new pure predicate `campfireFlowShown(hasSession, hasBook, minimized)` — a minimized campfire shows the solo player instead. (`NowPlayingHost`, `CampfireVisibility`.)

**F6 — playing the campfire's own book while in its lobby re-expands the lobby, not solo playback.** The guard's same-book pass had no phase awareness, so a minimized lobby participant tapping their campfire's book started premature solo playback — the exact "playback before the fire is lit" state #1101 removed. `ActiveCampfire` now carries `phase`; same-book + `LOBBY` emits a new `PlaybackGuardEvent.ReturnToCampfire`, which the shell handles by re-expanding the lobby. Same-book + `LIVE` still plays; different book still confirms leave/end.

**F1 — the campfire controller's Media3 mutations are marshalled to the main dispatcher.** The drift-correction seek, the `CampfireStarted` book-load, and non-echo `AnchorChanged` applies ran on `appScope` (`Dispatchers.Default`) and called `MediaController` directly — Media3 is single-threaded (the read path is already pinned to `Main.immediate`). A single device never hits these paths (drift ≈ 0 when you're the anchor source), so it was latent; it would first fire on 2-device co-listening. `applyAnchorToPlayback` is now `suspend` + `withContext(mainDispatcher)`, with the two non-suspend callers reordered to publish state first then launch the apply (preserving the "never gate a state transition on the player" invariant). New test proves the apply is dispatched through the injected main dispatcher.

## Gates
`verifyLocal` (lint + all JVM tests) ✅ · `:androidApp:assembleDebug` ✅. Swift-Export patcher count for `PlaybackGuardEvent` bumped 1→2 (Mac-lane validated).

## Held for the post-RPC-rebase controller pass (not in this PR)
- **F2** — process-scoped session ownership (activity-scoped VM currently orphans a live session on task-swipe). Structural; better written against the settled RpcChannel base, and it's the natural iOS seam.
- **F7/F8** — teardown RPC result handling + appScope; re-read `isHost` at confirm time.
- **2-device E2E** confirms F1 on-device — after the client/server data wipe that unblocks app launch.