### PR TITLE
✨ feat(server): metadata enrichment SPI vocabulary + routing config (rewrite step 1/7)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/metadata/BookField.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/metadata/BookField.kt
@@ -1,0 +1,47 @@
+package com.calypsan.listenup.api.metadata
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A single enrichable field on a book — the finest granularity the metadata
+ * router addresses.
+ *
+ * Every field belongs to exactly one [MetadataDomain] ([domain]); the domain is
+ * the default routing key, and a field may override its domain's provider order
+ * for surgical control. The flagship case is [AUTHORS] vs [NARRATORS]: both live
+ * in [MetadataDomain.CONTRIBUTORS], yet an operator can source authors from one
+ * catalog and narrators from another because they are distinct fields.
+ *
+ * Rides the wire in step 2 (field-level enrichment selection), hence `:contract`
+ * and `@Serializable`. [token] is the lowercase operator-facing config token used
+ * in `LISTENUP_ENRICHMENT_ROUTES` field clauses (e.g. `description=audible`).
+ */
+@Serializable
+enum class BookField(
+    /** The domain this field defaults its provider order to. */
+    val domain: MetadataDomain,
+) {
+    TITLE(MetadataDomain.BOOK_CORE),
+    SUBTITLE(MetadataDomain.BOOK_CORE),
+    DESCRIPTION(MetadataDomain.BOOK_CORE),
+    PUBLISHER(MetadataDomain.BOOK_CORE),
+    PUBLISH_YEAR(MetadataDomain.BOOK_CORE),
+    LANGUAGE(MetadataDomain.BOOK_CORE),
+    AUTHORS(MetadataDomain.CONTRIBUTORS),
+    NARRATORS(MetadataDomain.CONTRIBUTORS),
+    SERIES(MetadataDomain.SERIES),
+    GENRES(MetadataDomain.GENRES),
+    MOODS(MetadataDomain.GENRES),
+    TAGS(MetadataDomain.GENRES),
+    COVER(MetadataDomain.COVER),
+    CHAPTERS(MetadataDomain.CHAPTERS),
+    ;
+
+    /** Lowercase config token — the field's name lowercased (`publish_year`, `authors`). */
+    val token: String get() = name.lowercase()
+
+    companion object {
+        /** Resolves a config [token] (case-insensitive) to a field, or `null` if unrecognized. */
+        fun fromToken(token: String): BookField? = entries.firstOrNull { it.token.equals(token, ignoreCase = true) }
+    }
+}

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/metadata/MetadataDomain.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/metadata/MetadataDomain.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.api.metadata
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The coarse metadata concern a provider can satisfy — the KEY the enrichment
+ * router prioritizes providers by.
+ *
+ * A domain groups the fine-grained [BookField]s that are always sourced together
+ * (all book-core text fields, both contributor roles, every genre-family field).
+ * The operator configures a provider precedence *per domain*
+ * ([com.calypsan.listenup.server.metadata.spi.EnrichmentRoutes.domainOrder]); a
+ * single [BookField] may then override its domain's order for finer control.
+ *
+ * Lives in `:contract` — not because the enum itself must cross the wire, but so
+ * [BookField.domain] can reference it and a step-2 field-selection UI can group
+ * fields by their domain without duplicating this vocabulary. [token] is the
+ * stable operator-facing config token (`core`, not `book_core`).
+ */
+@Serializable
+enum class MetadataDomain(
+    /** Operator-facing config token used in `LISTENUP_ENRICHMENT_ROUTES` clauses. */
+    val token: String,
+) {
+    BOOK_CORE("core"),
+    CONTRIBUTORS("contributors"),
+    CHAPTERS("chapters"),
+    COVER("cover"),
+    SERIES("series"),
+    GENRES("genres"),
+    CHARACTERS("characters"),
+    ;
+
+    companion object {
+        /** Resolves a config [token] (case-insensitive) to a domain, or `null` if unrecognized. */
+        fun fromToken(token: String): MetadataDomain? =
+            entries.firstOrNull { it.token.equals(token, ignoreCase = true) }
+    }
+}

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/api/metadata/BookFieldTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/api/metadata/BookFieldTest.kt
@@ -1,0 +1,65 @@
+package com.calypsan.listenup.api.metadata
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class BookFieldTest :
+    FunSpec({
+        test("authors and narrators both live in the CONTRIBUTORS domain yet stay distinct fields") {
+            // The flagship field-routing case: an operator can point AUTHORS at one
+            // provider and NARRATORS at another even though both share a domain.
+            BookField.AUTHORS.domain shouldBe MetadataDomain.CONTRIBUTORS
+            BookField.NARRATORS.domain shouldBe MetadataDomain.CONTRIBUTORS
+            BookField.AUTHORS shouldNotBe BookField.NARRATORS
+        }
+
+        test("every book-core text field maps to BOOK_CORE") {
+            listOf(
+                BookField.TITLE,
+                BookField.SUBTITLE,
+                BookField.DESCRIPTION,
+                BookField.PUBLISHER,
+                BookField.PUBLISH_YEAR,
+                BookField.LANGUAGE,
+            ).forEach { it.domain shouldBe MetadataDomain.BOOK_CORE }
+        }
+
+        test("genre-family fields all map to the GENRES domain") {
+            listOf(BookField.GENRES, BookField.MOODS, BookField.TAGS)
+                .forEach { it.domain shouldBe MetadataDomain.GENRES }
+        }
+
+        test("single-field domains map one-to-one") {
+            BookField.SERIES.domain shouldBe MetadataDomain.SERIES
+            BookField.COVER.domain shouldBe MetadataDomain.COVER
+            BookField.CHAPTERS.domain shouldBe MetadataDomain.CHAPTERS
+        }
+
+        test("every field has a lowercase token that round-trips through fromToken") {
+            BookField.entries.forEach { field ->
+                field.token shouldBe field.name.lowercase()
+                BookField.fromToken(field.token) shouldBe field
+                BookField.fromToken(field.token.uppercase()) shouldBe field
+            }
+        }
+
+        test("fromToken returns null for an unknown token") {
+            BookField.fromToken("not_a_field") shouldBe null
+        }
+
+        test("every MetadataDomain except CHARACTERS has at least one field routing into it") {
+            val covered = BookField.entries.map { it.domain }.toSet()
+            MetadataDomain.entries.forEach { domain ->
+                covered.contains(domain) shouldBe (domain != MetadataDomain.CHARACTERS)
+            }
+        }
+
+        test("domain tokens round-trip through fromToken and reject the enum name") {
+            MetadataDomain.entries.forEach { domain ->
+                MetadataDomain.fromToken(domain.token) shouldBe domain
+            }
+            MetadataDomain.fromToken("book_core") shouldBe null
+            MetadataDomain.fromToken("core") shouldBe MetadataDomain.BOOK_CORE
+        }
+    })

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/BookCoreMeta.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/BookCoreMeta.kt
@@ -1,0 +1,56 @@
+package com.calypsan.listenup.server.metadata.spi
+
+import com.calypsan.listenup.api.dto.ContributorRole
+
+/**
+ * The provider-neutral core metadata for one book — every textual book-core field
+ * plus the book's credited contributors.
+ *
+ * Book *credits* (which people authored/narrated *this* book) fold into [authors]
+ * and [narrators] here rather than onto a contributor capability. This keeps the
+ * [ContributorSource] capability honest — it does contributor *profiles* only, so
+ * a catalog like Audible that has book credits but no standalone profile endpoint
+ * isn't forced to stub a half-capability.
+ *
+ * Every field is nullable/empty-able: a provider returns only what its catalog
+ * knows, and the router composes fields across providers.
+ */
+data class BookCoreMeta(
+    /** Canonical title. */
+    val title: String? = null,
+    /** Subtitle, when the catalog distinguishes one. */
+    val subtitle: String? = null,
+    /** Long-form description / synopsis. */
+    val description: String? = null,
+    /** Publishing imprint. */
+    val publisher: String? = null,
+    /** Release date in the catalog's raw form (ISO date or year). */
+    val releaseDate: String? = null,
+    /** BCP-47 / catalog language token. */
+    val language: String? = null,
+    /** Whether the catalog flags explicit content; `null` when unknown. */
+    val explicit: Boolean? = null,
+    /** Whether the edition is abridged; `null` when unknown. */
+    val abridged: Boolean? = null,
+    /** Credited authors on this book, in catalog order. */
+    val authors: List<BookContributorMeta> = emptyList(),
+    /** Credited narrators on this book, in catalog order. */
+    val narrators: List<BookContributorMeta> = emptyList(),
+)
+
+/**
+ * One credited contributor on a book, as a provider reports it.
+ *
+ * [key] is the catalog's stable id for the person when it exposes one (lets a
+ * later step fetch their [ContributorMeta] profile); it is `null` for catalogs
+ * that only give a name string. [role] reuses the shared [ContributorRole]
+ * vocabulary so credits align with the rest of the contract.
+ */
+data class BookContributorMeta(
+    /** Catalog contributor key, when available; `null` for name-only catalogs. */
+    val key: String? = null,
+    /** Display name as credited. */
+    val name: String,
+    /** The role this person played on the book. */
+    val role: ContributorRole,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/BookIdentity.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/BookIdentity.kt
@@ -1,0 +1,26 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * What the enrich phase knows about a book *before* asking a provider to fill it in.
+ *
+ * This is the lookup key handed to every fetch capability. ASIN-keyed catalogs
+ * (Audible, Audnexus) use [asin] directly when present; search-keyed lookups fall
+ * back to [title] + [primaryAuthor]. [durationMs], when known, feeds the phase-1
+ * match scorer so a candidate whose runtime matches the local file out-ranks a
+ * same-title edition of a different length.
+ *
+ * All fields except [title] are nullable — a freshly scanned book may carry only a
+ * folder-derived title.
+ */
+data class BookIdentity(
+    /** Audible/Audnexus catalog key, when the scan or a prior match resolved one. */
+    val asin: String? = null,
+    /** ISBN when known — some search-keyed catalogs accept it. */
+    val isbn: String? = null,
+    /** The book's best-known title; always present (folder-derived at minimum). */
+    val title: String,
+    /** The primary author, used for search-keyed lookups when [asin] is absent. */
+    val primaryAuthor: String? = null,
+    /** Local audio runtime in milliseconds, when measured — feeds the match scorer. */
+    val durationMs: Long? = null,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/BookMatch.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/BookMatch.kt
@@ -1,0 +1,27 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * A single ranked candidate returned by a [BookIdentitySource.searchBooks] query —
+ * the phase-1 "which catalog entry is this local book?" answer.
+ *
+ * [score] is a 0.0..1.0 confidence the candidate matches the queried book. The
+ * scorer itself lands in a later step; the approved weighting is
+ * `0.7·duration + 0.2·title + 0.1·author` — runtime dominates because two
+ * editions of the same title diverge most reliably by length. Step 1 only defines
+ * the shape; providers fill [score] with a provisional value until the shared
+ * scorer exists.
+ */
+data class BookMatch(
+    /** Catalog key (ASIN) when the source is ASIN-keyed; `null` for keyless hits. */
+    val asin: String? = null,
+    /** Candidate title as the catalog lists it. */
+    val title: String,
+    /** Candidate primary author, when the catalog reports one. */
+    val author: String? = null,
+    /** Candidate runtime in milliseconds — the strongest match signal. */
+    val durationMs: Long? = null,
+    /** A cover thumbnail URL for disambiguation UIs, when available. */
+    val coverUrl: String? = null,
+    /** Match confidence in `0.0..1.0`; higher ranks first. */
+    val score: Double,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/ChapterMeta.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/ChapterMeta.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * One chapter marker in a provider-neutral chapter list.
+ *
+ * [startMs] is the offset from the start of the book; [lengthMs] is the chapter's
+ * duration when the catalog provides it (`null` when only start markers are known,
+ * e.g. the next chapter's start implies this one's end). [title] is `null` for
+ * unnamed markers.
+ */
+data class ChapterMeta(
+    /** Chapter title, or `null` for an unnamed marker. */
+    val title: String? = null,
+    /** Offset from the start of the book, in milliseconds. */
+    val startMs: Long,
+    /** Chapter duration in milliseconds, when known. */
+    val lengthMs: Long? = null,
+)
+
+/**
+ * A provider-neutral chapter list for one book.
+ *
+ * [accurate] flags whether the markers are catalog-verified (true) or heuristic
+ * (false) — the router prefers an accurate list. [brandIntroMs] / [brandOutroMs]
+ * carry the publisher intro/outro padding a catalog reports so a later step can
+ * offset markers against the local file's own intro/outro.
+ */
+data class ChapterListMeta(
+    /** The chapter markers, in playback order. */
+    val chapters: List<ChapterMeta>,
+    /** Whether these markers are catalog-verified rather than heuristic. */
+    val accurate: Boolean,
+    /** Publisher intro padding in milliseconds, when reported. */
+    val brandIntroMs: Long? = null,
+    /** Publisher outro padding in milliseconds, when reported. */
+    val brandOutroMs: Long? = null,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/CharacterMeta.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/CharacterMeta.kt
@@ -1,0 +1,17 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * A character appearing in a book, as a provider reports it.
+ *
+ * The honest empty slot: no public metadata source exposes per-book character
+ * lists today, so [CharacterSource] has no real implementation and this type has
+ * no populated call site yet. It is defined so the capability vocabulary is
+ * complete and a future community/manual source can slot in without a schema
+ * change. [description] is a short blurb when a source ever provides one.
+ */
+data class CharacterMeta(
+    /** Character name. */
+    val name: String,
+    /** Short description, when a source provides one. */
+    val description: String? = null,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/ContributorMeta.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/ContributorMeta.kt
@@ -1,0 +1,33 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * A lightweight hit from a contributor-profile search — enough to disambiguate
+ * and then fetch the full [ContributorMeta].
+ *
+ * [key] is the catalog's stable contributor id (the fetch key). Deliberately lean:
+ * profile search only needs a name to show and a key to follow.
+ */
+data class ContributorHitMeta(
+    /** Catalog contributor key — pass to [ContributorSource.getContributor]. */
+    val key: String,
+    /** Display name of the hit. */
+    val name: String,
+)
+
+/**
+ * A provider-neutral contributor *profile*.
+ *
+ * Kept lean on purpose: the only public source (Audnexus) exposes name, biography,
+ * and a photo — no aliases, birthdate, or discography. Modelling only what a source
+ * can actually deliver keeps this from becoming a mostly-null wish-list.
+ */
+data class ContributorMeta(
+    /** Catalog contributor key. */
+    val key: String,
+    /** Display name. */
+    val name: String,
+    /** Biography / description, when the catalog has one. */
+    val description: String? = null,
+    /** Profile image URL, when the catalog has one. */
+    val imageUrl: String? = null,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/CoverMeta.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/CoverMeta.kt
@@ -1,0 +1,18 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * One cover-art candidate from a [CoverSource] search.
+ *
+ * [url] is the directly usable image; [maxSizeUrl] points at the largest available
+ * rendition when the catalog exposes a distinct high-res URL (often the same host
+ * with a size token swapped). [sourceKey] identifies which catalog entry the cover
+ * came from so a later step can attribute or de-duplicate it.
+ */
+data class CoverMeta(
+    /** Directly usable cover image URL. */
+    val url: String,
+    /** Largest available rendition URL, when distinct from [url]. */
+    val maxSizeUrl: String? = null,
+    /** The catalog entry key this cover belongs to. */
+    val sourceKey: String,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/EnrichmentRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/EnrichmentRoutes.kt
@@ -1,0 +1,155 @@
+package com.calypsan.listenup.server.metadata.spi
+
+import com.calypsan.listenup.api.metadata.BookField
+import com.calypsan.listenup.api.metadata.MetadataDomain
+import com.calypsan.listenup.server.logging.loggerFor
+
+private val logger = loggerFor<EnrichmentRoutes>()
+
+/**
+ * The operator-configured provider precedence for metadata enrichment.
+ *
+ * Two layers, coarse to fine:
+ * - [domainOrder] — the provider chain the router walks for a whole
+ *   [MetadataDomain]. Total over every domain, so [orderFor] can resolve any field.
+ * - [fieldOverrides] — a per-[BookField] chain that supersedes the field's domain
+ *   order. This is what lets [BookField.AUTHORS] and [BookField.NARRATORS] — same
+ *   domain — take different provider chains.
+ *
+ * The router asks [orderFor] for a field's chain and walks it first-non-empty. An
+ * empty chain (e.g. [MetadataDomain.CHARACTERS] by default) means "no provider" —
+ * the honest empty slot, not a failure.
+ *
+ * Built from code defaults ([DEFAULT]) and, when set, the `LISTENUP_ENRICHMENT_ORDER`
+ * / `LISTENUP_ENRICHMENT_ROUTES` environment variables via [parse].
+ */
+data class EnrichmentRoutes(
+    /** Provider precedence per domain — total over [MetadataDomain]. */
+    val domainOrder: Map<MetadataDomain, List<MetadataProviderId>>,
+    /** Per-field overrides that beat the field's [domainOrder] entry. */
+    val fieldOverrides: Map<BookField, List<MetadataProviderId>>,
+) {
+    /**
+     * The provider precedence for [field]: its explicit override when present, else
+     * its domain's order. Never fails — [domainOrder] is total over every domain.
+     */
+    fun orderFor(field: BookField): List<MetadataProviderId> =
+        fieldOverrides[field] ?: domainOrder.getValue(field.domain)
+
+    companion object {
+        /**
+         * The approved code defaults — the enrichment order with no env configured.
+         * Total over every [MetadataDomain]; [MetadataDomain.CHARACTERS] is empty (no
+         * source exists).
+         */
+        val DEFAULT_DOMAIN_ORDER: Map<MetadataDomain, List<MetadataProviderId>> =
+            mapOf(
+                MetadataDomain.BOOK_CORE to listOf(MetadataProviderId.AUDIBLE, MetadataProviderId.AUDNEXUS),
+                MetadataDomain.CONTRIBUTORS to listOf(MetadataProviderId.AUDNEXUS, MetadataProviderId.AUDIBLE),
+                MetadataDomain.CHAPTERS to
+                    listOf(MetadataProviderId.LOCAL, MetadataProviderId.AUDNEXUS, MetadataProviderId.AUDIBLE),
+                MetadataDomain.COVER to listOf(MetadataProviderId.AUDIBLE, MetadataProviderId.ITUNES),
+                MetadataDomain.SERIES to listOf(MetadataProviderId.AUDIBLE, MetadataProviderId.AUDNEXUS),
+                MetadataDomain.GENRES to listOf(MetadataProviderId.AUDIBLE, MetadataProviderId.AUDNEXUS),
+                MetadataDomain.CHARACTERS to emptyList(),
+            )
+
+        /** The routes with no env configured — code defaults, no field overrides. */
+        val DEFAULT = EnrichmentRoutes(DEFAULT_DOMAIN_ORDER, emptyMap())
+
+        /**
+         * Parses the enrichment configuration, never-strand.
+         *
+         * [order] mirrors `LISTENUP_ENRICHMENT_ORDER` (e.g. `audible,audnexus,itunes`)
+         * — a global baseline applied to every domain when set and non-empty.
+         * [routes] mirrors `LISTENUP_ENRICHMENT_ROUTES` (e.g.
+         * `contributors=audnexus,audible; chapters=local,audnexus,audible; description=audible`)
+         * — semicolon-separated `key=provider,provider` clauses. A key is a domain
+         * token OR a field token; a domain token wins the collision (`series`, `cover`,
+         * `chapters` are domains), and a field clause supersedes its domain at
+         * [orderFor] time.
+         *
+         * Resolution precedence per domain: a domain clause in [routes] > [order]'s
+         * global baseline > the code default. Field clauses populate [fieldOverrides].
+         *
+         * Malformed input never throws: an unknown provider token is dropped, a
+         * clause with no `=` / no valid providers / an unknown key is logged once and
+         * skipped, and a blank value behaves like unset. A misconfigured env must
+         * never strand enrichment.
+         */
+        fun parse(
+            order: String?,
+            routes: String?,
+        ): EnrichmentRoutes {
+            val resolved = DEFAULT_DOMAIN_ORDER.toMutableMap()
+
+            parseProviderList(order)?.let { globalBaseline ->
+                MetadataDomain.entries.forEach { domain -> resolved[domain] = globalBaseline }
+            }
+
+            val fieldOverrides = mutableMapOf<BookField, List<MetadataProviderId>>()
+            parseClauses(routes).forEach { (key, providers) ->
+                val domain = MetadataDomain.fromToken(key)
+                if (domain != null) {
+                    resolved[domain] = providers
+                    return@forEach
+                }
+                val field = BookField.fromToken(key)
+                if (field != null) {
+                    fieldOverrides[field] = providers
+                    return@forEach
+                }
+                logger.warn { "Unknown enrichment route key '$key' — skipping (not a domain or field token)." }
+            }
+
+            return EnrichmentRoutes(resolved.toMap(), fieldOverrides.toMap())
+        }
+
+        /**
+         * Parses a comma-separated provider token list into ids, dropping unknown
+         * tokens with a warning. Returns `null` when [raw] is blank or yields no valid
+         * id (so the caller treats it as unset).
+         */
+        private fun parseProviderList(raw: String?): List<MetadataProviderId>? {
+            if (raw.isNullOrBlank()) return null
+            val ids =
+                raw
+                    .split(",")
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+                    .mapNotNull { token ->
+                        MetadataProviderId.fromToken(token).also {
+                            if (it == null) logger.warn { "Unknown metadata provider '$token' — skipping." }
+                        }
+                    }
+            return ids.ifEmpty { null }
+        }
+
+        /**
+         * Splits a `LISTENUP_ENRICHMENT_ROUTES` value into `(key, providers)` clauses,
+         * skipping any malformed clause with a warning. Keys are lowercased for
+         * case-insensitive token matching.
+         */
+        private fun parseClauses(raw: String?): List<Pair<String, List<MetadataProviderId>>> {
+            if (raw.isNullOrBlank()) return emptyList()
+            return raw.split(";").mapNotNull { clause ->
+                val trimmed = clause.trim()
+                if (trimmed.isEmpty()) return@mapNotNull null
+                val eq = trimmed.indexOf('=')
+                if (eq <= 0) {
+                    logger.warn {
+                        "Malformed enrichment route clause '$trimmed' — skipping (expected 'key=provider,...')."
+                    }
+                    return@mapNotNull null
+                }
+                val key = trimmed.substring(0, eq).trim().lowercase()
+                val providers = parseProviderList(trimmed.substring(eq + 1))
+                if (providers == null) {
+                    logger.warn { "Enrichment route '$key' has no valid providers — skipping." }
+                    return@mapNotNull null
+                }
+                key to providers
+            }
+        }
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/GenreMeta.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/GenreMeta.kt
@@ -1,0 +1,27 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * Whether a genre-family term is a formal genre or a free-form tag.
+ *
+ * Catalogs mix curated shelf categories with loose keyword tags; keeping the
+ * distinction lets a later step route [GENRE][GenreKind.GENRE] into the genre
+ * taxonomy and [TAG][GenreKind.TAG] into free-form book tags.
+ */
+enum class GenreKind {
+    /** A formal, curated genre category. */
+    GENRE,
+
+    /** A free-form keyword tag. */
+    TAG,
+}
+
+/**
+ * One genre-family term from a [GenreSource] — a genre or a tag, distinguished by
+ * [kind]. [name] is the catalog's label verbatim.
+ */
+data class GenreMeta(
+    /** The term's label, as the catalog spells it. */
+    val name: String,
+    /** Whether this is a formal genre or a free-form tag. */
+    val kind: GenreKind,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataCapability.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataCapability.kt
@@ -1,0 +1,169 @@
+package com.calypsan.listenup.server.metadata.spi
+
+import com.calypsan.listenup.api.result.AppResult
+
+/**
+ * The root of the metadata provider SPI: one narrow capability a provider *may*
+ * implement.
+ *
+ * A concrete provider is a single object that implements as many of the capability
+ * sub-interfaces as its catalog supports — Audible is a [BookIdentitySource] +
+ * [BookCoreSource] + [CoverSource]; Audnexus adds [ContributorSource] and
+ * [GenreSource]. Splitting each concern into its own interface means no provider is
+ * ever forced to stub a capability it can't honor (the reason contributor *profiles*
+ * are their own [ContributorSource] rather than a method on every provider).
+ *
+ * The router discovers capabilities through
+ * [MetadataProviderRegistry.capable] — `filterIsInstance` over the registered
+ * providers — so adding a capability to a provider is just implementing one more
+ * interface.
+ *
+ * ### Return convention (uniform across every capability)
+ * - [AppResult.Failure] means the provider *errored* — network fault, parse
+ *   failure, rate-limit exhaustion. The router treats it as a real failure and its
+ *   containment kicks in.
+ * - `Success(null)` / `Success(emptyList())` means "this catalog simply has nothing
+ *   for that book" — a normal, expected miss. The router's first-non-empty
+ *   composition falls through to the next provider *without* tripping failure
+ *   containment.
+ *
+ * Keeping "empty" distinct from "failed" is what lets a lean catalog sit early in a
+ * precedence chain without poisoning it.
+ */
+sealed interface MetadataCapability {
+    /** The provider this capability belongs to. */
+    val id: MetadataProviderId
+}
+
+/**
+ * Phase-1 identity: search a catalog for candidates matching a free-text query and
+ * rank them. This is the "which catalog entry is this local book?" step, distinct
+ * from fetching the winning entry's fields.
+ */
+interface BookIdentitySource : MetadataCapability {
+    /**
+     * Searches the catalog for books matching [query] in [locale]. Returns ranked
+     * [BookMatch] candidates (highest [BookMatch.score] first). `Success(emptyList())`
+     * for no hits; [AppResult.Failure] only on a provider error.
+     */
+    suspend fun searchBooks(
+        query: String,
+        locale: MetadataLocale,
+    ): AppResult<List<BookMatch>>
+}
+
+/**
+ * Fetches the core metadata (and book credits) for an identified book.
+ */
+interface BookCoreSource : MetadataCapability {
+    /**
+     * Fetches core metadata for [book] in [locale]. `Success(null)` when the catalog
+     * has no entry for it; [AppResult.Failure] only on a provider error. Pass
+     * [refresh] = `true` to bypass any provider-side cache.
+     */
+    suspend fun getBookCore(
+        book: BookIdentity,
+        locale: MetadataLocale,
+        refresh: Boolean = false,
+    ): AppResult<BookCoreMeta?>
+}
+
+/**
+ * Contributor *profiles* — search and fetch a person's bio/photo. Book *credits*
+ * do NOT live here (they fold into [BookCoreMeta.authors] / [BookCoreMeta.narrators]);
+ * this keeps the capability honest for catalogs like Audible that have credits but
+ * no standalone profile endpoint.
+ */
+interface ContributorSource : MetadataCapability {
+    /**
+     * Searches contributor profiles by [name] in [locale]. `Success(emptyList())`
+     * for no hits; [AppResult.Failure] only on a provider error.
+     */
+    suspend fun searchContributors(
+        name: String,
+        locale: MetadataLocale,
+    ): AppResult<List<ContributorHitMeta>>
+
+    /**
+     * Fetches the profile for the contributor identified by [key] in [locale].
+     * `Success(null)` when the catalog has no such profile; [AppResult.Failure] only
+     * on a provider error. Pass [refresh] = `true` to bypass any provider-side cache.
+     */
+    suspend fun getContributor(
+        key: String,
+        locale: MetadataLocale,
+        refresh: Boolean = false,
+    ): AppResult<ContributorMeta?>
+}
+
+/**
+ * Fetches a chapter list for an identified book.
+ */
+interface ChapterSource : MetadataCapability {
+    /**
+     * Fetches chapters for [book] in [locale]. `Success(null)` when the catalog has
+     * no chapter data; [AppResult.Failure] only on a provider error.
+     */
+    suspend fun getChapters(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<ChapterListMeta?>
+}
+
+/**
+ * Searches cover-art candidates for an identified book.
+ */
+interface CoverSource : MetadataCapability {
+    /**
+     * Searches cover candidates for [book] in [locale]. `Success(emptyList())` for
+     * no hits; [AppResult.Failure] only on a provider error.
+     */
+    suspend fun searchCovers(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<CoverMeta>>
+}
+
+/**
+ * Fetches series placements for an identified book.
+ */
+interface SeriesSource : MetadataCapability {
+    /**
+     * Fetches series placements for [book] in [locale]. `Success(null)`/empty when
+     * the catalog has none; [AppResult.Failure] only on a provider error.
+     */
+    suspend fun getSeries(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<SeriesMeta>?>
+}
+
+/**
+ * Fetches genre-family terms for an identified book.
+ */
+interface GenreSource : MetadataCapability {
+    /**
+     * Fetches genres/tags for [book] in [locale]. `Success(null)`/empty when the
+     * catalog has none; [AppResult.Failure] only on a provider error.
+     */
+    suspend fun getGenres(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<GenreMeta>?>
+}
+
+/**
+ * Fetches per-book characters. The honest empty slot: no public source implements
+ * this today (see [CharacterMeta]). Defined so the vocabulary is complete and a
+ * future manual/community source can slot in without a schema change.
+ */
+interface CharacterSource : MetadataCapability {
+    /**
+     * Fetches characters for [book] in [locale]. `Success(null)`/empty when none are
+     * known; [AppResult.Failure] only on a provider error.
+     */
+    suspend fun getCharacters(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<CharacterMeta>?>
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataLocale.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataLocale.kt
@@ -1,0 +1,30 @@
+package com.calypsan.listenup.server.metadata.spi
+
+import kotlin.jvm.JvmInline
+
+/**
+ * The provider-neutral locale an enrichment lookup runs in.
+ *
+ * Each provider maps this to its own regional vocabulary (Audible maps it to an
+ * `AudibleRegion`, iTunes to a storefront country) — the SPI stays neutral so no
+ * capability signature leaks a single catalog's region enum. [code] is a short
+ * lowercase region/market token (e.g. `us`, `uk`, `de`).
+ *
+ * A provider that does not recognize a locale is expected to fall back to its own
+ * default rather than fail — the never-strand rule at the provider edge.
+ */
+@JvmInline
+value class MetadataLocale(
+    val code: String,
+) {
+    init {
+        require(code.isNotBlank()) { "MetadataLocale code cannot be blank" }
+    }
+
+    override fun toString(): String = code
+
+    companion object {
+        /** The default market when the caller has no library-specific locale. */
+        val DEFAULT = MetadataLocale("us")
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataProviderId.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataProviderId.kt
@@ -1,0 +1,48 @@
+package com.calypsan.listenup.server.metadata.spi
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Stable identity of a metadata provider — the value the enrichment router names
+ * a provider by in its priority chains.
+ *
+ * Server-internal: a provider id never crosses the RPC wire (the client picks
+ * fields and domains, not provider implementations). The [value] is the operator-
+ * facing config token used in `LISTENUP_ENRICHMENT_ORDER` / `_ROUTES`.
+ *
+ * [LOCAL] is a reserved pseudo-provider: it does not fetch from any catalog. Its
+ * presence in a domain's order means "the book's existing scan-derived value ranks
+ * here" — the never-strand anchor that lets local metadata out-rank, or fall
+ * behind, a remote catalog per the operator's precedence.
+ */
+@JvmInline
+value class MetadataProviderId(
+    val value: String,
+) {
+    init {
+        require(value.isNotBlank()) { "MetadataProviderId cannot be blank" }
+    }
+
+    override fun toString(): String = value
+
+    companion object {
+        /** The Audible catalog. */
+        val AUDIBLE = MetadataProviderId("audible")
+
+        /** The iTunes / Apple Books catalog. */
+        val ITUNES = MetadataProviderId("itunes")
+
+        /** The Audnexus aggregator (contributor profiles, chapters, genres). */
+        val AUDNEXUS = MetadataProviderId("audnexus")
+
+        /** Reserved pseudo-provider: the book's existing scan-derived value. */
+        val LOCAL = MetadataProviderId("local")
+
+        /** Every id the router recognizes from config tokens. */
+        val known: List<MetadataProviderId> = listOf(AUDIBLE, ITUNES, AUDNEXUS, LOCAL)
+
+        /** Resolves a config token (case-insensitive) to a known id, or `null` if unrecognized. */
+        fun fromToken(token: String): MetadataProviderId? =
+            known.firstOrNull { it.value.equals(token.trim(), ignoreCase = true) }
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataProviderRegistry.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataProviderRegistry.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * The set of registered metadata providers, queryable by capability and by id.
+ *
+ * A pure data structure — it holds providers and answers "who can do X?" and "give
+ * me provider Y as an X". The enrichment router leans on [capable] to fan a domain
+ * lookup across every provider that supports it, and on [get] to consult a specific
+ * provider named in a precedence chain. No providers are wired in yet (that lands
+ * with the concrete provider re-skin in a later step); step 1 defines the shape and
+ * proves the capability queries.
+ *
+ * When two providers share an [MetadataProviderId] the last one wins in [byId] — a
+ * provider is expected to be a single object per id, so this only guards against
+ * accidental double-registration.
+ */
+class MetadataProviderRegistry(
+    /** The registered providers, each a single object implementing one or more capabilities. */
+    val providers: List<MetadataCapability>,
+) {
+    /** Providers indexed by their [MetadataProviderId]. */
+    val byId: Map<MetadataProviderId, MetadataCapability> = providers.associateBy { it.id }
+
+    /** Every registered provider that implements capability [C], in registration order. */
+    inline fun <reified C : MetadataCapability> capable(): List<C> = providers.filterIsInstance<C>()
+
+    /** The provider registered under [id] as capability [C], or `null` if absent or incapable. */
+    inline fun <reified C : MetadataCapability> get(id: MetadataProviderId): C? = byId[id] as? C
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/SeriesMeta.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/SeriesMeta.kt
@@ -1,0 +1,18 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * A series placement for a book, as a provider reports it.
+ *
+ * A book can sit in more than one series (a main arc and a publisher collection),
+ * so [SeriesSource] returns a list. [key] is the catalog's stable series id when
+ * exposed; [sequence] is the book's position kept as a string because catalogs use
+ * non-integer positions (`"1.5"`, `"Book 2"`).
+ */
+data class SeriesMeta(
+    /** Catalog series key, when available. */
+    val key: String? = null,
+    /** Series title. */
+    val title: String,
+    /** The book's position within the series, verbatim (`"1"`, `"1.5"`). */
+    val sequence: String? = null,
+)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/spi/EnrichmentRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/spi/EnrichmentRoutesTest.kt
@@ -1,0 +1,130 @@
+package com.calypsan.listenup.server.metadata.spi
+
+import com.calypsan.listenup.api.metadata.BookField
+import com.calypsan.listenup.api.metadata.MetadataDomain
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+
+class EnrichmentRoutesTest :
+    FunSpec({
+        val audible = MetadataProviderId.AUDIBLE
+        val audnexus = MetadataProviderId.AUDNEXUS
+        val itunes = MetadataProviderId.ITUNES
+        val local = MetadataProviderId.LOCAL
+
+        // ---- orderFor: field override beats domain; domain default otherwise ----
+
+        test("orderFor falls through to the domain order when the field has no override") {
+            val routes =
+                EnrichmentRoutes(
+                    domainOrder = mapOf(MetadataDomain.CONTRIBUTORS to listOf(audnexus, audible)),
+                    fieldOverrides = emptyMap(),
+                )
+            routes.orderFor(BookField.AUTHORS) shouldBe listOf(audnexus, audible)
+        }
+
+        test("orderFor prefers a field override over the domain order") {
+            val routes =
+                EnrichmentRoutes(
+                    domainOrder = mapOf(MetadataDomain.CONTRIBUTORS to listOf(audnexus, audible)),
+                    fieldOverrides = mapOf(BookField.NARRATORS to listOf(audible)),
+                )
+            // NARRATORS overridden, AUTHORS still follows the domain.
+            routes.orderFor(BookField.NARRATORS) shouldBe listOf(audible)
+            routes.orderFor(BookField.AUTHORS) shouldBe listOf(audnexus, audible)
+        }
+
+        // ---- code defaults ----
+
+        test("DEFAULT covers every domain and encodes the approved code defaults") {
+            val d = EnrichmentRoutes.DEFAULT
+            MetadataDomain.entries.forEach { domain ->
+                d.domainOrder.containsKey(domain) shouldBe true
+            }
+            d.orderFor(BookField.TITLE) shouldBe listOf(audible, audnexus)
+            d.orderFor(BookField.AUTHORS) shouldBe listOf(audnexus, audible)
+            d.orderFor(BookField.CHAPTERS) shouldBe listOf(local, audnexus, audible)
+            d.orderFor(BookField.COVER) shouldBe listOf(audible, itunes)
+            d.orderFor(BookField.GENRES) shouldBe listOf(audible, audnexus)
+            d.orderFor(BookField.SERIES) shouldBe listOf(audible, audnexus)
+        }
+
+        test("CHARACTERS is the honest empty slot") {
+            EnrichmentRoutes.DEFAULT.domainOrder.getValue(MetadataDomain.CHARACTERS) shouldBe emptyList()
+        }
+
+        // ---- parse: global order + route clauses ----
+
+        test("null env yields the code defaults") {
+            EnrichmentRoutes.parse(order = null, routes = null) shouldBe EnrichmentRoutes.DEFAULT
+        }
+
+        test("LISTENUP_ENRICHMENT_ORDER sets a global baseline for every domain") {
+            val parsed = EnrichmentRoutes.parse(order = "audible,audnexus,itunes", routes = null)
+            MetadataDomain.entries.forEach { domain ->
+                if (domain == MetadataDomain.CHARACTERS) return@forEach
+                parsed.domainOrder.getValue(domain) shouldBe listOf(audible, audnexus, itunes)
+            }
+        }
+
+        test("route clauses override domains and fields; a field clause beats its domain clause") {
+            val parsed =
+                EnrichmentRoutes.parse(
+                    order = null,
+                    routes =
+                        "contributors=audnexus,audible; chapters=local,audnexus,audible; " +
+                            "cover=itunes,audible; description=audible; narrators=itunes",
+                )
+            // Domain clause.
+            parsed.orderFor(BookField.AUTHORS) shouldBe listOf(audnexus, audible)
+            parsed.orderFor(BookField.CHAPTERS) shouldBe listOf(local, audnexus, audible)
+            parsed.orderFor(BookField.COVER) shouldBe listOf(itunes, audible)
+            // Field clauses (description is BOOK_CORE, narrators is CONTRIBUTORS).
+            parsed.orderFor(BookField.DESCRIPTION) shouldBe listOf(audible)
+            parsed.orderFor(BookField.NARRATORS) shouldBe listOf(itunes)
+            // A sibling field under an overridden domain still follows the domain clause.
+            parsed.orderFor(BookField.TITLE) shouldBe EnrichmentRoutes.DEFAULT.orderFor(BookField.TITLE)
+        }
+
+        test("collision tokens (cover/chapters/series) resolve as DOMAIN clauses, not fields") {
+            val parsed = EnrichmentRoutes.parse(order = null, routes = "series=itunes")
+            // SERIES token is both a domain and a field name; domain wins → domainOrder changes,
+            // not a field override, so the whole SERIES domain is affected.
+            parsed.domainOrder.getValue(MetadataDomain.SERIES) shouldBe listOf(itunes)
+            parsed.fieldOverrides.containsKey(BookField.SERIES) shouldBe false
+        }
+
+        // ---- never-strand: malformed input falls back, never throws ----
+
+        test("malformed clauses are skipped, valid siblings survive, nothing throws") {
+            val parsed =
+                EnrichmentRoutes.parse(
+                    order = "audible,bogusprovider",
+                    routes = "garbage-no-equals; =audible; description=; cover=itunes,unknownprov; foo=audible",
+                )
+            // Unknown provider dropped from global order, valid one kept → global baseline of just audible.
+            parsed.domainOrder.getValue(MetadataDomain.BOOK_CORE) shouldBe listOf(audible)
+            // cover clause keeps the valid provider, drops the unknown one.
+            parsed.orderFor(BookField.COVER) shouldBe listOf(itunes)
+            // 'foo' is neither a domain nor a field token → skipped, no field override leaked.
+            parsed.fieldOverrides.keys.none { it.token == "foo" } shouldBe true
+        }
+
+        test("blank env strings behave like null") {
+            EnrichmentRoutes.parse(order = "   ", routes = "  ;  ; ") shouldBe EnrichmentRoutes.DEFAULT
+        }
+
+        test("property: arbitrary garbage never throws and always leaves every domain routable") {
+            checkAll(Arb.string(), Arb.string()) { order, routes ->
+                val parsed = EnrichmentRoutes.parse(order = order, routes = routes)
+                // The never-strand invariant: orderFor resolves for every field without throwing.
+                BookField.entries.forEach { field -> parsed.orderFor(field) }
+                MetadataDomain.entries.forEach { domain ->
+                    parsed.domainOrder.containsKey(domain) shouldBe true
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataProviderRegistryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataProviderRegistryTest.kt
@@ -1,0 +1,66 @@
+package com.calypsan.listenup.server.metadata.spi
+
+import com.calypsan.listenup.api.result.AppResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+// --- Tiny fakes: one object implementing several capability interfaces at once. ---
+
+private class FakeCoverOnly(
+    override val id: MetadataProviderId,
+) : CoverSource {
+    override suspend fun searchCovers(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<CoverMeta>> = AppResult.Success(emptyList())
+}
+
+private class FakeCoreAndCover(
+    override val id: MetadataProviderId,
+) : BookCoreSource,
+    CoverSource {
+    override suspend fun getBookCore(
+        book: BookIdentity,
+        locale: MetadataLocale,
+        refresh: Boolean,
+    ): AppResult<BookCoreMeta?> = AppResult.Success(null)
+
+    override suspend fun searchCovers(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<CoverMeta>> = AppResult.Success(emptyList())
+}
+
+class MetadataProviderRegistryTest :
+    FunSpec({
+        test("capable() collects every provider implementing a capability, across the mixed set") {
+            val audible = FakeCoreAndCover(MetadataProviderId.AUDIBLE)
+            val itunes = FakeCoverOnly(MetadataProviderId.ITUNES)
+            val registry = MetadataProviderRegistry(listOf(audible, itunes))
+
+            registry.capable<CoverSource>() shouldContainExactlyInAnyOrder listOf(audible, itunes)
+            registry.capable<BookCoreSource>() shouldContainExactlyInAnyOrder listOf(audible)
+            registry.capable<ChapterSource>().shouldBe(emptyList())
+        }
+
+        test("get<C>(id) returns the provider only when it satisfies both the id and the capability") {
+            val audible = FakeCoreAndCover(MetadataProviderId.AUDIBLE)
+            val itunes = FakeCoverOnly(MetadataProviderId.ITUNES)
+            val registry = MetadataProviderRegistry(listOf(audible, itunes))
+
+            registry.get<BookCoreSource>(MetadataProviderId.AUDIBLE) shouldBe audible
+            // iTunes is registered but is not a BookCoreSource → null, not a class cast.
+            registry.get<BookCoreSource>(MetadataProviderId.ITUNES).shouldBeNull()
+            // Unknown id → null.
+            registry.get<CoverSource>(MetadataProviderId.AUDNEXUS).shouldBeNull()
+        }
+
+        test("byId keys each provider by its id") {
+            val audible = FakeCoreAndCover(MetadataProviderId.AUDIBLE)
+            val registry = MetadataProviderRegistry(listOf(audible))
+            registry.byId[MetadataProviderId.AUDIBLE] shouldBe audible
+            registry.byId[MetadataProviderId.ITUNES].shouldBeNull()
+        }
+    })


### PR DESCRIPTION
**Step 1 of the approved metadata-enrichment rewrite** (Fable Pass-2 design). Pure addition — 19 files, no existing code touched. Establishes the target vocabulary so the whole architecture is reviewable before any provider is re-skinned onto it.

## What's here
**`:contract` (`api/metadata/`)** — the wire-facing keys (they ride the wire in step 2):
- `MetadataDomain` — `@Serializable enum` (BOOK_CORE, CONTRIBUTORS, CHAPTERS, COVER, SERIES, GENRES, CHARACTERS), each with an operator config `token`.
- `BookField(val domain: MetadataDomain)` — the finest enrichment granularity. `AUTHORS`/`NARRATORS` are split (both CONTRIBUTORS) — the flagship field-routing case that lets authors and narrators come from different catalogs.

**`:server` (`metadata/spi/`)** — server-internal, nothing crosses RPC:
- Capability interfaces — `sealed interface MetadataCapability` + `BookIdentitySource`, `BookCoreSource`, `ContributorSource` (profiles only — book credits fold into `BookCoreMeta`, so Audible isn't forced to stub a profile endpoint it lacks), `ChapterSource`, `CoverSource`, `SeriesSource`, `GenreSource`, `CharacterSource`. Uniform return convention: `Failure` = provider error; `Success(null|empty)` = catalog miss (so a lean catalog can sit early in a chain without poisoning it).
- Neutral meta types (one per concern), `MetadataProviderId` (open, replaces the closed `enum MetadataSource` in step 4), neutral `MetadataLocale`, `BookIdentity`, `BookMatch`.
- `MetadataProviderRegistry` — reified `capable<C>()` / `get<C>(id)` capability queries (no casts, no stubs).
- `EnrichmentRoutes` — `orderFor(field) = fieldOverrides[field] ?: domainOrder[field.domain]`; approved code defaults baked in; never-strand `parse(order, routes)` for `LISTENUP_ENRICHMENT_ORDER` / `LISTENUP_ENRICHMENT_ROUTES`.

## Tests (Kotest, red→green)
Registry capability queries (`get` returns null for registered-but-incapable — no ClassCast); `orderFor` field-override-beats-domain; exact default chains; the routes parser (domain-token-wins-collision, field clauses, malformed input skipped with valid siblings surviving); **property test** — arbitrary garbage config never throws and `domainOrder` stays total over every domain (the never-strand invariant).

## Verification
`:contract:jvmTest :server:jvmTest` (targeted) · `com.calypsan.listenup.server.konsist.*` (KDoc on every public type passes) · `:contract:compileKotlinLinuxX64 :server:compileKotlinLinuxX64` (native parity) · `spotlessCheck detekt` — all green.

## Export surface
Two new `@Serializable` contract enums (`BookField`, `MetadataDomain`) — added to `scripts/export-surface-baseline.txt` at their alphabetical positions. They're plain enums (no `@SerialName`/`StablePropertyOrderRule` concern). The macOS `Test (iOS)` export gate is the authority — if it wants a different baseline shape, I'll regenerate from the generated `Shared.swift`.

Next: step 2 (provenance substrate = scanner R8; nuke-and-pave, no backfill).