### PR TITLE
🔒 fix(auth): never log out on a network blip + auth/security hardening (Fable audit — C-cluster)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/core/CachingSecureStorage.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/core/CachingSecureStorage.kt
@@ -34,9 +34,12 @@ class CachingSecureStorage(
     override suspend fun save(
         key: String,
         value: String,
-    ) {
+    ) = mutex.withLock {
+        // Delegate write and cache update under ONE lock so concurrent writers can't land on disk in
+        // one order and in the cache in another, leaving the cache disagreeing with the delegate
+        // (C7 — a rotated token reverting under a racing write).
         delegate.save(key, value)
-        mutex.withLock { cache[key] = value }
+        cache[key] = value
     }
 
     override suspend fun read(key: String): String? =
@@ -44,13 +47,16 @@ class CachingSecureStorage(
             cache[key] ?: delegate.read(key)?.also { cache[key] = it }
         }
 
-    override suspend fun delete(key: String) {
-        delegate.delete(key)
-        mutex.withLock { cache.remove(key) }
-    }
+    override suspend fun delete(key: String) =
+        mutex.withLock {
+            delegate.delete(key)
+            cache.remove(key)
+            Unit
+        }
 
-    override suspend fun clear() {
-        delegate.clear()
-        mutex.withLock { cache.clear() }
-    }
+    override suspend fun clear() =
+        mutex.withLock {
+            delegate.clear()
+            cache.clear()
+        }
 }

--- a/contract/src/jvmMain/kotlin/com/calypsan/listenup/core/JvmSecureStorage.kt
+++ b/contract/src/jvmMain/kotlin/com/calypsan/listenup/core/JvmSecureStorage.kt
@@ -2,9 +2,13 @@ package com.calypsan.listenup.core
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.security.SecureRandom
 import java.util.Base64
 import javax.crypto.Cipher
@@ -41,6 +45,14 @@ class JvmSecureStorage(
 ) : SecureStorage {
     private val json = appJson
     private val secretKey: SecretKeySpec by lazy { deriveKey() }
+
+    /**
+     * Serializes the read-modify-write of the single backing file. Without it two concurrent writers
+     * both decode the same snapshot, each add their key, and the later write clobbers the earlier —
+     * silently reverting a just-rotated token (C7). Reads stay lock-free: [saveStore] swaps the file
+     * in with an atomic rename, so a concurrent reader always sees a whole old-or-new file.
+     */
+    private val writeMutex = Mutex()
 
     /**
      * Derive encryption key from machine-specific data.
@@ -142,22 +154,31 @@ class JvmSecureStorage(
         }
 
     /**
-     * Save the data store to disk.
+     * Save the data store to disk via a temp file + atomic rename, so a crash or a concurrent read
+     * mid-write never observes a half-written (and thus undecryptable) file.
      */
     private fun saveStore(store: Map<String, String>) {
         storageFile.parentFile?.mkdirs()
         val plaintext = json.encodeToString(store)
         val encrypted = encrypt(plaintext)
-        storageFile.writeText(encrypted)
+        val tmp = File(storageFile.parentFile, "${storageFile.name}.tmp")
+        tmp.writeText(encrypted)
+        try {
+            Files.move(tmp.toPath(), storageFile.toPath(), StandardCopyOption.ATOMIC_MOVE)
+        } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+            Files.move(tmp.toPath(), storageFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
     }
 
     override suspend fun save(
         key: String,
         value: String,
     ) = withContext(Dispatchers.IO) {
-        val store = loadStore()
-        store[key] = value
-        saveStore(store)
+        writeMutex.withLock {
+            val store = loadStore()
+            store[key] = value
+            saveStore(store)
+        }
     }
 
     override suspend fun read(key: String): String? =
@@ -167,15 +188,19 @@ class JvmSecureStorage(
 
     override suspend fun delete(key: String) =
         withContext(Dispatchers.IO) {
-            val store = loadStore()
-            store.remove(key)
-            saveStore(store)
+            writeMutex.withLock {
+                val store = loadStore()
+                store.remove(key)
+                saveStore(store)
+            }
         }
 
     override suspend fun clear() =
         withContext(Dispatchers.IO) {
-            if (storageFile.exists()) {
-                storageFile.delete()
+            writeMutex.withLock {
+                if (storageFile.exists()) {
+                    storageFile.delete()
+                }
             }
         }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportPaths.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportPaths.kt
@@ -4,6 +4,20 @@ import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
 /**
+ * True when [id] is safe to use as an import directory-name segment: non-blank, and free of path
+ * separators (`/`, `\`) and `..` traversal sequences. Server-minted import ids are always safe, but
+ * the RPC surface accepts a client-supplied [com.calypsan.listenup.core.ImportId], so every
+ * id-taking [com.calypsan.listenup.server.api.ImportServiceImpl] method validates before any
+ * filesystem access — mirroring [com.calypsan.listenup.server.backup.isSafeBackupId].
+ */
+fun isSafeImportId(id: String): Boolean {
+    if (id.isBlank()) return false
+    if (id.contains('/') || id.contains('\\')) return false
+    if (id.contains("..")) return false
+    return true
+}
+
+/**
  * All filesystem locations the ABS-import domain uses, rooted at `$LISTENUP_HOME/imports/`.
  *
  * Import jobs are **filesystem-truth**: there is no database table. Each staged import lives in

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
@@ -157,6 +157,10 @@ class AdminUserServiceImpl(
         patch: AdminUserPatch,
     ): AppResult<User> {
         requireAdmin()?.let { return it }
+        // Captured inside the txn, acted on after commit: a privilege demotion must sever the
+        // demoted user's live sessions so a still-valid access token can't outlive its role (≤15m
+        // stale-privilege window otherwise — the access JWT embeds the role claim).
+        var demoted = false
         val outcome: AppResult<User> =
             suspendTransaction(sql) {
                 val user =
@@ -169,6 +173,7 @@ class AdminUserServiceImpl(
                 // Merge only the non-null patch fields, then write the merged row back.
                 val mergedDisplayName = patch.displayName ?: user.displayName
                 val mergedRole = patch.role?.toColumn() ?: user.role
+                demoted = user.role == UserRoleColumn.ADMIN && mergedRole == UserRoleColumn.MEMBER
                 val mergedCanEdit = patch.permissions?.canEdit ?: user.canEdit
                 val mergedCanShare = patch.permissions?.canShare ?: user.canShare
                 val now = clock.now().toEpochMilliseconds()
@@ -194,6 +199,7 @@ class AdminUserServiceImpl(
         // Publish AFTER commit, mirroring deleteUser's capture-then-act shape: the merged-row
         // write is the durable fact, so the roster refresh only fires once it's actually landed.
         if (outcome is AppResult.Success) {
+            if (demoted) sessions.revokeAll(id)
             adminUserRosterMaintainer?.refreshBestEffort(id.value)
         }
         return outcome

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ImportServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ImportServiceImpl.kt
@@ -19,6 +19,7 @@ import com.calypsan.listenup.server.absimport.ImportAnalyzer
 import com.calypsan.listenup.server.absimport.ImportApplier
 import com.calypsan.listenup.server.absimport.ImportStore
 import com.calypsan.listenup.server.absimport.MappingValidator
+import com.calypsan.listenup.server.absimport.isSafeImportId
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -51,6 +52,7 @@ class ImportServiceImpl(
 
     override suspend fun analyze(importId: ImportId): AppResult<ImportAnalysis> {
         requireAdmin()?.let { return it }
+        rejectUnsafeId(importId)?.let { return it }
         return analyzer.analyze(importId) { eventBus.tryEmit(it) }
     }
 
@@ -60,6 +62,7 @@ class ImportServiceImpl(
         bookOverrides: Map<AbsItemId, BookId?>,
     ): AppResult<Unit> {
         requireAdmin()?.let { return it }
+        rejectUnsafeId(importId)?.let { return it }
         if (store.getImport(importId) == null) {
             return AppResult.Failure(ImportError.ImportNotFound())
         }
@@ -70,6 +73,7 @@ class ImportServiceImpl(
 
     override suspend fun apply(importId: ImportId): AppResult<ImportResult> {
         requireAdmin()?.let { return it }
+        rejectUnsafeId(importId)?.let { return it }
         return applier.apply(importId) { eventBus.tryEmit(it) }
     }
 
@@ -80,12 +84,14 @@ class ImportServiceImpl(
 
     override suspend fun getImport(importId: ImportId): AppResult<ImportSummary> {
         requireAdmin()?.let { return it }
+        rejectUnsafeId(importId)?.let { return it }
         return store.getImport(importId)?.let { AppResult.Success(it) }
             ?: AppResult.Failure(ImportError.ImportNotFound())
     }
 
     override suspend fun deleteImport(importId: ImportId): AppResult<Unit> {
         requireAdmin()?.let { return it }
+        rejectUnsafeId(importId)?.let { return it }
         return if (store.deleteImport(importId)) {
             AppResult.Success(Unit)
         } else {
@@ -109,6 +115,14 @@ class ImportServiceImpl(
         }
 
     // ── Private helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * null = safe id; an [ImportError.ImportNotFound] Failure for a client-supplied id that could
+     * escape the imports directory (path separators / `..`). Reported as not-found so a traversal
+     * probe learns nothing. Mirrors the backup surface's `isSafeBackupId` guard.
+     */
+    private fun rejectUnsafeId(importId: ImportId): AppResult.Failure? =
+        if (isSafeImportId(importId.value)) null else AppResult.Failure(ImportError.ImportNotFound())
 
     /** null = allowed; a Failure (PermissionDenied / SessionExpired) otherwise. */
     private fun requireAdmin(): AppResult.Failure? {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
@@ -91,11 +91,16 @@ class AuthServiceImpl(
         val user =
             suspendTransaction(db) {
                 db.usersQueries.selectByEmailNormalized(normalized).executeAsOneOrNull()
-            }?.toAuthUser() ?: return AppResult.Failure(AuthError.InvalidCredentials())
+            }?.toAuthUser()
 
-        // A soft-deleted account must be indistinguishable from a nonexistent one:
-        // same InvalidCredentials, so admin deletion is final and existence doesn't leak.
-        if (user.deletedAt != null) return AppResult.Failure(AuthError.InvalidCredentials())
+        // A soft-deleted account must be indistinguishable from a nonexistent one, and a
+        // nonexistent one from a wrong password. Skipping Argon2 on the unknown/deleted path
+        // would leak account existence via response time (Argon2 is the dominant cost), so run a
+        // throwaway hash of the same input to equalize timing before failing (C12).
+        if (user == null || user.deletedAt != null) {
+            hasher.hash(request.password)
+            return AppResult.Failure(AuthError.InvalidCredentials())
+        }
 
         if (!hasher.verify(request.password, user.passwordHash)) {
             return AppResult.Failure(AuthError.InvalidCredentials())
@@ -220,7 +225,21 @@ class AuthServiceImpl(
                 status = UserStatusColumn.ACTIVE,
                 now = now,
             )
-        suspendTransaction(db) { insert(user) }
+        // Re-check emptiness INSIDE the insert transaction (C6). The pre-check above is a cheap
+        // fast-fail (no Argon2 once setup is done); Argon2 then widens a TOCTOU window during which a
+        // second concurrent setupRoot could also observe an empty table. SQLite serializes writers,
+        // so re-reading hasAnyUser within the write transaction makes the loser observe the winner's
+        // ROOT row and abort — never a second ROOT.
+        val inserted =
+            suspendTransaction(db) {
+                if (db.usersQueries.hasAnyUser().executeAsOne()) {
+                    false
+                } else {
+                    insert(user)
+                    true
+                }
+            }
+        if (!inserted) return AppResult.Failure(AuthError.SetupAlreadyComplete())
         createStarterShelfBestEffort(user.id)
         adminUserRosterMaintainer?.refreshBestEffort(user.id)
         publicProfileMaintainer?.refreshBestEffort(user.id)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/SessionService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/SessionService.kt
@@ -13,6 +13,7 @@ import kotlin.time.Clock
 import kotlin.uuid.Uuid
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
 /** Result of creating a new session — the raw refresh token is only returned here. */
@@ -48,6 +49,15 @@ class SessionService(
     private val tokenHasher: RefreshTokenHasher,
     private val tokenGenerator: RefreshTokenGenerator,
     private val refreshTtl: Duration = DEFAULT_REFRESH_TTL,
+    /**
+     * Lost-response grace window (C4). A refresh token whose rotation completed on the server but
+     * whose response never reached the client leaves the client holding the pre-rotation token. When
+     * the client retries, the server sees that token in `previous_hash` and would normally read it as
+     * a stolen-token replay and revoke the whole family — a dropped packet forcing a logout. Within
+     * this window of the last rotation we instead treat the retry as benign: rotate again on the same
+     * family and hand back a usable token. Genuine reuse after the window still hard-revokes.
+     */
+    private val reuseGracePeriod: Duration = DEFAULT_REUSE_GRACE,
     private val clock: Clock = Clock.System,
 ) {
     suspend fun createSession(
@@ -122,14 +132,40 @@ class SessionService(
                 )
             }
 
-            // Pass 2: previous-hash match → replay; revoke the family.
+            // Pass 2: previous-hash match. This is either a lost-response retry (benign) or a
+            // stolen-token replay (attack). The reuse-grace window (C4) distinguishes them: a live
+            // session whose last rotation was within the window is a dropped-response retry — rotate
+            // again on the same family without revoking. Anything else is a genuine replay → revoke.
             val replay =
                 db.sessionsQueries
                     .selectByPreviousHash(previous_hash = incomingHash)
                     .executeAsOneOrNull()
-            if (replay != null) {
-                db.sessionsQueries.revokeFamily(revoked_at = now, family_id = replay.family_id)
+                    ?: return@suspendTransaction null // unknown token — nothing to rotate or revoke.
+
+            val withinGrace =
+                replay.revoked_at == null &&
+                    replay.expires_at > now &&
+                    now - replay.last_used_at <= reuseGracePeriod.inWholeMilliseconds
+            if (withinGrace) {
+                // Re-rotate on the same lineage. previous_hash stays keyed on the incoming token so
+                // the window remains anchored to it; a late replay of the same token past the window
+                // still lands in the revoke branch below.
+                db.sessionsQueries.rotate(
+                    previous_hash = incomingHash,
+                    refresh_token_hash = newHash,
+                    last_used_at = now,
+                    expires_at = newExpires,
+                    id = replay.id,
+                )
+                return@suspendTransaction RotatedSession(
+                    sessionId = SessionId(replay.id),
+                    userId = UserId(replay.user_id),
+                    refreshToken = RefreshToken(newRaw),
+                    expiresAt = newExpires,
+                )
             }
+
+            db.sessionsQueries.revokeFamily(revoked_at = now, family_id = replay.family_id)
             null
         }
     }
@@ -212,5 +248,6 @@ class SessionService(
 
     companion object {
         private val DEFAULT_REFRESH_TTL: Duration = 30.days
+        private val DEFAULT_REUSE_GRACE: Duration = 60.seconds
     }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -41,6 +41,7 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
 /**
@@ -81,11 +82,17 @@ fun authModule(config: ApplicationConfig): Module {
         }
 
         single {
+            // Lost-response reuse-grace window (C4). Configurable so an operator can tune it and so
+            // integration tests can pin the family-revoke path with a real Clock.System by setting 0.
+            val graceSeconds =
+                config.propertyOrNull("auth.refreshReuseGraceSeconds")?.getString()?.toLong()
+                    ?: DEFAULT_REUSE_GRACE_SECONDS
             SessionService(
                 db = get<ListenUpDatabase>(),
                 tokenHasher = get(),
                 tokenGenerator = get(),
                 refreshTtl = REFRESH_TOKEN_TTL_DAYS.days,
+                reuseGracePeriod = graceSeconds.seconds,
                 clock = get(),
             )
         }
@@ -203,6 +210,9 @@ fun authModule(config: ApplicationConfig): Module {
 }
 
 private const val REFRESH_TOKEN_TTL_DAYS = 30L
+
+/** Default lost-response reuse-grace window in seconds (C4). Overridable via `auth.refreshReuseGraceSeconds`. */
+private const val DEFAULT_REUSE_GRACE_SECONDS = 60L
 
 private const val DEFAULT_SERVER_NAME = "ListenUp"
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ListeningEventRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ListeningEventRepository.kt
@@ -281,6 +281,7 @@ class ListeningEventRepository(
                 updated_at = now,
                 client_op_id = clientOpId,
                 id = value.id,
+                user_id = userId,
             )
         } else {
             db.listeningEventsQueries.insert(

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
@@ -79,11 +79,13 @@ VALUES (
     :playback_speed, :tz, :device_label, :revision, :created_at, :updated_at, :deleted_at, :client_op_id
 );
 
--- Append-only re-upsert: advance only the sync-discipline columns, never the domain fields.
+-- Append-only re-upsert: advance only the sync-discipline columns, never the domain fields. Scoped
+-- by user_id so one user replaying another user's event id can never touch that row (cross-user
+-- authz): the id is a global PK but ownership is per-user.
 updateSyncColumns:
 UPDATE listening_events
 SET revision = :revision, updated_at = :updated_at, client_op_id = :client_op_id
-WHERE id = :id;
+WHERE id = :id AND user_id = :user_id;
 
 -- Stats support: a user's non-deleted events ordered by ended_at ascending (backfill walk).
 selectForUserOrderedByEndedAt:

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportPathsTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportPathsTest.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.server.absimport
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins [isSafeImportId] — the path-traversal guard the RPC import surface applies to a
+ * client-supplied `ImportId` before any filesystem access. Mirrors the backup-id contract.
+ */
+class ImportPathsTest :
+    FunSpec({
+        test("accepts a well-formed server-minted id") {
+            isSafeImportId("01H9ZABCDE1234567890") shouldBe true
+            isSafeImportId("import-2026-07-13") shouldBe true
+        }
+
+        test("rejects blank ids") {
+            isSafeImportId("") shouldBe false
+            isSafeImportId("   ") shouldBe false
+        }
+
+        test("rejects path separators and traversal sequences") {
+            isSafeImportId("../etc/passwd") shouldBe false
+            isSafeImportId("..") shouldBe false
+            isSafeImportId("a/b") shouldBe false
+            isSafeImportId("a\\b") shouldBe false
+            isSafeImportId("foo/../bar") shouldBe false
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
@@ -201,6 +201,49 @@ class AdminUserServiceImplTest :
             }
         }
 
+        test("demoting an admin to member revokes all their sessions (no stale privileged window)") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestUser("root1", UserRoleColumn.ROOT)
+                sql.seedTestUser("a1", UserRoleColumn.ADMIN)
+                runTest {
+                    // A live session the demoted admin still holds a valid access token against.
+                    val sessions =
+                        SessionService(sql, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = fixedClock)
+                    val issued = sessions.createSession(UserId("a1"))
+                    sessions.isLive(issued.sessionId) shouldBe true
+
+                    makeAdminUserService(db)
+                        .actAs("root1", UserRole.ROOT)
+                        .updateUser(UserId("a1"), AdminUserPatch(role = UserRole.MEMBER))
+                        .shouldSucceed()
+
+                    // The demotion must sever their sessions so the ADMIN-role JWT can't outlive it.
+                    sessions.isLive(issued.sessionId) shouldBe false
+                }
+            }
+        }
+
+        test("a permission-only update does NOT revoke sessions") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestUser("root1", UserRoleColumn.ROOT)
+                sql.seedTestUser("m1", UserRoleColumn.MEMBER)
+                runTest {
+                    val sessions =
+                        SessionService(sql, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = fixedClock)
+                    val issued = sessions.createSession(UserId("m1"))
+
+                    makeAdminUserService(db)
+                        .actAs("root1", UserRole.ROOT)
+                        .updateUser(UserId("m1"), AdminUserPatch(displayName = "Renamed"))
+                        .shouldSucceed()
+
+                    sessions.isLive(issued.sessionId) shouldBe true
+                }
+            }
+        }
+
         test("updateUser by a non-admin is rejected with PermissionDenied") {
             withSqlDatabase {
                 val db = this

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/auth/AuthServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/auth/AuthServiceImplTest.kt
@@ -22,6 +22,7 @@ import com.calypsan.listenup.server.settings.ServerSettingsRepository
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.MutableClock
 import com.calypsan.listenup.server.testing.migratedTestDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -30,7 +31,9 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldNotBeBlank
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -39,20 +42,23 @@ class AuthServiceImplTest :
         val pepper = "x".repeat(32).toByteArray()
         val clock = FixedClock(Instant.parse("2026-05-02T12:00:00Z"))
 
-        fun newSvc(policy: RegistrationPolicy = RegistrationPolicy.OPEN): AuthServiceImpl {
+        fun newSvc(
+            policy: RegistrationPolicy = RegistrationPolicy.OPEN,
+            svcClock: Clock = clock,
+        ): AuthServiceImpl {
             val db = migratedTestDatabase().db
             val hasher = PasswordHasher()
             val sessions =
-                SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = clock)
-            val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client", 15.minutes, clock)
+                SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = svcClock)
+            val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client", 15.minutes, svcClock)
             val settings = ServerSettingsRepository(db, default = policy)
             return AuthServiceImpl(
                 db = db,
                 sessions = sessions,
                 hasher = hasher,
                 jwt = jwt,
-                sessionIssuer = SessionIssuer(sessions, jwt, clock),
-                clock = clock,
+                sessionIssuer = SessionIssuer(sessions, jwt, svcClock),
+                clock = svcClock,
                 settings = settings,
             )
         }
@@ -323,8 +329,9 @@ class AuthServiceImplTest :
             }
         }
 
-        test("refreshSession on a replayed token errors InvalidRefreshToken (familyRevoked=true)") {
-            val svc = newSvc()
+        test("refreshSession replaying a token AFTER the grace window errors InvalidRefreshToken (familyRevoked=true)") {
+            val mutClock = MutableClock(Instant.parse("2026-05-02T12:00:00Z"))
+            val svc = newSvc(svcClock = mutClock)
             runTest {
                 svc.setupRoot(RegisterRequest("root@x", "x".repeat(8), "Root")).shouldSucceed()
                 val first =
@@ -336,11 +343,37 @@ class AuthServiceImplTest :
 
                 svc.refreshSession(RefreshRequest(original)).shouldSucceed()
 
+                // Past the lost-response grace window, replaying the original token is an
+                // unambiguous reuse attack → family revoke.
+                mutClock.instant = mutClock.instant + 61.seconds
                 val err =
                     svc
                         .refreshSession(RefreshRequest(original))
                         .shouldFail<AuthError.InvalidRefreshToken>()
                 err.familyRevoked shouldBe true
+            }
+        }
+
+        test("refreshSession replaying a token WITHIN the grace window rotates again (lost-response retry, C4)") {
+            val mutClock = MutableClock(Instant.parse("2026-05-02T12:00:00Z"))
+            val svc = newSvc(svcClock = mutClock)
+            runTest {
+                svc.setupRoot(RegisterRequest("root@x", "x".repeat(8), "Root")).shouldSucceed()
+                val first =
+                    svc
+                        .register(RegisterRequest("alice@x", "x".repeat(8), "Alice"))
+                        .shouldSucceed()
+                        .shouldBeInstanceOf<RegisterResult.Authenticated>()
+                val original = first.session.refreshToken
+
+                val firstRotation = svc.refreshSession(RefreshRequest(original)).shouldSucceed()
+
+                // The client never saw firstRotation's response and re-presents the original token a
+                // moment later — a dropped-response retry, not an attack.
+                mutClock.instant = mutClock.instant + 30.seconds
+                val retry = svc.refreshSession(RefreshRequest(original)).shouldSucceed()
+                retry.sessionId shouldBe firstRotation.sessionId
+                retry.refreshToken shouldNotBe firstRotation.refreshToken
             }
         }
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/auth/SessionServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/auth/SessionServiceTest.kt
@@ -5,6 +5,7 @@ package com.calypsan.listenup.server.auth
 import com.calypsan.listenup.api.dto.auth.RefreshToken
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.MutableClock
 import com.calypsan.listenup.server.testing.migratedTestDatabase
 import com.calypsan.listenup.server.testing.seedTestUser
 import io.kotest.core.spec.style.FunSpec
@@ -13,6 +14,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlin.time.ExperimentalTime
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 class SessionServiceTest :
@@ -70,16 +72,19 @@ class SessionServiceTest :
             rotated shouldBe null
         }
 
-        test("rotate replaying the previous token revokes the entire family") {
+        test("rotate replaying the previous token AFTER the grace window revokes the entire family") {
             val db = freshDb()
             db.seedTestUser("u-1")
+            val mutClock = MutableClock(Instant.parse("2026-05-02T12:00:00Z"))
             val svc =
-                SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = clock)
+                SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = mutClock)
 
             val issued = svc.createSession(UserId("u-1"))
             val firstRotation = svc.rotate(issued.refreshToken).shouldNotBeNull()
 
-            // Adversary replays the original (now-stale) refresh token.
+            // Adversary replays the original (now-stale) refresh token WELL beyond the lost-response
+            // grace window — an unambiguous reuse attack.
+            mutClock.instant = mutClock.instant + 61.seconds
             val replay = svc.rotate(issued.refreshToken)
             replay shouldBe null
 
@@ -91,6 +96,61 @@ class SessionServiceTest :
             // After family revoke, even the *current* good token can't rotate the
             // session — the row is revoked.
             svc.rotate(firstRotation.refreshToken) shouldBe null
+        }
+
+        test("a replay WITHIN the grace window rotates again and never revokes the family (C4)") {
+            val db = freshDb()
+            db.seedTestUser("u-1")
+            val mutClock = MutableClock(Instant.parse("2026-05-02T12:00:00Z"))
+            val svc =
+                SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = mutClock)
+
+            val issued = svc.createSession(UserId("u-1"))
+            val firstRotation = svc.rotate(issued.refreshToken).shouldNotBeNull()
+
+            // The client never received firstRotation's response and re-presents the ORIGINAL token
+            // a moment later — a lost-response retry, not an attack.
+            mutClock.instant = mutClock.instant + 30.seconds
+            val retry = svc.rotate(issued.refreshToken).shouldNotBeNull()
+
+            // It rotates AGAIN — a usable fresh token — rather than family-revoking.
+            retry.sessionId shouldBe issued.sessionId
+            retry.userId shouldBe UserId("u-1")
+            retry.refreshToken shouldNotBe firstRotation.refreshToken
+            retry.refreshToken shouldNotBe issued.refreshToken
+
+            // The session stays live throughout.
+            db.sessionsQueries
+                .selectById(issued.sessionId.value)
+                .executeAsOne()
+                .revoked_at shouldBe null
+            svc.isLive(issued.sessionId) shouldBe true
+
+            // The freshly-minted token works on the next rotation (the client recovered cleanly).
+            svc.rotate(retry.refreshToken).shouldNotBeNull()
+        }
+
+        test("a replay within grace is idempotent-safe but a LATE replay of the same token still revokes") {
+            val db = freshDb()
+            db.seedTestUser("u-1")
+            val mutClock = MutableClock(Instant.parse("2026-05-02T12:00:00Z"))
+            val svc =
+                SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = mutClock)
+
+            val issued = svc.createSession(UserId("u-1"))
+            svc.rotate(issued.refreshToken).shouldNotBeNull()
+
+            // A grace retry keeps the family alive.
+            mutClock.instant = mutClock.instant + 10.seconds
+            svc.rotate(issued.refreshToken).shouldNotBeNull()
+
+            // The same original token surfacing long after the window is an attack → family revoke.
+            mutClock.instant = mutClock.instant + 61.seconds
+            svc.rotate(issued.refreshToken) shouldBe null
+            db.sessionsQueries
+                .selectById(issued.sessionId.value)
+                .executeAsOne()
+                .revoked_at shouldNotBe null
         }
 
         test("revoke marks the session row revoked; revokeAll does the same for every active session") {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndFixture.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndFixture.kt
@@ -83,6 +83,9 @@ internal class AuthEndToEndFixture private constructor(
                             "jwt.audience" to "listenup-client",
                             "registration.policy" to "OPEN",
                             "mdns.enabled" to "false",
+                            // Disable the lost-response reuse-grace window (C4) so the immediate-replay
+                            // family-revoke path is exercised against a real Clock.System.
+                            "auth.refreshReuseGraceSeconds" to "0",
                         )
                 }
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/ListeningEventRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/ListeningEventRepositoryTest.kt
@@ -67,6 +67,38 @@ class ListeningEventRepositoryTest :
             }
         }
 
+        test("a re-upsert of another user's event id cannot stomp that row (cross-user authz)") {
+            withSqlDatabase {
+                val repo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                runTest {
+                    // Victim userB owns the event.
+                    val victim =
+                        (
+                            repo.upsert(
+                                listeningEventPayload("shared-id", "book-b", startPositionMs = 1_000L),
+                                clientOpId = "op-B",
+                                userId = "userB",
+                            ) as AppResult.Success
+                        ).data
+
+                    // Attacker userA replays the SAME id with attacker-controlled fields.
+                    repo.upsert(
+                        listeningEventPayload("shared-id", "book-a", startPositionMs = 55_555L),
+                        clientOpId = "op-A",
+                        userId = "userA",
+                    )
+
+                    // userB's row is untouched — same owner, domain fields, and sync columns.
+                    val row = sql.listeningEventsQueries.selectById("shared-id").executeAsOne()
+                    row.user_id shouldBe "userB"
+                    row.book_id shouldBe "book-b"
+                    row.start_position_ms shouldBe 1_000L
+                    row.client_op_id shouldBe "op-B"
+                    row.revision shouldBe victim.revision
+                }
+            }
+        }
+
         test("pullSince(userId = u1) returns only u1's events") {
             withSqlDatabase {
                 val repo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/FixedClock.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/FixedClock.kt
@@ -12,3 +12,10 @@ class FixedClock(
 ) : Clock {
     override fun now(): Instant = fixed
 }
+
+/** An advanceable [kotlin.time.Clock] for exercising time-window behaviour (e.g. the refresh reuse-grace). */
+class MutableClock(
+    var instant: Instant,
+) : Clock {
+    override fun now(): Instant = instant
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/TestApplicationConfig.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/TestApplicationConfig.kt
@@ -58,6 +58,11 @@ fun ApplicationTestBuilder.useIsolatedTestConfig(
                 "jwt.secret" to "x".repeat(32),
                 "jwt.issuer" to "listenup",
                 "jwt.audience" to "listenup-client",
+                // Disable the lost-response reuse-grace window so integration tests can pin the
+                // family-revoke path against a real Clock.System (an immediate replay would otherwise
+                // fall inside the grace window and rotate again). Unit tests exercise the grace
+                // behaviour directly with a controllable clock.
+                "auth.refreshReuseGraceSeconds" to "0",
                 // No test should bind multicast sockets or run an mDNS receive loop — pure overhead
                 // and a source of cross-test load that flakes the firehose timeout budget.
                 "mdns.enabled" to "false",

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.client.data.remote.RpcFailureClassifier
 import com.calypsan.listenup.client.data.remote.ServerUrlNotConfiguredException
+import com.calypsan.listenup.client.data.remote.TransientAuthRefreshException
 import com.calypsan.listenup.client.data.remote.model.EnvelopeMismatchException
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
@@ -29,6 +30,14 @@ import kotlinx.serialization.SerializationException
 internal object ErrorMapper {
     fun map(exception: Throwable): AppError =
         when {
+            // A transient refresh failure during a 401-heal (C5): the refresh outcome was network /
+            // timeout / 5xx, NOT a server-confirmed dead token. Surface a RETRYABLE transport error and
+            // keep the session — a network blip must never log the user out. Checked FIRST so the
+            // wrapped handshake-401 cause it carries can't be misread as SessionExpired below.
+            exception is TransientAuthRefreshException -> {
+                TransportError.NetworkUnavailable(debugInfo = exception.message)
+            }
+
             // A handshake-401 WebSocketException is a stale-session signal from the `/api/rpc/authed`
             // upgrade. After RpcProxyCache's one bounded token-refresh + retry, a SECOND 401 reaches
             // here — surface it typed as SessionExpired so the global auth observer drives to login,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -515,8 +515,9 @@ internal expect fun createUnauthenticatedStreamingHttpClient(
  * Bridges the bearer plugin's `refreshTokens { }` block to
  * `AuthRepository.refreshAccessToken()`.
  *
- *  - Success → persist the rotated pair into [AuthSession] (so the next `loadTokens`
- *    sees the fresh values) and return them as [BearerTokens] for the immediate retry.
+ *  - Success → the rotated pair was ALREADY persisted inside the single-flight refresh (C1); just
+ *    return it as [BearerTokens] for the immediate retry. Persisting here again would be redundant and
+ *    reopen the stale-token window this bridge used to own.
  *  - `Failure(SessionExpired | InvalidRefreshToken)` → the refresh token is dead; soft-clear the
  *    session credentials so state lands in `AuthState.SessionLapsed` (shell stays mounted,
  *    banner offers sign-in) instead of the login wall.
@@ -534,12 +535,6 @@ internal suspend fun refreshAuthTokens(
         when (val result = refreshAccessToken()) {
             is AppResult.Success -> {
                 val session = result.data
-                authSession.saveAuthTokens(
-                    access = session.accessToken,
-                    refresh = session.refreshToken,
-                    sessionId = session.sessionId.value,
-                    userId = session.user.id.value,
-                )
                 BearerTokens(
                     accessToken = session.accessToken.value,
                     refreshToken = session.refreshToken.value,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcAuthRecovery.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcAuthRecovery.kt
@@ -1,8 +1,25 @@
 package com.calypsan.listenup.client.data.remote
 
+import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+
+/**
+ * The outcome of a handshake-401 recovery attempt (C5). The three cases drive whether the session
+ * survives — the difference between a network blip and a real logout.
+ */
+internal enum class AuthRecoveryOutcome {
+    /** A fresh token is in place — retry the handshake. */
+    Refreshed,
+
+    /** The refresh failed transiently (network / timeout / 5xx) — KEEP the session, surface retryable. */
+    Transient,
+
+    /** The refresh token is server-confirmed dead — lapse the session (surface SessionExpired). */
+    SessionInvalid,
+}
 
 /**
  * Recovers RPC authentication when the `/api/rpc/authed` WebSocket handshake is rejected with 401 —
@@ -16,12 +33,12 @@ import kotlinx.coroutines.sync.withLock
  * is idempotent and cheap relative to the failure it recovers.
  */
 internal interface RpcAuthRecovery {
-    /** @return true if a fresh token is now in place (retry the handshake); false if re-auth is required. */
-    suspend fun refreshAndRebuild(): Boolean
+    /** Classifies the refresh so a transient failure can't be mistaken for session death (C5). */
+    suspend fun refreshAndRebuild(): AuthRecoveryOutcome
 
     /** No-op recovery for the unauthenticated `/api/rpc/public` mount — it must never trigger a refresh. */
     object None : RpcAuthRecovery {
-        override suspend fun refreshAndRebuild(): Boolean = false
+        override suspend fun refreshAndRebuild(): AuthRecoveryOutcome = AuthRecoveryOutcome.SessionInvalid
     }
 }
 
@@ -32,16 +49,33 @@ internal class RpcAuthRecoveryImpl(
 ) : RpcAuthRecovery {
     private val mutex = Mutex()
 
-    override suspend fun refreshAndRebuild(): Boolean =
+    override suspend fun refreshAndRebuild(): AuthRecoveryOutcome =
         mutex.withLock {
-            // refreshAuthTokens saves the new tokens into AuthSession and returns them (null on failure,
-            // clearing tokens on an invalid refresh token so the global auth observer routes to login).
-            val refreshed = refreshAuthTokens(authSession, refreshAccessToken) != null
-            if (refreshed) {
-                // Rebuild ONLY the request client so its Bearer provider re-reads the refreshed token;
-                // the long-lived streaming/SSE client is untouched.
-                apiClientFactory.invalidateRequestClientOnly()
+            // The rotated tokens (on success) are persisted inside the single-flight refresh (C1); here
+            // we only classify the outcome and rebuild the request client on success.
+            when (val result = refreshAccessToken()) {
+                is AppResult.Success -> {
+                    // Rebuild ONLY the request client so its Bearer provider re-reads the refreshed
+                    // token; the long-lived streaming/SSE client is untouched.
+                    apiClientFactory.invalidateRequestClientOnly()
+                    AuthRecoveryOutcome.Refreshed
+                }
+
+                is AppResult.Failure -> {
+                    when (result.error) {
+                        // Server-confirmed dead refresh token → soft-clear so state lands in
+                        // SessionLapsed and the boundary surfaces SessionExpired.
+                        is AuthError.SessionExpired, is AuthError.InvalidRefreshToken -> {
+                            authSession.clearSessionCredentials()
+                            AuthRecoveryOutcome.SessionInvalid
+                        }
+
+                        // Network / timeout / 5xx / internal — NOT session death. Keep the session.
+                        else -> {
+                            AuthRecoveryOutcome.Transient
+                        }
+                    }
+                }
             }
-            refreshed
         }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
@@ -178,8 +178,25 @@ internal class RpcProxyCache<T : Any>(
             } catch (e: Throwable) {
                 if (e.isCallerCancellation()) throw e
                 invalidate(first.generation)
-                if (!canResubscribeStream(e, emitted)) surfaceStreamFailure(e)
-                resubscribe(subscribe)
+                when {
+                    // A handshake 401 before the first emit heals per the C5 outcome: refresh + resubscribe,
+                    // keep-session-retryable on a transient refresh failure, or lapse on a confirmed-dead token.
+                    !emitted && isWsHandshake401(e) -> {
+                        when (authRecovery.refreshAndRebuild()) {
+                            AuthRecoveryOutcome.Refreshed -> resubscribe(subscribe)
+                            AuthRecoveryOutcome.Transient -> throw TransientAuthRefreshException(e)
+                            AuthRecoveryOutcome.SessionInvalid -> throw e
+                        }
+                    }
+
+                    canResubscribeStream(e, emitted) -> {
+                        resubscribe(subscribe)
+                    }
+
+                    else -> {
+                        surfaceStreamFailure(e)
+                    }
+                }
             }
         }
 
@@ -209,19 +226,14 @@ internal class RpcProxyCache<T : Any>(
 
     /**
      * Whether a from-below streaming failure can be retried on a fresh lease: only when nothing was
-     * emitted yet AND the fault is provably pre-delivery (a refreshable handshake 401, a pre-delivery
-     * transport failure, or a dead-client ISE). Everything else is [surfaceStreamFailure]d.
+     * emitted yet AND the fault is provably pre-delivery (a pre-delivery transport failure or a
+     * dead-client ISE). The handshake-401 case is handled separately at the call site (it must branch
+     * on the C5 recovery outcome); everything else is [surfaceStreamFailure]d.
      */
-    private suspend fun canResubscribeStream(
+    private fun canResubscribeStream(
         e: Throwable,
         emitted: Boolean,
-    ): Boolean =
-        !emitted &&
-            when {
-                isWsHandshake401(e) -> authRecovery.refreshAndRebuild()
-                isPreDeliveryTransportFailure(e) || isDeadRpcClient(e) -> true
-                else -> false
-            }
+    ): Boolean = !emitted && (isPreDeliveryTransportFailure(e) || isDeadRpcClient(e))
 
     /**
      * Turn a non-resubscribable streaming failure into the right thrown signal — always throws.
@@ -320,13 +332,27 @@ internal class RpcProxyCache<T : Any>(
         block: suspend (T) -> R,
     ): R {
         logger.info { "RPC handshake 401; refreshing token before retry" }
-        val refreshed = authRecovery.refreshAndRebuild()
+        val outcome = authRecovery.refreshAndRebuild()
         invalidate(leasedGeneration)
-        if (!refreshed) {
-            logger.warn { "Token refresh failed; surfacing the 401 instead of retrying" }
-            throw e
+        return when (outcome) {
+            AuthRecoveryOutcome.Refreshed -> {
+                retryOnce(timeout, block)
+            }
+
+            // C5: a transient refresh failure (network/timeout/5xx) is NOT session death — surface a
+            // retryable TransportError and KEEP the session, instead of re-raising the 401 (which maps
+            // to SessionExpired → logout). A network blip must never log the user out.
+            AuthRecoveryOutcome.Transient -> {
+                logger.warn { "Refresh transiently failed during 401-heal; keeping session (retryable)" }
+                throw TransientAuthRefreshException(e)
+            }
+
+            // Server-confirmed invalid refresh token — surface the 401 so the session lapses.
+            AuthRecoveryOutcome.SessionInvalid -> {
+                logger.warn { "Refresh token server-confirmed invalid; surfacing the 401 (session lapse)" }
+                throw e
+            }
         }
-        return retryOnce(timeout, block)
     }
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/TransientAuthRefreshException.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/TransientAuthRefreshException.kt
@@ -1,0 +1,17 @@
+package com.calypsan.listenup.client.data.remote
+
+/**
+ * Signals that a token refresh during a handshake-401 heal failed **transiently** — a network drop,
+ * a timeout, or a 5xx — rather than because the refresh token was server-confirmed invalid.
+ *
+ * The distinction is the whole point of the never-stranded promise (C5): a network blip while healing
+ * a 401 must NOT be misread as session death and log the user out. [RpcProxyCache] throws this instead
+ * of re-raising the original handshake-401 (which
+ * [com.calypsan.listenup.client.core.error.ErrorMapper] would map to `SessionExpired` → logout), so
+ * the boundary surfaces a **retryable** `TransportError` and the session is kept. A genuinely dead
+ * refresh token (an explicit 401/`InvalidRefreshToken` from the refresh endpoint) still surfaces as
+ * `SessionExpired`.
+ */
+internal class TransientAuthRefreshException(
+    cause: Throwable,
+) : Exception("Token refresh transiently failed during a 401 heal — session kept, retry.", cause)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AuthRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AuthRepositoryImpl.kt
@@ -64,6 +64,10 @@ internal class AuthRepositoryImpl(
      *
      * The refresh RPC rides [authPublicChannel] (recovery = None): the refresh call is
      * itself what a 401 recovery invokes, so it must never be able to trigger one.
+     *
+     * Persistence (C1) is done HERE, inside the single-flight and BEFORE leadership is released, so no
+     * later caller can present a stale refresh token after rotation. The auth epoch captured at the
+     * start guards it (C8): a logout that intervened makes the persist a no-op via [AuthSession.saveAuthTokens].
      */
     override suspend fun refreshAccessToken(): AppResult<AuthSession> {
         val leader = CompletableDeferred<AppResult<AuthSession>>()
@@ -72,6 +76,7 @@ internal class AuthRepositoryImpl(
         if (existing !== leader) return existing.await()
 
         return try {
+            val epoch = authSession.currentAuthEpoch()
             val token = authSession.getRefreshToken()
             val result =
                 if (token == null) {
@@ -79,6 +84,16 @@ internal class AuthRepositoryImpl(
                 } else {
                     authPublicChannel.call { it.refreshSession(RefreshRequest(token)) }
                 }
+            if (result is AppResult.Success) {
+                val session = result.data
+                authSession.saveAuthTokens(
+                    access = session.accessToken,
+                    refresh = session.refreshToken,
+                    sessionId = session.sessionId.value,
+                    userId = session.user.id.value,
+                    ifEpoch = epoch,
+                )
+            }
             leader.complete(result)
             result
         } catch (e: CancellationException) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStore.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStore.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.time.TimeSource
 import com.calypsan.listenup.client.domain.model.AuthState as DomainAuthState
 
@@ -50,6 +52,15 @@ internal class AuthSessionStore(
     private val policyStream by policyStream
     override val authState: StateFlow<DomainAuthState>
         field = MutableStateFlow<DomainAuthState>(DomainAuthState.Initializing)
+
+    /**
+     * Serializes the auth-epoch check/bump with the credential writes it guards, so the epoch a
+     * refresh captured can't change between [saveAuthTokens]'s guard read and its writes (C8/C9).
+     */
+    private val credentialMutex = Mutex()
+    private var authEpoch: Long = 0
+
+    override suspend fun currentAuthEpoch(): Long = credentialMutex.withLock { authEpoch }
 
     init {
         observeRegistrationPolicy()
@@ -94,13 +105,27 @@ internal class AuthSessionStore(
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) {
-        secureStorage.save(KEY_ACCESS_TOKEN, access.value)
-        secureStorage.save(KEY_REFRESH_TOKEN, refresh.value)
-        secureStorage.save(KEY_SESSION_ID, sessionId)
-        secureStorage.save(KEY_USER_ID, userId)
+        credentialMutex.withLock {
+            // Epoch guard (C8): a refresh that captured an epoch which a logout has since bumped must
+            // NOT resurrect the signed-out session. Login/register/setup pass null → unconditional.
+            if (ifEpoch != null && ifEpoch != authEpoch) {
+                logger.info {
+                    "saveAuthTokens skipped: auth epoch advanced ($ifEpoch → $authEpoch) — session ended mid-refresh"
+                }
+                return
+            }
+            // Write order (C9): refresh → session → user → access. The access token is the readiness
+            // signal a concurrent reader keys on, so it lands LAST — never a new access token paired
+            // with a stale refresh token.
+            secureStorage.save(KEY_REFRESH_TOKEN, refresh.value)
+            secureStorage.save(KEY_SESSION_ID, sessionId)
+            secureStorage.save(KEY_USER_ID, userId)
+            secureStorage.save(KEY_ACCESS_TOKEN, access.value)
 
-        authState.value = DomainAuthState.Authenticated(UserId(userId), SessionId(sessionId))
+            authState.value = DomainAuthState.Authenticated(UserId(userId), SessionId(sessionId))
+        }
     }
 
     override suspend fun getAccessToken(): AccessToken? = secureStorage.read(KEY_ACCESS_TOKEN)?.let { AccessToken(it) }
@@ -123,6 +148,12 @@ internal class AuthSessionStore(
      * through [clearSessionCredentials] instead, which keeps the user id and never walls.
      */
     override suspend fun clearAuthTokens() {
+        credentialMutex.withLock { clearAuthTokensLocked() }
+    }
+
+    /** Full credential wipe under the [credentialMutex]. Bumps the auth epoch so an in-flight refresh can't resurrect. */
+    private suspend fun clearAuthTokensLocked() {
+        authEpoch++
         secureStorage.delete(KEY_ACCESS_TOKEN)
         secureStorage.delete(KEY_REFRESH_TOKEN)
         secureStorage.delete(KEY_SESSION_ID)
@@ -132,18 +163,24 @@ internal class AuthSessionStore(
     }
 
     override suspend fun clearSessionCredentials() {
-        val userId = getUserId()
-        if (userId == null) {
-            // No persisted identity to lapse into (fresh install / already signed out) —
-            // fall back to the full clear rather than invent a SessionLapsed without a user.
-            clearAuthTokens()
-            return
-        }
-        secureStorage.delete(KEY_ACCESS_TOKEN)
-        secureStorage.delete(KEY_REFRESH_TOKEN)
-        secureStorage.delete(KEY_SESSION_ID)
+        credentialMutex.withLock {
+            // Bump the epoch first: a concurrent late refresh that already captured the old epoch must
+            // not re-persist over this lapse (C8). [clearAuthTokensLocked] bumps it too; guard against
+            // double-invalidation by reading userId under the same lock.
+            val userId = getUserId()
+            if (userId == null) {
+                // No persisted identity to lapse into (fresh install / already signed out) —
+                // fall back to the full clear rather than invent a SessionLapsed without a user.
+                clearAuthTokensLocked()
+                return
+            }
+            authEpoch++
+            secureStorage.delete(KEY_ACCESS_TOKEN)
+            secureStorage.delete(KEY_REFRESH_TOKEN)
+            secureStorage.delete(KEY_SESSION_ID)
 
-        authState.value = DomainAuthState.SessionLapsed(UserId(userId))
+            authState.value = DomainAuthState.SessionLapsed(UserId(userId))
+        }
     }
 
     override suspend fun isAuthenticated(): Boolean = getAccessToken() != null

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/SettingsRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/SettingsRepository.kt
@@ -60,12 +60,28 @@ interface AuthSession {
     /** Reactive authentication state. */
     val authState: StateFlow<AuthState>
 
-    /** Save authentication tokens after successful login or token refresh. */
+    /**
+     * Monotonic auth epoch (C8). Captured at the start of a token refresh and passed back to
+     * [saveAuthTokens] as `ifEpoch`; a logout ([clearAuthTokens] / [clearSessionCredentials]) bumps
+     * it, so an in-flight refresh completing AFTER logout can't resurrect the session.
+     */
+    suspend fun currentAuthEpoch(): Long
+
+    /**
+     * Save authentication tokens after successful login or token refresh.
+     *
+     * [ifEpoch] is the epoch captured by the refresh path via [currentAuthEpoch] at its start. When
+     * non-null and no longer current (a logout intervened), the save is a no-op — this is the guard
+     * that stops a late refresh from resurrecting a signed-out session (C8). Login/register/setup pass
+     * null (unconditional). Writes land refresh → session → user → access so the access token — the
+     * readiness signal a concurrent reader keys on — is never paired with a stale refresh token (C9).
+     */
     suspend fun saveAuthTokens(
         access: AccessToken,
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long? = null,
     )
 
     suspend fun getAccessToken(): AccessToken?

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProvider.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProvider.kt
@@ -13,7 +13,13 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 import kotlin.concurrent.Volatile
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
@@ -68,7 +74,11 @@ class CachedAudioTokenProvider(
     private val refreshMutex = Mutex()
 
     init {
-        scope.launch { refreshToken() }
+        // Do NOT rotate on every construction (C11): a stored access token that is still comfortably
+        // fresh is served as-is, so a construction-time refresh can't needlessly burn a refresh-token
+        // rotation nor race the Ktor bearer plugin's own refresh. Only refresh when the stored token
+        // is missing, undecodable, or already inside the proactive horizon.
+        scope.launch { if (!primeFromFreshStoredToken()) refreshToken() }
         scope.launch {
             while (isActive) {
                 delay(PROACTIVE_CHECK_CADENCE)
@@ -113,13 +123,9 @@ class CachedAudioTokenProvider(
         refreshMutex.withLock {
             when (val result = authRepository.refreshAccessToken()) {
                 is AppResult.Success -> {
+                    // Persistence already happened inside the single-flight refresh (C1); here we only
+                    // update this provider's in-memory cache so getToken() serves the fresh token.
                     val session = result.data
-                    authSession.saveAuthTokens(
-                        access = session.accessToken,
-                        refresh = session.refreshToken,
-                        sessionId = session.sessionId.value,
-                        userId = session.user.id.value,
-                    )
                     cachedToken = session.accessToken
                     tokenExpiresAt = session.accessTokenExpiresAt
                     logger.info { "Token refreshed successfully" }
@@ -155,7 +161,45 @@ class CachedAudioTokenProvider(
 
     private fun now(): Long = clock.now().toEpochMilliseconds()
 
+    /**
+     * Loads a stored access token into the cache WITHOUT a network refresh when it is a decodable
+     * JWT still comfortably outside [PROACTIVE_REFRESH_HORIZON]. @return true when it did (so the
+     * caller skips the construction-time refresh); false when there is no usable-and-fresh token and
+     * a real refresh is warranted.
+     */
+    private suspend fun primeFromFreshStoredToken(): Boolean {
+        val stored = authSession.getAccessToken() ?: return false
+        val expiry = jwtExpiryMillis(stored.value) ?: return false
+        if (expiry - now() <= PROACTIVE_REFRESH_HORIZON.inWholeMilliseconds) return false
+        cachedToken = stored
+        tokenExpiresAt = expiry
+        return true
+    }
+
+    /**
+     * Best-effort read of a JWT's `exp` claim (seconds → epoch millis). Returns null for anything not
+     * a well-formed JWT with a numeric `exp` — the caller then falls back to a refresh, so a malformed
+     * or opaque token can never be trusted as fresh.
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun jwtExpiryMillis(token: String): Long? =
+        runCatching {
+            val payload = token.split('.').getOrNull(1) ?: return null
+            val decoded =
+                Base64.UrlSafe
+                    .withPadding(Base64.PaddingOption.ABSENT_OPTIONAL)
+                    .decode(payload)
+                    .decodeToString()
+            Json
+                .parseToJsonElement(decoded)
+                .jsonObject["exp"]
+                ?.jsonPrimitive
+                ?.longOrNull
+                ?.let { it * MILLIS_PER_SECOND }
+        }.getOrNull()
+
     companion object {
         private val STORED_TOKEN_GRACE = 50.minutes
+        private const val MILLIS_PER_SECOND = 1_000L
     }
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RefreshAuthTokensTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RefreshAuthTokensTest.kt
@@ -15,7 +15,6 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
-import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
@@ -53,7 +52,7 @@ private fun fakeContractSession(
  * `refreshTokens { }` block and `AuthRepository.refreshAccessToken()`.
  *
  * Coverage matrix:
- *  - Success → tokens persisted to [AuthSession], BearerTokens returned for the retry.
+ *  - Success → BearerTokens returned for the retry (persistence is the single-flight refresh's job, C1).
  *  - Failure(InvalidRefreshToken) and Failure(SessionExpired) → auth state cleared.
  *  - Failure(NetworkUnavailable) and other transient errors → auth state preserved.
  *  - CancellationException → re-thrown per coroutines convention.
@@ -62,25 +61,18 @@ private fun fakeContractSession(
 class RefreshAuthTokensTest :
     FunSpec({
 
-        test("Success persists rotated tokens and returns BearerTokens") {
+        test("Success returns BearerTokens without re-persisting (persistence is the single-flight's job, C1)") {
             runTest {
+                // saveAuthTokens is NOT stubbed — Mokkery throws if the bridge tries to persist, which
+                // it must not: the rotated pair is already persisted inside AuthRepository's single-flight.
                 val authSession = mock<AuthSession>()
                 val session = fakeContractSession()
-                everySuspend { authSession.saveAuthTokens(any(), any(), any(), any()) } returns Unit
 
                 val tokens = refreshAuthTokens(authSession) { AppResult.Success(session) }
 
                 tokens.shouldNotBeNull()
                 tokens.accessToken shouldBe "fresh-access"
                 tokens.refreshToken shouldBe "fresh-refresh"
-                verifySuspend {
-                    authSession.saveAuthTokens(
-                        access = AccessToken("fresh-access"),
-                        refresh = RefreshToken("fresh-refresh"),
-                        sessionId = "session-1",
-                        userId = "user-1",
-                    )
-                }
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
@@ -54,9 +54,9 @@ class RpcProxyCacheCallTest :
             var count = 0
                 private set
 
-            override suspend fun refreshAndRebuild(): Boolean {
+            override suspend fun refreshAndRebuild(): AuthRecoveryOutcome {
                 count++
-                return true
+                return AuthRecoveryOutcome.Refreshed
             }
         }
 
@@ -273,16 +273,16 @@ class RpcProxyCacheCallTest :
             }
         }
 
-        test("a handshake 401 whose token refresh fails surfaces SessionExpired without a doomed retry") {
+        test("a handshake 401 whose refresh is server-confirmed invalid surfaces SessionExpired without a doomed retry") {
             runTest {
-                // Refresh fails (tokens cleared) → retrying the handshake would just 401 again.
+                // Refresh is server-confirmed dead (tokens cleared) → retrying the handshake would just 401 again.
                 val failingRecovery =
                     object : RpcAuthRecovery {
                         var count = 0
 
-                        override suspend fun refreshAndRebuild(): Boolean {
+                        override suspend fun refreshAndRebuild(): AuthRecoveryOutcome {
                             count++
-                            return false
+                            return AuthRecoveryOutcome.SessionInvalid
                         }
                     }
                 val (cache, connects) =
@@ -304,6 +304,40 @@ class RpcProxyCacheCallTest :
                     .shouldBeInstanceOf<AuthError.SessionExpired>()
                 failingRecovery.count shouldBe 1
                 connects() shouldBe 1 // no retry — the second behavior is never reached
+            }
+        }
+
+        test("a handshake 401 whose refresh fails TRANSIENTLY keeps the session and surfaces a retryable error (C5)") {
+            runTest {
+                // A network blip during the 401-heal is NOT session death — the session must survive.
+                val transientRecovery =
+                    object : RpcAuthRecovery {
+                        var count = 0
+
+                        override suspend fun refreshAndRebuild(): AuthRecoveryOutcome {
+                            count++
+                            return AuthRecoveryOutcome.Transient
+                        }
+                    }
+                val (cache, connects) =
+                    scriptedCache(
+                        ArrayDeque(
+                            listOf(
+                                { throw WebSocketException("expected status code 101 but was 401") },
+                                { "must-not-run" },
+                            ),
+                        ),
+                        authRecovery = transientRecovery,
+                    )
+
+                val result: AppResult<String> = catchingRpcResult { cache.call { AppResult.Success(it.work()) } }
+
+                val error = result.shouldBeInstanceOf<AppResult.Failure>().error
+                // Retryable transport error — NOT SessionExpired, so the app stays signed in.
+                error.shouldBeInstanceOf<TransportError.NetworkUnavailable>()
+                error.isRetryable shouldBe true
+                transientRecovery.count shouldBe 1
+                connects() shouldBe 1 // no retry against the same dead socket
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheStreamingTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheStreamingTest.kt
@@ -49,9 +49,9 @@ class RpcProxyCacheStreamingTest :
             var count = 0
                 private set
 
-            override suspend fun refreshAndRebuild(): Boolean {
+            override suspend fun refreshAndRebuild(): AuthRecoveryOutcome {
                 count++
-                return true
+                return AuthRecoveryOutcome.Refreshed
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/TokenRefreshSingleFlightTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/TokenRefreshSingleFlightTest.kt
@@ -58,11 +58,14 @@ private class FakeAuthSession : AuthSession {
 
     override val authState: StateFlow<AuthState> get() = throw NotImplementedError()
 
+    override suspend fun currentAuthEpoch(): Long = 0L
+
     override suspend fun saveAuthTokens(
         access: AccessToken,
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) {
         this.access = access
         this.refresh = refresh

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthRepositoryImplTest.kt
@@ -2,9 +2,15 @@ package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.api.AuthServiceAuthed
 import com.calypsan.listenup.api.AuthServicePublic
+import com.calypsan.listenup.api.dto.auth.AccessToken
+import com.calypsan.listenup.api.dto.auth.AuthSession as ContractAuthSession
 import com.calypsan.listenup.api.dto.auth.RefreshToken
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.SessionSummary
+import com.calypsan.listenup.api.dto.auth.User
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.dto.auth.UserStatus
 import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
@@ -114,6 +120,7 @@ class AuthRepositoryImplTest :
                     AppResult.Failure(AuthError.SessionExpired())
                 }
                 val authSession = mock<ClientAuthSession>()
+                everySuspend { authSession.currentAuthEpoch() } returns 0L
                 everySuspend { authSession.getRefreshToken() } returns RefreshToken("rt-0")
 
                 val repo =
@@ -136,6 +143,53 @@ class AuthRepositoryImplTest :
             }
         }
 
+        test("a successful refresh persists the rotated tokens inside the single-flight, epoch-guarded (C1/C8)") {
+            runTest {
+                val session =
+                    ContractAuthSession(
+                        accessToken = AccessToken("fresh-access"),
+                        accessTokenExpiresAt = 0L,
+                        refreshToken = RefreshToken("fresh-refresh"),
+                        refreshTokenExpiresAt = 0L,
+                        sessionId = SessionId("session-1"),
+                        user =
+                            User(
+                                id = UserId("user-1"),
+                                email = "alice@example.com",
+                                displayName = "Alice",
+                                role = UserRole.MEMBER,
+                                status = UserStatus.ACTIVE,
+                                createdAt = 0L,
+                            ),
+                    )
+                val public = mock<AuthServicePublic>()
+                everySuspend { public.refreshSession(any()) } returns AppResult.Success(session)
+                val authSession = mock<ClientAuthSession>()
+                everySuspend { authSession.currentAuthEpoch() } returns 7L
+                everySuspend { authSession.getRefreshToken() } returns RefreshToken("rt-0")
+                everySuspend { authSession.saveAuthTokens(any(), any(), any(), any(), any()) } returns Unit
+                val repo =
+                    AuthRepositoryImpl(
+                        authPublicChannel = RpcChannel.forTest(public, RpcPolicy.Public),
+                        authedChannel = RpcChannel.forTest(mock<AuthServiceAuthed>()),
+                        authSession = authSession,
+                    )
+
+                repo.refreshAccessToken().shouldBeInstanceOf<AppResult.Success<*>>()
+
+                // Persisted inside refreshAccessToken with the epoch captured at its start (C1/C8).
+                verifySuspend {
+                    authSession.saveAuthTokens(
+                        access = AccessToken("fresh-access"),
+                        refresh = RefreshToken("fresh-refresh"),
+                        sessionId = "session-1",
+                        userId = "user-1",
+                        ifEpoch = 7L,
+                    )
+                }
+            }
+        }
+
         test("a leader whose token read throws wakes coalesced followers with a Failure (never hangs)") {
             runTest {
                 // The leader's getRefreshToken() throws a non-cancellation fault AFTER a follower has
@@ -144,6 +198,7 @@ class AuthRepositoryImplTest :
                 // must ALWAYS complete its deferred.
                 val readGate = CompletableDeferred<Unit>()
                 val authSession = mock<ClientAuthSession>()
+                everySuspend { authSession.currentAuthEpoch() } returns 0L
                 everySuspend { authSession.getRefreshToken() } calls {
                     readGate.await()
                     throw RuntimeException("secure storage read failed")
@@ -176,6 +231,7 @@ class AuthRepositoryImplTest :
                 everySuspend { public.refreshSession(any()) } throws
                     WebSocketException("Handshake exception, expected status code 101 but was 401")
                 val authSession = mock<ClientAuthSession>()
+                everySuspend { authSession.currentAuthEpoch() } returns 0L
                 everySuspend { authSession.getRefreshToken() } returns RefreshToken("rt-0")
                 val repo =
                     AuthRepositoryImpl(
@@ -197,6 +253,7 @@ class AuthRepositoryImplTest :
                 everySuspend { public.refreshSession(any()) } throws
                     kotlinx.io.IOException("connection refused")
                 val authSession = mock<ClientAuthSession>()
+                everySuspend { authSession.currentAuthEpoch() } returns 0L
                 everySuspend { authSession.getRefreshToken() } returns RefreshToken("rt-0")
                 val repo =
                     AuthRepositoryImpl(

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
@@ -45,6 +45,30 @@ private fun createTestServerInfo(
 
 private fun createMockStorage(): SecureStorage = mock<SecureStorage>()
 
+/** In-memory [SecureStorage] that records the order of writes — for the C8 epoch + C9 order tests. */
+private class RecordingStorage : SecureStorage {
+    val data = mutableMapOf<String, String>()
+    val saveOrder = mutableListOf<String>()
+
+    override suspend fun save(
+        key: String,
+        value: String,
+    ) {
+        saveOrder += key
+        data[key] = value
+    }
+
+    override suspend fun read(key: String): String? = data[key]
+
+    override suspend fun delete(key: String) {
+        data.remove(key)
+    }
+
+    override suspend fun clear() {
+        data.clear()
+    }
+}
+
 private fun createMockServerConfig(): ServerConfig = mock<ServerConfig>()
 
 private fun createMockInstanceRepository(): InstanceRepository = mock<InstanceRepository>()
@@ -101,6 +125,55 @@ class AuthSessionStoreTest :
                 val state = store.authState.value.shouldBeInstanceOf<AuthState.Authenticated>()
                 state.userId.value shouldBe "user001"
                 state.sessionId.value shouldBe "session789"
+            }
+        }
+
+        test("saveAuthTokens writes refresh/session/user BEFORE access so no reader pairs new access with stale refresh (C9)") {
+            runTest {
+                val storage = RecordingStorage()
+                val store = createStore(storage = storage)
+
+                store.saveAuthTokens(AccessToken("a"), RefreshToken("r"), "s", "u")
+
+                val accessIdx = storage.saveOrder.indexOf("access_token")
+                accessIdx shouldBe storage.saveOrder.size - 1 // access lands last
+                (storage.saveOrder.indexOf("refresh_token") < accessIdx) shouldBe true
+                (storage.saveOrder.indexOf("session_id") < accessIdx) shouldBe true
+                (storage.saveOrder.indexOf("user_id") < accessIdx) shouldBe true
+            }
+        }
+
+        test("a stale-epoch saveAuthTokens no-ops after a logout bumped the epoch — no resurrection (C8)") {
+            runTest {
+                val storage = RecordingStorage()
+                val store = createStore(storage = storage)
+                store.saveAuthTokens(AccessToken("a0"), RefreshToken("r0"), "s0", "u0")
+                val epoch = store.currentAuthEpoch()
+
+                // Logout wipes credentials and advances the epoch.
+                store.clearAuthTokens()
+                storage.data["access_token"] shouldBe null
+
+                // A late refresh captured the OLD epoch and tries to persist — must be ignored.
+                store.saveAuthTokens(AccessToken("a1"), RefreshToken("r1"), "s1", "u1", ifEpoch = epoch)
+
+                storage.data["access_token"] shouldBe null
+                storage.data["refresh_token"] shouldBe null
+                store.authState.value.shouldBeInstanceOf<AuthState.NeedsLogin>()
+            }
+        }
+
+        test("a current-epoch saveAuthTokens applies (the normal single-flight refresh path, C1/C8)") {
+            runTest {
+                val storage = RecordingStorage()
+                val store = createStore(storage = storage)
+                store.saveAuthTokens(AccessToken("a0"), RefreshToken("r0"), "s0", "u0")
+                val epoch = store.currentAuthEpoch()
+
+                store.saveAuthTokens(AccessToken("a1"), RefreshToken("r1"), "s1", "u1", ifEpoch = epoch)
+
+                storage.data["access_token"] shouldBe "a1"
+                storage.data["refresh_token"] shouldBe "r1"
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProviderTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProviderTest.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -51,7 +53,7 @@ import kotlin.time.Instant
 class CachedAudioTokenProviderTest :
     FunSpec({
 
-        test("init refresh success caches the token and persists it") {
+        test("init refresh success caches the token (persistence is the repository's job now)") {
             runTest {
                 val clock = VirtualClock(testScheduler)
                 val repo =
@@ -65,7 +67,9 @@ class CachedAudioTokenProviderTest :
 
                 provider.getToken() shouldBe "t1"
                 repo.calls shouldBe 1
-                storage.saved shouldBe listOf(AccessToken("t1"))
+                // Persistence now happens inside AuthRepository.refreshAccessToken's single-flight (C1),
+                // not in the provider — so the provider no longer writes tokens to storage itself.
+                storage.saved shouldBe emptyList()
             }
         }
 
@@ -243,7 +247,55 @@ class CachedAudioTokenProviderTest :
                 provider.getToken() shouldBe "t2"
             }
         }
+
+        test("init does NOT refresh when a stored JWT is comfortably fresh (C11)") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val repo =
+                    FakeAudioAuthRepository {
+                        AppResult.Success(contractSession("refreshed", clock.now().toEpochMilliseconds() + 60.minutes.inWholeMilliseconds))
+                    }
+                // exp an hour out — well beyond the 10-minute proactive horizon.
+                val storedJwt = jwtWithExp((clock.now().toEpochMilliseconds() + 60.minutes.inWholeMilliseconds) / 1000)
+                val storage = FakeStorageAuthSession(stored = AccessToken(storedJwt))
+                val provider = CachedAudioTokenProvider(storage, repo, backgroundScope, clock)
+
+                testScheduler.runCurrent()
+
+                // No construction-time rotation; the fresh stored token is served as-is.
+                repo.calls shouldBe 0
+                provider.getToken() shouldBe storedJwt
+            }
+        }
+
+        test("init DOES refresh when the stored JWT is inside the refresh horizon (C11)") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val repo =
+                    FakeAudioAuthRepository {
+                        AppResult.Success(contractSession("t1", clock.now().toEpochMilliseconds() + 60.minutes.inWholeMilliseconds))
+                    }
+                // exp only a minute out — inside the horizon, so a refresh is warranted.
+                val storedJwt = jwtWithExp((clock.now().toEpochMilliseconds() + 60.seconds.inWholeMilliseconds) / 1000)
+                val storage = FakeStorageAuthSession(stored = AccessToken(storedJwt))
+                val provider = CachedAudioTokenProvider(storage, repo, backgroundScope, clock)
+
+                testScheduler.runCurrent()
+
+                repo.calls shouldBe 1
+                provider.getToken() shouldBe "t1"
+            }
+        }
     })
+
+/** Builds an (unsigned) JWT whose payload carries the given `exp` (epoch seconds). */
+@OptIn(ExperimentalEncodingApi::class)
+private fun jwtWithExp(expSeconds: Long): String {
+    val enc = Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT)
+    val header = enc.encode("""{"alg":"HS256","typ":"JWT"}""".encodeToByteArray())
+    val payload = enc.encode("""{"exp":$expSeconds,"sub":"user-1"}""".encodeToByteArray())
+    return "$header.$payload.sig"
+}
 
 /** Bridges [kotlin.time.Clock] to the test scheduler's virtual time. */
 private class VirtualClock(
@@ -263,11 +315,14 @@ private class FakeStorageAuthSession(
 
     override val authState: StateFlow<AuthState> get() = throw NotImplementedError()
 
+    override suspend fun currentAuthEpoch(): Long = 0L
+
     override suspend fun saveAuthTokens(
         access: AccessToken,
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) {
         saved.add(access)
         stored = access

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeAuthSession.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeAuthSession.kt
@@ -37,11 +37,14 @@ class FakeAuthSession(
 
     private val getUserIdResult: String? = userId
 
+    override suspend fun currentAuthEpoch(): Long = 0L
+
     override suspend fun saveAuthTokens(
         access: AccessToken,
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) = Unit
 
     override suspend fun getAccessToken(): AccessToken? = null

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoThrowsInDataLayerRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoThrowsInDataLayerRule.kt
@@ -119,6 +119,12 @@ private fun com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration.contai
             // in this internal marker so streaming/resubscribe can tell a consumer-side abort apart
             // from an upstream transport fault. It never escapes the file — both catch clauses unwrap
             // it and re-raise its cause. A control-flow signal, not a swallowed failure.
-            !line.contains("throw DownstreamEmitException(")
+            !line.contains("throw DownstreamEmitException(") &&
+            // transient-auth-refresh signal (C5): RpcProxyCache throws this when a 401-heal refresh
+            // fails TRANSIENTLY (network/timeout/5xx), so the boundary folds it to a RETRYABLE
+            // TransportError and KEEPS the session instead of misreading a network blip as logout.
+            // Same category as RpcOutcomeUnknownException — a typed transport signal, not a swallowed
+            // failure.
+            !line.contains("throw TransientAuthRefreshException(")
     }
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImplTest.kt
@@ -470,11 +470,14 @@ private fun seedBook(id: String): BookEntity =
 private class FakeAuthSession(
     override val authState: StateFlow<AuthState>,
 ) : AuthSession {
+    override suspend fun currentAuthEpoch(): Long = 0L
+
     override suspend fun saveAuthTokens(
         access: AccessToken,
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) = Unit
 
     override suspend fun getAccessToken(): AccessToken? = null

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPositionEndToEndTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPositionEndToEndTest.kt
@@ -145,11 +145,14 @@ private class StubAuthSession(
 
     override suspend fun getUserId(): String = userId
 
+    override suspend fun currentAuthEpoch(): Long = 0L
+
     override suspend fun saveAuthTokens(
         access: AccessToken,
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) = Unit
 
     override suspend fun getAccessToken(): AccessToken? = null

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/core/JvmSecureStorageTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/core/JvmSecureStorageTest.kt
@@ -3,6 +3,9 @@ package com.calypsan.listenup.core
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import java.io.File
 
@@ -199,6 +202,22 @@ class JvmSecureStorageTest :
 
                 newStorage.read("key") shouldBe "value"
                 newFile.exists() shouldBe true
+            }
+        }
+
+        test("concurrent saves of distinct keys never lose an update (RMW is serialized)") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
+                val keys = (0 until 64).map { "key-$it" }
+
+                // Fan out real-thread writers at the same target file. An unsynchronized
+                // load-modify-save loses updates when two writers read the same snapshot; a
+                // Mutex-serialized RMW + atomic rename keeps every key.
+                coroutineScope {
+                    keys.forEach { k -> launch(Dispatchers.Default) { storage.save(k, "v-$k") } }
+                }
+
+                keys.forEach { k -> storage.read(k) shouldBe "v-$k" }
             }
         }
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidAudioTokenProviderTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidAudioTokenProviderTest.kt
@@ -119,11 +119,14 @@ private class FakeAuthSession : AuthSession {
 
     override suspend fun getUserId(): String? = "u1"
 
+    override suspend fun currentAuthEpoch(): Long = 0L
+
     override suspend fun saveAuthTokens(
         access: AccessToken,
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) = Unit
 
     override suspend fun updateAccessToken(token: AccessToken) = Unit

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AudioTokenAuthenticatorTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AudioTokenAuthenticatorTest.kt
@@ -116,11 +116,14 @@ private class StubAudioAuthSession : AuthSession {
 
     override suspend fun getUserId(): String? = null
 
+    override suspend fun currentAuthEpoch(): Long = 0L
+
     override suspend fun saveAuthTokens(
         access: AccessToken,
         refresh: RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) = Unit
 
     override suspend fun updateAccessToken(token: AccessToken) = Unit

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
@@ -1102,11 +1102,14 @@ private class StubAuthSession : com.calypsan.listenup.client.domain.repository.A
 
     override suspend fun getUserId(): String? = "u1"
 
+    override suspend fun currentAuthEpoch(): Long = 0L
+
     override suspend fun saveAuthTokens(
         access: com.calypsan.listenup.api.dto.auth.AccessToken,
         refresh: com.calypsan.listenup.api.dto.auth.RefreshToken,
         sessionId: String,
         userId: String,
+        ifEpoch: Long?,
     ) = Unit
 
     override suspend fun updateAccessToken(token: com.calypsan.listenup.api.dto.auth.AccessToken) = Unit


### PR DESCRIPTION
Fixes the confirmed findings from Fable's **auth/session-lifecycle** and **security** audits. The north star: **a network blip must never log the user out.** Spurious logouts are the deepest glass-breaking failure — the user self-hosts precisely so their session is *theirs*. Strict TDD throughout; every fix has a red→green regression test.

## The spurious-logout cluster (C1/C4/C5/C8/C9 — one coherent design)
These five interlock into a single guarantee that a transient failure can never destroy a session:
- **C1** — token persistence moved *inside* `refreshAccessToken()`'s single-flight, before leadership is released, so no later caller can present a stale refresh token after rotation (it previously persisted outside the lock → a late 401 replayed the old token → server family-revoke → forced logout). Removed the now-redundant persists from the bearer bridge, `CachedAudioTokenProvider`, and `RpcAuthRecovery`.
- **C9** — `AuthSessionStore.saveAuthTokens` now writes refresh→session→user→**access last** (access is the readiness signal) under a new `credentialMutex`, so a concurrent reader can never pair a *new* access token with a *stale* refresh token.
- **C8** — a monotonic `authEpoch` captured at refresh start, passed as `ifEpoch`; `saveAuthTokens` no-ops if a logout bumped the epoch mid-refresh; logout bumps it. The mutex makes check-and-write atomic against the bump — an in-flight refresh can no longer resurrect a logged-out session.
- **C5** — `RpcAuthRecovery.refreshAndRebuild()` returns `AuthRecoveryOutcome { Refreshed | Transient | SessionInvalid }`. The 401-heal (unary + streaming) retries on `Refreshed`, keeps the session and surfaces a **retryable** `TransportError.NetworkUnavailable` on `Transient` (network/timeout/5xx), and logs out (`SessionExpired`) **only** on a server-confirmed invalid refresh.
- **C4** (server) — `SessionService.rotate` grows a 60s lost-response **reuse-grace** window: a `previous_hash` match on a still-live session within the window rotates again instead of family-revoking (a dropped refresh *response* no longer bricks the session); genuine reuse past the window still hard-revokes. Config-driven (`auth.refreshReuseGraceSeconds`, default 60).

## Other auth/security findings
- **C11** — `CachedAudioTokenProvider` no longer rotates on every construction; refreshes only when the stored expiry is inside the horizon.
- **C6** — `setupRoot` re-checks emptiness *inside* the insert transaction (closing the Argon2-widened dual-ROOT TOCTOU) while keeping the cheap pre-check.
- **C7** — desktop `JvmSecureStorage` gets a `Mutex` around load-modify-save + atomic temp-file rename; `CachingSecureStorage` writes delegate+cache under one lock (test: 64 concurrent distinct-key writers lose nothing).
- **C12** — login runs a throwaway hash on the unknown/deleted-account path to close the timing oracle.
- **Cross-user authz** — `ListeningEvents` `updateSyncColumns` scoped by `user_id` (a client-supplied event id can no longer touch another user's row).
- **ImportId traversal** — new `isSafeImportId` (mirrors `isSafeBackupId`) guards every id-taking import method.
- **Admin demotion** — `AdminUserServiceImpl` revokes all sessions on ADMIN→MEMBER demotion (was ≤15m of residual access).

## Deferred to a focused follow-up (flagged, not forgotten)
- **C2 (live WS/SSE liveness gate)** and **C3 (RPC-mount auth rate-limit + Argon2 semaphore)** — both HIGH, but each needs cross-cutting plumbing (per-message socket liveness / revocation broadcast; threading the client remote-host into `AuthServiceImpl` + making `PasswordHasher` injectable for a non-flaky test). Deliberately kept out of this PR rather than ship a half-measure or an untested change into the most delicate path. Tracked for a dedicated PR.

## Verification (all green locally)
- Client: `:contract:jvmTest` + `:sharedLogic:jvmTest` + `:sharedLogic:testAndroidHostTest` (incl. the `NoThrowsInDataLayerRule` edit + Koin-graph E2E guard)
- Server: auth/session/authz/import/listening-event suites + all `konsist` rules
- `spotlessCheck detekt`; `:sharedLogic:compileKotlinIosSimulatorArm64`

## Notes for review
- **`NoThrowsInDataLayerRule`**: `TransientAuthRefreshException` added to the documented sanctioned-signal exclusions (same category as `RpcOutcomeUnknownException` — an internal transport signal folded immediately to a typed `AppResult.Failure`). Not a weakening.
- **Export surface**: `AuthSession` (already exported) gained `currentAuthEpoch()` + an `ifEpoch` param — members on an existing type, **no new type name and no new sealed `AppError` variant**, so the name-based Swift-export baseline should be unaffected (the ObjC `compileKotlinIosSimulatorArm64` compile passes). The macOS `Test (iOS)` job's export-surface gate is the authority — flagging in case a baseline regen is needed.