### PR TITLE
🔒 fix(server): gate ProfileService password-change Argon2 through the shared limiter

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ProfileServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ProfileServiceImpl.kt
@@ -7,7 +7,7 @@ import com.calypsan.listenup.api.dto.profile.UpdateProfileRequest
 import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.ProfileError
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.server.auth.PasswordHasher
+import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.Users
@@ -35,7 +35,7 @@ private const val AVATAR_TYPE_AUTO = "auto"
  */
 internal class ProfileServiceImpl(
     private val sql: ListenUpDatabase,
-    private val passwordHasher: PasswordHasher,
+    private val argon2Limiter: Argon2Limiter,
     private val publicProfileMaintainer: PublicProfileMaintainer,
     private val imageStore: ImageStore,
     private val clock: Clock = Clock.System,
@@ -58,7 +58,7 @@ internal class ProfileServiceImpl(
             principal.current()?.userId?.value
                 ?: return AppResult.Failure(AuthError.PermissionDenied())
         // Hash outside the transaction — Argon2 is CPU-bound and must not hold a DB connection.
-        val newHash = request.password?.let { passwordHasher.hash(it.newPassword) }
+        val newHash = request.password?.let { argon2Limiter.hash(it.newPassword) }
         // Read the current row first. The password verify and the write are split across two
         // steps because the SQLDelight transaction body is non-suspend and cannot call the
         // suspend Argon2 verify — matching the established cutover shape.
@@ -68,7 +68,7 @@ internal class ProfileServiceImpl(
 
         // Verify the current password (suspend Argon2) outside any transaction.
         request.password?.let { pc ->
-            if (!passwordHasher.verify(pc.currentPassword, current.password_hash)) {
+            if (!argon2Limiter.verify(pc.currentPassword, current.password_hash)) {
                 return AppResult.Failure(ProfileError.WrongPassword())
             }
         }
@@ -118,7 +118,7 @@ internal class ProfileServiceImpl(
     fun copyWith(principal: PrincipalProvider): ProfileServiceImpl =
         ProfileServiceImpl(
             sql = sql,
-            passwordHasher = passwordHasher,
+            argon2Limiter = argon2Limiter,
             publicProfileMaintainer = publicProfileMaintainer,
             imageStore = imageStore,
             clock = clock,
@@ -145,13 +145,13 @@ internal class ProfileServiceImpl(
  */
 fun createProfileService(
     sql: ListenUpDatabase,
-    passwordHasher: PasswordHasher,
+    argon2Limiter: Argon2Limiter,
     publicProfileMaintainer: PublicProfileMaintainer,
     imageStore: ImageStore,
 ): ProfileService =
     ProfileServiceImpl(
         sql = sql,
-        passwordHasher = passwordHasher,
+        argon2Limiter = argon2Limiter,
         publicProfileMaintainer = publicProfileMaintainer,
         imageStore = imageStore,
     )

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ProfileModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ProfileModule.kt
@@ -16,7 +16,7 @@ fun profileModule(avatarsDir: Path): Module =
         single<ProfileService> {
             ProfileServiceImpl(
                 sql = get<ListenUpDatabase>(),
-                passwordHasher = get(),
+                argon2Limiter = get(),
                 publicProfileMaintainer = get(),
                 imageStore = get(),
                 clock = get(),

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ProfileServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ProfileServiceImplTest.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.api.dto.profile.Profile
 import com.calypsan.listenup.api.dto.profile.UpdateProfileRequest
 import com.calypsan.listenup.api.error.ProfileError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PasswordHasher
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserPrincipal
@@ -29,7 +30,7 @@ class ProfileServiceImplTest :
         fun SqlTestDatabases.svc(userId: String): ProfileServiceImpl =
             ProfileServiceImpl(
                 sql = sql,
-                passwordHasher = PasswordHasher(),
+                argon2Limiter = Argon2Limiter(PasswordHasher()),
                 publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                 imageStore = tempAvatarImageStore(),
             ).copyWith(
@@ -53,7 +54,7 @@ class ProfileServiceImplTest :
                     val svc =
                         ProfileServiceImpl(
                             sql = sql,
-                            passwordHasher = PasswordHasher(),
+                            argon2Limiter = Argon2Limiter(PasswordHasher()),
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = tempAvatarImageStore(),
                             clock = FixedClock(Instant.fromEpochMilliseconds(fixed)),
@@ -94,7 +95,7 @@ class ProfileServiceImplTest :
                     val svc =
                         ProfileServiceImpl(
                             sql = sql,
-                            passwordHasher = hasher,
+                            argon2Limiter = Argon2Limiter(hasher),
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = tempAvatarImageStore(),
                         ).copyWith(
@@ -124,7 +125,7 @@ class ProfileServiceImplTest :
                     val svc =
                         ProfileServiceImpl(
                             sql = sql,
-                            passwordHasher = hasher,
+                            argon2Limiter = Argon2Limiter(hasher),
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = tempAvatarImageStore(),
                         ).copyWith(
@@ -140,6 +141,53 @@ class ProfileServiceImplTest :
                         )
                     val failure = r.shouldBeInstanceOf<AppResult.Failure>()
                     failure.error.shouldBeInstanceOf<ProfileError.WrongPassword>()
+                }
+            }
+        }
+
+        test("a password change routes hash + verify through the Argon2Limiter (bounded, not the raw hasher)") {
+            withSqlDatabase {
+                val hasher = PasswordHasher()
+                var hashCalls = 0
+                var verifyCalls = 0
+                // A limiter wrapping counting stand-ins over the real hasher — proves ProfileServiceImpl's
+                // Argon2 goes through the shared gate (C3 DoS ceiling) instead of a raw PasswordHasher.
+                val counting =
+                    Argon2Limiter(
+                        permits = 1,
+                        hashFn = { plaintext ->
+                            hashCalls++
+                            hasher.hash(plaintext)
+                        },
+                        verifyFn = { plaintext, encoded ->
+                            verifyCalls++
+                            hasher.verify(plaintext, encoded)
+                        },
+                    )
+                runTest {
+                    val hash = hasher.hash("correct-pass")
+                    sql.seedTestUser("u1")
+                    sql.usersQueries.updatePasswordHash(password_hash = hash, id = "u1")
+                    val svc =
+                        ProfileServiceImpl(
+                            sql = sql,
+                            argon2Limiter = counting,
+                            publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
+                            imageStore = tempAvatarImageStore(),
+                        ).copyWith(
+                            PrincipalProvider {
+                                UserPrincipal(UserId("u1"), SessionId("s"), UserRole.MEMBER)
+                            },
+                        )
+                    svc
+                        .updateMyProfile(
+                            UpdateProfileRequest(
+                                password = PasswordChange("correct-pass", "brand-new-pass"),
+                            ),
+                        ).shouldBeInstanceOf<AppResult.Success<Profile>>()
+                    // Both the current-password verify and the new-password hash went through the gate.
+                    verifyCalls shouldBe 1
+                    hashCalls shouldBe 1
                 }
             }
         }
@@ -164,7 +212,7 @@ class ProfileServiceImplTest :
                     val svc =
                         ProfileServiceImpl(
                             sql = sql,
-                            passwordHasher = PasswordHasher(),
+                            argon2Limiter = Argon2Limiter(PasswordHasher()),
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = imageStore,
                             clock = FixedClock(Instant.fromEpochMilliseconds(t2)),

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PublicProfileLifecycleTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PublicProfileLifecycleTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.dto.profile.UpdateProfileRequest
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PasswordHasher
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.RegistrationBroadcaster
@@ -125,7 +126,7 @@ class PublicProfileLifecycleTest :
                     val svc =
                         ProfileServiceImpl(
                             sql = sql,
-                            passwordHasher = PasswordHasher(),
+                            argon2Limiter = Argon2Limiter(PasswordHasher()),
                             publicProfileMaintainer = maintainer,
                             imageStore = tempAvatarImageStore(),
                         ).copyWith(principalFor("u1"))

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/di/ProfileModuleVerifyTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/di/ProfileModuleVerifyTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server.di
 
 import com.calypsan.listenup.api.ProfileService
+import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PasswordHasher
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.media.ImageStore
@@ -25,7 +26,7 @@ class ProfileModuleVerifyTest :
                             modules(
                                 module {
                                     single<ListenUpDatabase> { sql }
-                                    single { PasswordHasher() }
+                                    single { Argon2Limiter(PasswordHasher()) }
                                     single { sql.noOpPublicProfileMaintainer() }
                                     single<Clock> { Clock.System }
                                 },

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/profile/ProfileE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/profile/ProfileE2ETest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.sync.testing.testAuth
 import com.calypsan.listenup.server.api.createProfileService
 import com.calypsan.listenup.server.api.profileServiceScopedTo
+import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PasswordHasher
 import com.calypsan.listenup.server.services.PublicProfileMaintainer
 import com.calypsan.listenup.server.sync.ChangeBus
@@ -110,7 +111,7 @@ class ProfileE2ETest :
             val profileService =
                 createProfileService(
                     sql = serverSqlDb,
-                    passwordHasher = PasswordHasher(),
+                    argon2Limiter = Argon2Limiter(PasswordHasher()),
                     publicProfileMaintainer =
                         PublicProfileMaintainer(
                             serverSqlDb,
@@ -167,7 +168,7 @@ class ProfileE2ETest :
             val profileService =
                 createProfileService(
                     sql = serverSqlDb,
-                    passwordHasher = hasher,
+                    argon2Limiter = Argon2Limiter(hasher),
                     publicProfileMaintainer =
                         PublicProfileMaintainer(
                             serverSqlDb,


### PR DESCRIPTION
Follow-up to #1107 (C3). The Argon2 bounded-parallelism semaphore (`Argon2Limiter`) now covers **every** auth-path hash — except `ProfileServiceImpl`'s password-change, which #1107 left on the raw `PasswordHasher` (it's an *authenticated* path, not an unauthenticated brute-force vector, so it was scoped out). Folding it in closes the last gap so no password hashing anywhere bypasses the CPU-DoS ceiling.

`ProfileServiceImpl` now depends on `Argon2Limiter` (identical `hash`/`verify` API) instead of `PasswordHasher` — same shape as `AuthServiceImpl`/`InviteServiceImpl` after #1107, so there's one canonical way password hashing is gated.

## Test
New regression test — `a password change routes hash + verify through the Argon2Limiter` — injects a counting limiter and asserts the current-password verify **and** the new-password hash both go through the gate (fails if the service ever reverts to a raw hasher). Existing password-change tests + `ProfileModuleVerifyTest` updated to the new dependency.

## Verification (green)
`:server:jvmTest` (ProfileServiceImpl / PublicProfileLifecycle / Argon2Limiter / ProfileModuleVerify) · `:sharedLogic:jvmTest` (ProfileE2ETest) · `spotlessCheck detekt`. No `:contract`/export change.