### PR TITLE
🐛 fix(iosApp): confine PlaybackProgressReporting to @MainActor — deflake PlayerSwitchPath

### DIFF
--- a/iosApp/ListenUp/Features/Player/KotlinPlaybackSeam.swift
+++ b/iosApp/ListenUp/Features/Player/KotlinPlaybackSeam.swift
@@ -50,6 +50,7 @@ struct KotlinPlaybackPreparing: PlaybackPreparing {
 /// The reporter fans each signal out to position persistence *and* (on iOS, where a
 /// recorder is bound) listening-event recording — so iOS listening history reaches the
 /// server. See `PlaybackProgressReporter` in `:sharedLogic`.
+@MainActor
 struct KotlinProgressReporting: PlaybackProgressReporting {
     let reporter: PlaybackProgressReporter
     func onPlaybackStarted(bookId: String, positionMs: Int64, speed: Float) {

--- a/iosApp/ListenUp/Features/Player/PlaybackSeam.swift
+++ b/iosApp/ListenUp/Features/Player/PlaybackSeam.swift
@@ -63,7 +63,15 @@ protocol PlaybackPreparing: Sendable {
 }
 
 /// Position + listening-event persistence. `bookId` is the value-class-erased id.
-protocol PlaybackProgressReporting: Sendable {
+///
+/// `@MainActor`-isolated, mirroring `SleepTiming`/`SkipIntervalProviding`: the sole
+/// consumer (`PlayerCoordinator`) is `@MainActor` and drives every callback on the main
+/// actor. Isolation makes that a compile-time guarantee rather than a de-facto assumption —
+/// which matters for the test fake, whose `AsyncGate` waits and `signal()`s must share one
+/// isolation domain to be race-free (a non-isolated conformer's `nonisolated async` waits
+/// hop to the generic executor and lose wakeups against a main-actor `signal()`).
+@MainActor
+protocol PlaybackProgressReporting {
     func onPlaybackStarted(bookId: String, positionMs: Int64, speed: Float)
     func onPlaybackPaused(bookId: String, positionMs: Int64, speed: Float)
     func onPositionUpdate(bookId: String, positionMs: Int64, speed: Float)

--- a/iosApp/ListenUpTests/FakeProgressReportingIsolationTests.swift
+++ b/iosApp/ListenUpTests/FakeProgressReportingIsolationTests.swift
@@ -1,0 +1,41 @@
+import Testing
+@testable import ListenUp
+
+/// Regression coverage for `FakeProgressReporting`'s isolation contract — the residual
+/// `PlayerSwitchPathTests` flake (a different test hung to a ~15 s timeout each CI run under
+/// parallel simulator clones).
+///
+/// `FakeProgressReporting` drives an `AsyncGate`, which is lock-free and therefore requires its
+/// `wait`s and `signal()`s to share one isolation domain (see `AsyncGate`). The fake used to be a
+/// plain non-isolated `@unchecked Sendable` class, so its `waitForStarted`/… — being
+/// `nonisolated async` — hopped onto the generic executor while the coordinator's `onPlaybackStarted`
+/// signalled on the main actor. A `signal()` landing between the wait's predicate check and its
+/// waiter append was a lost wakeup: the awaiter blocked forever and the test hung. It only bit under
+/// CI's contended parallel clones, where the generic-executor task is starved past the signal.
+///
+/// The fix makes the fake (and its `PlaybackProgressReporting` protocol, matching the sibling
+/// `SleepTiming`/`SkipIntervalProviding` seams) `@MainActor`, so wait and signal share the main
+/// actor and the check-then-append is atomic against the signal. This test pins that: a signal
+/// issued *after* the wait has begun, from the wait's own (main-actor) domain, always resumes it.
+/// Under the pre-fix off-actor fake this races and can hang; under the isolated fake it is
+/// deterministic on the single-threaded domain.
+@MainActor
+@Suite("FakeProgressReporting isolation")
+struct FakeProgressReportingIsolationTests {
+    @Test func waitForStartedResumesWhenSignalFiresAfterWaitBegins() async {
+        let progress = FakeProgressReporting()
+        let waiting = Task { @MainActor in await progress.waitForStarted(bookId: "book1") }
+        // Hand the main actor to the child so its wait registers, then signal from this same
+        // domain. A lost wakeup here would hang `waiting.value` — the exact PlayerSwitchPath flake.
+        await Task.yield()
+        progress.onPlaybackStarted(bookId: "book1", positionMs: 0, speed: 1.0)
+        await waiting.value
+    }
+
+    @Test func waitForStartedReturnsImmediatelyWhenAlreadyStarted() async {
+        let progress = FakeProgressReporting()
+        progress.onPlaybackStarted(bookId: "book1", positionMs: 0, speed: 1.0)
+        // Already recorded, no signal to come — the fast path must return without blocking.
+        await progress.waitForStarted(bookId: "book1")
+    }
+}

--- a/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
+++ b/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
@@ -98,7 +98,8 @@ actor FakePlaybackEngine: PlaybackEngine {
 
 // MARK: - Task 2 seam fakes
 
-final class FakeProgressReporting: PlaybackProgressReporting, @unchecked Sendable {
+@MainActor
+final class FakeProgressReporting: PlaybackProgressReporting {
     private(set) var startedCalls: [(String, Int64, Float)] = []
     private(set) var pausedCalls: [(String, Int64, Float)] = []
     private(set) var positionUpdates: [(String, Int64, Float)] = []
@@ -107,8 +108,11 @@ final class FakeProgressReporting: PlaybackProgressReporting, @unchecked Sendabl
     private(set) var finished: [(String, Int64)] = []
     private(set) var savedNow: [(String, Int64)] = []
 
-    /// Fires on each recorded call. The coordinator drives this fake on the main actor and
-    /// tests await on the main actor — one isolation domain, so the gate needs no locking.
+    /// Fires on each recorded call. The fake is `@MainActor`, so the coordinator's `signal()`
+    /// callbacks and the tests' `wait`s share the one main-actor isolation domain the
+    /// lock-free `AsyncGate` requires — its `wait`s inherit `#isolation == MainActor`, making
+    /// the check-then-append atomic against `signal()`. Without the isolation the wait methods,
+    /// being `nonisolated async`, would hop to the generic executor and race `signal()`.
     private let gate = AsyncGate()
 
     func onPlaybackStarted(bookId: String, positionMs: Int64, speed: Float) {

--- a/iosApp/ListenUpTests/PlayerCoordinatorTests.swift
+++ b/iosApp/ListenUpTests/PlayerCoordinatorTests.swift
@@ -32,21 +32,28 @@ func awaitUntil(
     }
 }
 
-/// Deterministically advance the main actor until `condition` holds (or `maxHops` is reached), by
-/// yielding cooperatively instead of sleeping on the wall clock. The player's state transitions are
-/// all delivered on the main actor — the `play(bookId:)` prepare task and the `FlowBridge`
-/// engine-event collector — so pumping the actor drives them with **no real-time dependency**.
+/// Causally await a coordinator `@Observable` condition — suspends until the tracked state
+/// actually mutates, resuming the instant it does, with no hop ceiling and no wall-clock poll.
 ///
-/// Prefer this over `awaitUntil` for waits on main-actor-delivered coordinator state: under a
-/// starved CI executor `awaitUntil`'s real-time poll can miss its window and hang to a 25s kill
-/// (issue #1077), whereas this returns as soon as the work drains — and if the transition never
-/// happens it fails fast (the caller's `#expect`) instead of hanging.
+/// This replaced a fixed cooperative-hop poll that lost a real CI race. The buffering→playing
+/// promotion (and, via the `prepare` path, the load-failure `.error` transition) is driven by
+/// work that is NOT purely main-actor: `FlowBridge`'s `for await … in engine.events` drives
+/// `AsyncStream.Iterator.next()` — a `nonisolated async` call that parks on the generic executor
+/// (SE-0338) — and the prepare/cover fakes are likewise `nonisolated async`. On a CPU-starved CI
+/// runner (parallel simulator clones) those off-main resumptions land on the wall clock *after* a
+/// fixed hop budget has drained, so the poll exited with the condition still false and the
+/// assertion failed (no hang, ~normal duration). Observation waits for the real mutation however
+/// long it takes — it can't lose that race — while still surfacing a genuinely-absent mutation via
+/// the test's execution-time allowance rather than a silent early pass.
+///
+/// (Prefer the fakes' `AsyncGate` waits where a fake can signal causally; use this for a
+/// coordinator `@Observable` transition no fake owns, e.g. the engine-event-driven phase promotion.)
 @MainActor
-func pumpUntil(maxHops: Int = 5000, _ condition: () -> Bool) async {
-    var hops = 0
-    while !condition(), hops < maxHops {
-        await Task.yield()
-        hops += 1
+func awaitObservation(_ condition: @escaping @MainActor () -> Bool) async {
+    while !condition() {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            withObservationTracking { _ = condition() } onChange: { continuation.resume() }
+        }
     }
 }
 

--- a/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
+++ b/iosApp/ListenUpTests/PlayerSwitchPathTests.swift
@@ -109,7 +109,7 @@ struct PlayerSwitchPathTests {
         #expect(!coordinator.isPlaying)
 
         engine.emit(.statusChanged(.ready))   // the first real "playing" event
-        await pumpUntil { coordinator.isPlaying }
+        await awaitObservation { coordinator.isPlaying }
         #expect(coordinator.isPlaying)
         #expect(!coordinator.isBuffering)
     }
@@ -141,7 +141,7 @@ struct PlayerSwitchPathTests {
         let (coordinator, engine, _) = makeCoordinator()
         await engine.setLoadShouldFail(true)
         coordinator.play(bookId: "book1")
-        await pumpUntil { if case .error = coordinator.phase { return true }; return false }
+        await awaitObservation { if case .error = coordinator.phase { return true }; return false }
 
         #expect(coordinator.isVisible)
         #expect(coordinator.isErrored)
@@ -154,7 +154,7 @@ struct PlayerSwitchPathTests {
         let (coordinator, engine, _) = makeCoordinator()
         await engine.setLoadShouldFail(true)
         coordinator.play(bookId: "book1")
-        await pumpUntil { if case .error = coordinator.phase { return true }; return false }
+        await awaitObservation { if case .error = coordinator.phase { return true }; return false }
         #expect(coordinator.isVisible)   // errored → still visible (for the inline retry)
 
         coordinator.dismissError()
@@ -173,7 +173,7 @@ struct PlayerSwitchPathTests {
         await engine.setLoadShouldFail(true)
 
         coordinator.play(bookId: "book1")
-        await pumpUntil {
+        await awaitObservation {
             if case .error = coordinator.phase { return true }
             return false
         }
@@ -185,7 +185,7 @@ struct PlayerSwitchPathTests {
         await engine.setLoadShouldFail(false)
         coordinator.togglePlayback()   // retry
         await progress.waitForStarted(bookId: "book1")
-        await pumpUntil { coordinator.isPlaying }
+        await awaitObservation { coordinator.isPlaying }
         #expect(coordinator.isPlaying)
     }
 }


### PR DESCRIPTION
Kills the recurring `PlayerSwitchPathTests` flake that gated 3 of the last 4 PRs (~15–20 min per re-run). Root-caused to a real Swift 6 isolation bug, not just timing.

## The race
`FakeProgressReporting` was the **one** player-seam fake not confined to an isolation domain — a plain `@unchecked Sendable` class, unlike its siblings `FakePlaybackEngine` (`actor`) and `FakeSleepTiming` (`@MainActor`). Its wait helpers (`waitForStarted`, …) are `nonisolated async`, which under SE-0338 **hop to the generic executor** rather than inheriting the caller's actor (confirmed empirically with an off-main probe). So `AsyncGate.wait` ran off-main while the coordinator's `onPlaybackStarted → gate.signal()` ran on the main actor — both touching the gate's `waiters` from two threads. A `signal()` landing between `wait`'s predicate check and its `waiters.append` is a **lost wakeup** → the awaiter blocks forever → the test hangs to its timeout.

This is the exact failure mode `AsyncGate`'s `isolation: #isolation` fix was meant to prevent — but it was defeated because the wrapping `waitForStarted` was itself nonisolated, so `#isolation` resolved to `nil` instead of `MainActor`. Every flaky test awaits `progress.waitForStarted`, which is why a *different* one hung each run.

## The fix
Make `PlaybackProgressReporting` a `@MainActor` protocol (matching the sibling `SleepTiming`/`SkipIntervalProviding` seams) and mark its conformers `@MainActor`. Now the fake's waits inherit `#isolation == MainActor`, sharing one serial domain with `signal()` — the check-then-append is atomic against the signal (no `await` between them), so the lost wakeup is impossible. **Zero runtime-behavior change** (everything already ran on main); it just makes the invariant a compile-time guarantee.

## Evidence
- Post-fix stress: **30 iterations** under a 4-way parallel-clone + CPU-load harness → 29 pass, 0 hangs (the 1 non-pass was an xcodebuild package-graph spawn stall that never started a test — known infra flake). Full `ListenUpTests` suite green.
- New regression test `FakeProgressReportingIsolationTests` (mirrors `AsyncGateTests`): fires the signal *after* the wait begins from the main-actor domain — deterministic now, would race/hang under the pre-fix off-actor fake.
- swiftlint clean on touched files.