### PR TITLE
✨ feat(server): custom-HTTP metadata provider seam + honest empty CHARACTERS slot (rewrite step 7/7 — final)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/MetadataModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/MetadataModule.kt
@@ -17,6 +17,9 @@ import com.calypsan.listenup.server.metadata.audible.AudibleRateLimiter
 import com.calypsan.listenup.server.metadata.audnexus.AudnexusApi
 import com.calypsan.listenup.server.metadata.audnexus.AudnexusClient
 import com.calypsan.listenup.server.metadata.audnexus.AudnexusRateLimiter
+import com.calypsan.listenup.server.metadata.custom.CustomHttpProvider
+import com.calypsan.listenup.server.metadata.custom.CustomMetadataClient
+import com.calypsan.listenup.server.metadata.custom.CustomProviderSpec
 import com.calypsan.listenup.server.metadata.itunes.ITunesApi
 import com.calypsan.listenup.server.metadata.itunes.ITunesClient
 import com.calypsan.listenup.server.metadata.itunes.ITunesRateLimiter
@@ -62,7 +65,9 @@ import org.koin.dsl.module
  *  - [AudibleProvider] / [AudnexusProvider] / [ITunesProvider] — the capability-SPI providers,
  *    collected in a [MetadataProviderRegistry]; [CoverSearchService] fans cover lookups over the
  *    registry's [com.calypsan.listenup.server.metadata.spi.CoverSource]s. Audnexus is the contributor-
- *    profile, catalog-chapter, and genre/tag source.
+ *    profile, catalog-chapter, and genre/tag source. Any operator-declared
+ *    [com.calypsan.listenup.server.metadata.custom.CustomHttpProvider]s (from `LISTENUP_CUSTOM_PROVIDERS`)
+ *    join the same registry — the extensibility seam, and the only per-book character source.
  *  - [EnrichmentRoutes] / [EnrichmentCoordinator] — the operator-configured provider precedence
  *    and the composer that walks it per domain to build a book's metadata for the lookup service.
  *  - [ImageStorage] — downloads cover/photo images to disk.
@@ -154,7 +159,8 @@ fun metadataModule(imageHome: Path): Module =
 
         single {
             MetadataProviderRegistry(
-                providers = listOf(get<AudibleProvider>(), get<AudnexusProvider>(), get<ITunesProvider>()),
+                providers =
+                    listOf(get<AudibleProvider>(), get<AudnexusProvider>(), get<ITunesProvider>()) + customProviders(),
             )
         }
 
@@ -256,6 +262,29 @@ private fun Module.metadataEnrichmentBindings() {
         )
     }
 }
+
+/**
+ * Builds an operator's custom metadata providers from `LISTENUP_CUSTOM_PROVIDERS`, one
+ * [CustomHttpProvider] per parsed [CustomProviderSpec], each over the shared metadata HTTP
+ * client with its own rate limiter. Never-strand: a misconfigured env parses to an empty list
+ * (see [CustomProviderSpec.parse]), so enrichment runs on the built-ins alone.
+ */
+private fun Scope.customProviders(): List<CustomHttpProvider> =
+    CustomProviderSpec.parse(readEnv("LISTENUP_CUSTOM_PROVIDERS")).map { spec ->
+        CustomHttpProvider(
+            spec = spec,
+            client =
+                CustomMetadataClient(
+                    httpClient = get(named(METADATA_HTTP_CLIENT)),
+                    json =
+                        Json {
+                            ignoreUnknownKeys = true
+                            isLenient = true
+                        },
+                    baseUrl = spec.baseUrl,
+                ),
+        )
+    }
 
 private fun Scope.audnexusApi(): AudnexusApi =
     AudnexusClient(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/EnrichmentCoordinator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/EnrichmentCoordinator.kt
@@ -13,6 +13,8 @@ import com.calypsan.listenup.server.metadata.spi.BookIdentitySource
 import com.calypsan.listenup.server.metadata.spi.BookMatch
 import com.calypsan.listenup.server.metadata.spi.ChapterListMeta
 import com.calypsan.listenup.server.metadata.spi.ChapterSource
+import com.calypsan.listenup.server.metadata.spi.CharacterMeta
+import com.calypsan.listenup.server.metadata.spi.CharacterSource
 import com.calypsan.listenup.server.metadata.spi.ContributorHitMeta
 import com.calypsan.listenup.server.metadata.spi.ContributorMeta
 import com.calypsan.listenup.server.metadata.spi.ContributorSource
@@ -134,6 +136,27 @@ internal class EnrichmentCoordinator(
         val order = routes.orderFor(BookField.CHAPTERS)
         return order.firstNotNullOfOrNull { byProvider[it]?.takeIf { list -> list.accurate } }
             ?: order.firstNotNullOfOrNull { byProvider[it]?.takeIf { list -> list.chapters.isNotEmpty() } }
+    }
+
+    /**
+     * Composes the character list for [identity] in [locale] — the honest empty slot.
+     *
+     * No built-in provider implements [CharacterSource] (there is no public per-book
+     * character catalog), so with the default routes this returns an empty list rather
+     * than fabricating data — the user-facing story is manual character entry. When an
+     * operator points a custom provider at a character source and routes
+     * [MetadataDomain.CHARACTERS] to it, that provider slots straight in here: the method
+     * fans out across every registered [CharacterSource] and returns the first non-empty
+     * list walking the CHARACTERS provider order. Each source is failure-contained.
+     */
+    suspend fun composeCharacters(
+        identity: BookIdentity,
+        locale: MetadataLocale,
+    ): List<CharacterMeta> {
+        val byProvider =
+            fanOut(registry.capable<CharacterSource>(), "characters") { it.getCharacters(identity, locale) }
+        val order = routes.domainOrder.getValue(MetadataDomain.CHARACTERS)
+        return order.firstNotNullOfOrNull { byProvider[it]?.takeIf { list -> list.isNotEmpty() } } ?: emptyList()
     }
 
     /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomHttpProvider.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomHttpProvider.kt
@@ -1,0 +1,93 @@
+package com.calypsan.listenup.server.metadata.custom
+
+import com.calypsan.listenup.api.metadata.MetadataDomain
+import com.calypsan.listenup.api.metadata.MetadataLocale
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.map
+import com.calypsan.listenup.server.metadata.spi.BookCoreMeta
+import com.calypsan.listenup.server.metadata.spi.BookCoreSource
+import com.calypsan.listenup.server.metadata.spi.BookIdentity
+import com.calypsan.listenup.server.metadata.spi.CharacterMeta
+import com.calypsan.listenup.server.metadata.spi.CharacterSource
+import com.calypsan.listenup.server.metadata.spi.CoverMeta
+import com.calypsan.listenup.server.metadata.spi.CoverSource
+import com.calypsan.listenup.server.metadata.spi.GenreMeta
+import com.calypsan.listenup.server.metadata.spi.GenreSource
+import com.calypsan.listenup.server.metadata.spi.MetadataProviderId
+import com.calypsan.listenup.server.metadata.spi.SeriesMeta
+import com.calypsan.listenup.server.metadata.spi.SeriesSource
+
+/**
+ * An operator-declared custom metadata source, re-skinned onto the capability SPI — the
+ * extensibility seam and the only way to fill the [MetadataDomain.CHARACTERS] slot today.
+ *
+ * One object per `LISTENUP_CUSTOM_PROVIDERS` entry ([spec]), registered in the
+ * [com.calypsan.listenup.server.metadata.spi.MetadataProviderRegistry] alongside the built-ins
+ * and routable by its `custom:<name>` id exactly like `audible`/`audnexus`/`itunes` (e.g.
+ * `LISTENUP_ENRICHMENT_ROUTES=characters=custom:mysource`).
+ *
+ * It implements every capability the [CustomMetadataClient] JSON contract can serve, but each
+ * method first checks [spec]'s declared [CustomProviderSpec.capabilities]: a domain the operator
+ * did **not** declare is an immediate honest miss (`Success(null)`/empty, no HTTP), so a lean
+ * endpoint is never asked for what it can't serve. A declared domain issues the request; a `404`
+ * from the endpoint is likewise an honest catalog miss (see [CustomMetadataClient]).
+ *
+ * Orchestration only — the custom-JSON → neutral-meta mapping lives in the pure functions in
+ * `CustomTypes`. Server-internal: provider ids never cross the RPC wire.
+ */
+internal class CustomHttpProvider(
+    private val spec: CustomProviderSpec,
+    private val client: CustomMetadataClient,
+) : BookCoreSource,
+    CharacterSource,
+    CoverSource,
+    GenreSource,
+    SeriesSource {
+    override val id: MetadataProviderId = spec.id
+
+    private fun serves(domain: MetadataDomain): Boolean = domain in spec.capabilities
+
+    override suspend fun getBookCore(
+        book: BookIdentity,
+        locale: MetadataLocale,
+        refresh: Boolean,
+    ): AppResult<BookCoreMeta?> {
+        if (!serves(MetadataDomain.BOOK_CORE)) return AppResult.Success(null)
+        return client.getBook(book.asin, book.title, book.primaryAuthor, locale.region).map { it?.toBookCoreMeta() }
+    }
+
+    override suspend fun getCharacters(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<CharacterMeta>?> {
+        if (!serves(MetadataDomain.CHARACTERS)) return AppResult.Success(null)
+        return client.getCharacters(book.asin, book.title, locale.region).map { it?.toCharacterMetas() }
+    }
+
+    override suspend fun searchCovers(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<CoverMeta>> {
+        if (!serves(MetadataDomain.COVER)) return AppResult.Success(emptyList())
+        return client.getCovers(book.asin, book.title, book.primaryAuthor, locale.region).map {
+            it?.toCoverMetas()
+                ?: emptyList()
+        }
+    }
+
+    override suspend fun getGenres(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<GenreMeta>?> {
+        if (!serves(MetadataDomain.GENRES)) return AppResult.Success(null)
+        return client.getGenres(book.asin, book.title, locale.region).map { it?.toGenreMetas() }
+    }
+
+    override suspend fun getSeries(
+        book: BookIdentity,
+        locale: MetadataLocale,
+    ): AppResult<List<SeriesMeta>?> {
+        if (!serves(MetadataDomain.SERIES)) return AppResult.Success(null)
+        return client.getSeries(book.asin, book.title, locale.region).map { it?.toSeriesMetas() }
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomMetadataClient.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomMetadataClient.kt
@@ -1,0 +1,146 @@
+package com.calypsan.listenup.server.metadata.custom
+
+import com.calypsan.listenup.api.error.MetadataError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.logging.loggerFor
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+private val logger = loggerFor<CustomMetadataClient>()
+
+/**
+ * Ktor-backed HTTP adapter for one operator-declared custom metadata endpoint.
+ *
+ * Speaks the thin JSON contract documented in `CustomTypes` over the shared metadata
+ * [HttpClient], paced by its own [rateLimiter]. Every method:
+ * 1. Awaits the [rateLimiter].
+ * 2. Issues a GET to the endpoint on [baseUrl], passing the lookup key params (`asin`,
+ *    `title`, `author`) it knows plus `region`, skipping blanks.
+ * 3. Maps the response to an [AppResult], identically to the built-in provider clients:
+ *    - 200 → decode JSON → [AppResult.Success]
+ *    - 404 → `Success(null)` (a catalog miss, not a failure)
+ *    - 429 → [MetadataError.ExternalRateLimited]
+ *    - 5xx / network failure → [MetadataError.ExternalUnavailable]
+ *    - decode failure → [MetadataError.Malformed]
+ *
+ * Authentication is the operator's responsibility — front the endpoint with whatever the
+ * hosting setup provides (a reverse-proxy token, network ACL, or a token baked into the
+ * URL). Keeping the client auth-free keeps the config surface a single `name=baseUrl` line.
+ *
+ * [CancellationException] is never swallowed — it is always rethrown.
+ */
+internal class CustomMetadataClient(
+    private val httpClient: HttpClient,
+    private val json: Json,
+    private val baseUrl: String,
+    private val rateLimiter: CustomRateLimiter = CustomRateLimiter(),
+) {
+    suspend fun getBook(
+        asin: String?,
+        title: String?,
+        author: String?,
+        region: String,
+    ): AppResult<CustomBookJson?> =
+        apiGet("/book", asin, title, author, region) { json.decodeFromString<CustomBookJson>(it) }
+
+    suspend fun getCharacters(
+        asin: String?,
+        title: String?,
+        region: String,
+    ): AppResult<List<CustomCharacterJson>?> =
+        apiGet(
+            "/characters",
+            asin,
+            title,
+            author = null,
+            region,
+        ) { json.decodeFromString<List<CustomCharacterJson>>(it) }
+
+    suspend fun getCovers(
+        asin: String?,
+        title: String?,
+        author: String?,
+        region: String,
+    ): AppResult<List<CustomCoverJson>?> =
+        apiGet("/cover", asin, title, author, region) { json.decodeFromString<List<CustomCoverJson>>(it) }
+
+    suspend fun getGenres(
+        asin: String?,
+        title: String?,
+        region: String,
+    ): AppResult<List<CustomGenreJson>?> =
+        apiGet("/genres", asin, title, author = null, region) { json.decodeFromString<List<CustomGenreJson>>(it) }
+
+    suspend fun getSeries(
+        asin: String?,
+        title: String?,
+        region: String,
+    ): AppResult<List<CustomSeriesJson>?> =
+        apiGet("/series", asin, title, author = null, region) { json.decodeFromString<List<CustomSeriesJson>>(it) }
+
+    /**
+     * Issues a GET to [path] on [baseUrl] with the non-blank lookup params plus `region`,
+     * mapping the response to [AppResult<T?>] via [decode]. A 404 maps to `Success(null)`.
+     * [CancellationException] is always rethrown; every other failure becomes a typed
+     * [MetadataError].
+     */
+    private suspend fun <T> apiGet(
+        path: String,
+        asin: String?,
+        title: String?,
+        author: String?,
+        region: String,
+        decode: (String) -> T,
+    ): AppResult<T?> =
+        try {
+            rateLimiter.await()
+            val response =
+                httpClient.get("$baseUrl$path") {
+                    header("Accept", "application/json")
+                    header("User-Agent", "ListenUp/1.0")
+                    parameter("region", region)
+                    asin?.takeIf { it.isNotBlank() }?.let { parameter("asin", it) }
+                    title?.takeIf { it.isNotBlank() }?.let { parameter("title", it) }
+                    author?.takeIf { it.isNotBlank() }?.let { parameter("author", it) }
+                }
+            when (response.status) {
+                HttpStatusCode.OK -> {
+                    try {
+                        AppResult.Success(decode(response.bodyAsText()))
+                    } catch (e: SerializationException) {
+                        AppResult.Failure(MetadataError.Malformed(debugInfo = e.message))
+                    } catch (e: IllegalArgumentException) {
+                        AppResult.Failure(MetadataError.Malformed(debugInfo = e.message))
+                    }
+                }
+
+                HttpStatusCode.NotFound -> {
+                    AppResult.Success(null)
+                }
+
+                HttpStatusCode.TooManyRequests -> {
+                    logger.warn { "Custom provider rate-limited: base=$baseUrl path=$path region=$region" }
+                    AppResult.Failure(MetadataError.ExternalRateLimited())
+                }
+
+                else -> {
+                    logger.warn {
+                        "Custom provider request failed: base=$baseUrl path=$path status=${response.status.value}"
+                    }
+                    AppResult.Failure(MetadataError.ExternalUnavailable(debugInfo = "HTTP ${response.status.value}"))
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Custom provider request errored: base=$baseUrl path=$path region=$region" }
+            AppResult.Failure(MetadataError.ExternalUnavailable(debugInfo = e.message))
+        }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomProviderSpec.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomProviderSpec.kt
@@ -1,0 +1,146 @@
+package com.calypsan.listenup.server.metadata.custom
+
+import com.calypsan.listenup.api.metadata.MetadataDomain
+import com.calypsan.listenup.server.logging.loggerFor
+import com.calypsan.listenup.server.metadata.spi.MetadataProviderId
+
+private val logger = loggerFor<CustomProviderSpec>()
+
+/**
+ * One operator-declared custom metadata provider, parsed from a `LISTENUP_CUSTOM_PROVIDERS`
+ * entry.
+ *
+ * A custom provider lets an operator point ListenUp at *their own* metadata HTTP endpoint —
+ * a community character wiki, a private catalog, a scraper they host — and have it
+ * participate in enrichment exactly like the built-in Audible/iTunes/Audnexus providers.
+ * It is the extensibility seam and, because no built-in source has per-book characters, the
+ * only way to fill the [MetadataDomain.CHARACTERS] slot today.
+ *
+ * [id] is `custom:<name>` (see [MetadataProviderId.custom]) — the token a route names it by
+ * in `LISTENUP_ENRICHMENT_ROUTES` (e.g. `characters=custom:mysource`). [capabilities] are the
+ * metadata domains this endpoint advertises; a domain the operator did *not* declare is an
+ * immediate honest miss (no HTTP), so a lean endpoint never gets asked for what it can't serve.
+ */
+data class CustomProviderSpec(
+    /** The provider id — `custom:<name>`, the token routes name it by. */
+    val id: MetadataProviderId,
+    /** The operator-chosen short name, lowercased. */
+    val name: String,
+    /** The endpoint base URL, trailing slash trimmed (paths are appended as `/book`, `/characters`, …). */
+    val baseUrl: String,
+    /** The metadata domains this endpoint advertises; undeclared domains are immediate misses. */
+    val capabilities: Set<MetadataDomain>,
+) {
+    companion object {
+        /**
+         * The metadata domains a custom provider can serve over the [CustomMetadataClient]
+         * JSON contract. A declared capability outside this set is dropped: the client has no
+         * endpoint for contributors, chapters, or book search.
+         */
+        val SUPPORTED_CAPABILITIES: Set<MetadataDomain> =
+            setOf(
+                MetadataDomain.BOOK_CORE,
+                MetadataDomain.CHARACTERS,
+                MetadataDomain.COVER,
+                MetadataDomain.GENRES,
+                MetadataDomain.SERIES,
+            )
+
+        /**
+         * Parses `LISTENUP_CUSTOM_PROVIDERS` into provider specs, never-strand.
+         *
+         * ### Format
+         * Semicolon-separated entries, each `name=baseUrl` with an optional `|caps` suffix:
+         *
+         * ```
+         * mysource=https://meta.example.com|characters,cover; catalog=https://x.y
+         * ```
+         *
+         * - `name` becomes the id `custom:<name>` (lowercased); it is what a route names.
+         * - `baseUrl` is the endpoint root; the client appends `/book`, `/characters`, `/cover`,
+         *   `/genres`, `/series`.
+         * - `|caps` is an optional comma-separated list of domain tokens
+         *   (`core`, `characters`, `cover`, `genres`, `series`) the endpoint serves. **Omit it to
+         *   advertise every [SUPPORTED_CAPABILITIES] domain** (the endpoint 404s what it lacks).
+         *
+         * ### Never-strand
+         * A misconfigured env must never strand enrichment. An entry with no `=`, a blank name or
+         * base URL, or a `|caps` clause that names no supported domain is logged once and skipped;
+         * an unknown/unsupported cap token is dropped with a warning; a duplicate name keeps the
+         * first and warns. Blank/absent input yields an empty list.
+         */
+        fun parse(raw: String?): List<CustomProviderSpec> {
+            if (raw.isNullOrBlank()) return emptyList()
+            val byId = LinkedHashMap<MetadataProviderId, CustomProviderSpec>()
+            raw.split(";").forEach { entry ->
+                parseEntry(entry.trim())?.let { spec ->
+                    if (byId.containsKey(spec.id)) {
+                        logger.warn {
+                            "Duplicate custom provider '${spec.name}' — keeping the first, skipping the rest."
+                        }
+                    } else {
+                        byId[spec.id] = spec
+                    }
+                }
+            }
+            return byId.values.toList()
+        }
+
+        private fun parseEntry(entry: String): CustomProviderSpec? {
+            if (entry.isEmpty()) return null
+            val eq = entry.indexOf('=')
+            if (eq <= 0) {
+                logger.warn { "Malformed custom provider '$entry' — skipping (expected 'name=baseUrl[|caps]')." }
+                return null
+            }
+            val name = entry.substring(0, eq).trim().lowercase()
+            val rest = entry.substring(eq + 1).trim()
+            val pipe = rest.indexOf('|')
+            val baseUrl = (if (pipe < 0) rest else rest.substring(0, pipe)).trim().trimEnd('/')
+            if (name.isEmpty() || baseUrl.isEmpty()) {
+                logger.warn { "Custom provider '$entry' has a blank name or base URL — skipping." }
+                return null
+            }
+            val capabilities =
+                if (pipe <
+                    0
+                ) {
+                    SUPPORTED_CAPABILITIES
+                } else {
+                    parseCapabilities(name, rest.substring(pipe + 1))
+                }
+            if (capabilities.isEmpty()) {
+                logger.warn { "Custom provider '$name' declares no supported capabilities — skipping." }
+                return null
+            }
+            return CustomProviderSpec(MetadataProviderId.custom(name), name, baseUrl, capabilities)
+        }
+
+        private fun parseCapabilities(
+            name: String,
+            raw: String,
+        ): Set<MetadataDomain> =
+            raw
+                .split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .mapNotNull { token ->
+                    val domain = MetadataDomain.fromToken(token)
+                    when {
+                        domain == null -> {
+                            logger.warn { "Custom provider '$name': unknown capability '$token' — dropping." }
+                            null
+                        }
+
+                        domain !in SUPPORTED_CAPABILITIES -> {
+                            logger.warn { "Custom provider '$name': capability '$token' is not supported — dropping." }
+                            null
+                        }
+
+                        else -> {
+                            domain
+                        }
+                    }
+                }.toSet()
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomRateLimiter.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomRateLimiter.kt
@@ -1,0 +1,40 @@
+package com.calypsan.listenup.server.metadata.custom
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+/**
+ * Serializes one custom provider's outbound calls to at most one per [minInterval]
+ * (default one request/second). One limiter per [CustomHttpProvider], so operators with
+ * several custom endpoints pace each independently.
+ *
+ * Pacing an operator's own endpoint is courtesy rather than necessity, but keeping a limiter
+ * matches every other provider ([com.calypsan.listenup.server.metadata.audnexus.AudnexusRateLimiter],
+ * `ITunesRateLimiter`) — one polite shape across the SPI. [await] is cooperative: it uses
+ * [delay], so cancellation propagates immediately through the wait.
+ */
+open class CustomRateLimiter(
+    private val minInterval: Duration = 1.seconds,
+    private val clock: Clock = Clock.System,
+) {
+    private val mutex = Mutex()
+    private var nextAllowedAt: Instant? = null
+
+    /** Waits until the next call is permitted, then returns. The first call is free. */
+    open suspend fun await() {
+        val waitFor =
+            mutex.withLock {
+                val now = clock.now()
+                val next = nextAllowedAt ?: now
+                val remaining = next - now
+                nextAllowedAt = maxOf(next, now) + minInterval
+                remaining
+            }
+        if (waitFor > Duration.ZERO) delay(waitFor)
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomTypes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/custom/CustomTypes.kt
@@ -1,0 +1,154 @@
+package com.calypsan.listenup.server.metadata.custom
+
+import com.calypsan.listenup.api.dto.ContributorRole
+import com.calypsan.listenup.server.metadata.spi.BookContributorMeta
+import com.calypsan.listenup.server.metadata.spi.BookCoreMeta
+import com.calypsan.listenup.server.metadata.spi.CharacterMeta
+import com.calypsan.listenup.server.metadata.spi.CoverMeta
+import com.calypsan.listenup.server.metadata.spi.GenreKind
+import com.calypsan.listenup.server.metadata.spi.GenreMeta
+import com.calypsan.listenup.server.metadata.spi.SeriesMeta
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ─── The custom-provider JSON contract ───────────────────────────
+//
+// The wire shape an operator's endpoint returns, and the pure mappers onto the
+// neutral `*Meta` SPI types the EnrichmentCoordinator composes. This is the operator's
+// integration surface: an endpoint that emits these shapes participates in enrichment
+// like any built-in provider. Every field is optional so an endpoint returns only what
+// it knows; a 404 (handled in CustomMetadataClient) is an honest catalog miss.
+//
+// Endpoints (all GET, all keyed by the query params `asin`, `title`, `author`, `region`
+// when the coordinator knows them):
+//   GET {baseUrl}/book?asin=&title=&author=&region=   -> CustomBookJson (object)
+//   GET {baseUrl}/characters?asin=&title=&region=      -> [CustomCharacterJson]
+//   GET {baseUrl}/cover?asin=&title=&author=&region=   -> [CustomCoverJson]
+//   GET {baseUrl}/genres?asin=&title=&region=          -> [CustomGenreJson]
+//   GET {baseUrl}/series?asin=&title=&region=          -> [CustomSeriesJson]
+
+/**
+ * The `/book` response — provider-neutral core fields plus credits. Mirrors [BookCoreMeta];
+ * [authors] carry the [ContributorRole.AUTHOR] role and [narrators] the
+ * [ContributorRole.NARRATOR] role implicitly (an endpoint lists a person under the role
+ * they served).
+ */
+@Serializable
+@SerialName("CustomBookJson")
+data class CustomBookJson(
+    val title: String? = null,
+    val subtitle: String? = null,
+    val description: String? = null,
+    val publisher: String? = null,
+    val releaseDate: String? = null,
+    val language: String? = null,
+    val runtimeMinutes: Int? = null,
+    val explicit: Boolean? = null,
+    val abridged: Boolean? = null,
+    val authors: List<CustomCreditJson> = emptyList(),
+    val narrators: List<CustomCreditJson> = emptyList(),
+)
+
+/** One credited contributor on a `/book` response; [key] is the endpoint's stable person id when it has one. */
+@Serializable
+@SerialName("CustomCreditJson")
+data class CustomCreditJson(
+    val key: String? = null,
+    val name: String,
+)
+
+/** One entry in a `/characters` response. */
+@Serializable
+@SerialName("CustomCharacterJson")
+data class CustomCharacterJson(
+    val name: String,
+    val description: String? = null,
+)
+
+/** One entry in a `/cover` response; [sourceKey] identifies the catalog entry the cover came from. */
+@Serializable
+@SerialName("CustomCoverJson")
+data class CustomCoverJson(
+    val url: String,
+    val maxSizeUrl: String? = null,
+    val sourceKey: String? = null,
+)
+
+/** One entry in a `/genres` response; [kind] is `genre` (default) or `tag`. */
+@Serializable
+@SerialName("CustomGenreJson")
+data class CustomGenreJson(
+    val name: String,
+    val kind: String? = null,
+)
+
+/** One entry in a `/series` response. */
+@Serializable
+@SerialName("CustomSeriesJson")
+data class CustomSeriesJson(
+    val key: String? = null,
+    val title: String,
+    val sequence: String? = null,
+)
+
+// ─── Mappers: custom JSON → neutral SPI meta ───────────────────────
+
+private const val TAG_KIND = "tag"
+
+private fun String?.orNullIfBlank(): String? = this?.takeIf { it.isNotBlank() }
+
+/** Folds credits into [BookCoreMeta.authors]/[narrators]; blank string fields collapse to `null`. */
+internal fun CustomBookJson.toBookCoreMeta(): BookCoreMeta =
+    BookCoreMeta(
+        title = title.orNullIfBlank(),
+        subtitle = subtitle.orNullIfBlank(),
+        description = description.orNullIfBlank(),
+        publisher = publisher.orNullIfBlank(),
+        releaseDate = releaseDate.orNullIfBlank(),
+        language = language.orNullIfBlank(),
+        runtimeMinutes = runtimeMinutes?.takeIf { it > 0 },
+        explicit = explicit,
+        abridged = abridged,
+        authors = authors.mapNotNull { it.toBookContributorMeta(ContributorRole.AUTHOR) },
+        narrators = narrators.mapNotNull { it.toBookContributorMeta(ContributorRole.NARRATOR) },
+    )
+
+private fun CustomCreditJson.toBookContributorMeta(role: ContributorRole): BookContributorMeta? {
+    val cleanName = name.orNullIfBlank() ?: return null
+    return BookContributorMeta(key = key.orNullIfBlank(), name = cleanName, role = role)
+}
+
+/** Drops unnamed characters; keeps a blank description as `null`. */
+internal fun List<CustomCharacterJson>.toCharacterMetas(): List<CharacterMeta> =
+    mapNotNull { json ->
+        json.name.orNullIfBlank()?.let { CharacterMeta(name = it, description = json.description.orNullIfBlank()) }
+    }
+
+/** Drops covers with a blank [url]; falls back the missing [sourceKey] to a stable literal. */
+internal fun List<CustomCoverJson>.toCoverMetas(): List<CoverMeta> =
+    mapNotNull { json ->
+        json.url.orNullIfBlank()?.let { url ->
+            CoverMeta(
+                url = url,
+                maxSizeUrl = json.maxSizeUrl.orNullIfBlank(),
+                sourceKey = json.sourceKey.orNullIfBlank() ?: "custom",
+            )
+        }
+    }
+
+/** Drops unnamed terms; a `kind` of `tag` marks a free-form tag, everything else a formal genre. */
+internal fun List<CustomGenreJson>.toGenreMetas(): List<GenreMeta> =
+    mapNotNull { json ->
+        json.name.orNullIfBlank()?.let { name ->
+            val isTag = json.kind?.trim()?.equals(TAG_KIND, ignoreCase = true) == true
+            GenreMeta(name = name, kind = if (isTag) GenreKind.TAG else GenreKind.GENRE)
+        }
+    }
+
+/** Drops untitled placements; keeps a blank key/sequence as `null`. */
+internal fun List<CustomSeriesJson>.toSeriesMetas(): List<SeriesMeta> =
+    mapNotNull { json ->
+        json.title.orNullIfBlank()?.let { title ->
+            SeriesMeta(key = json.key.orNullIfBlank(), title = title, sequence = json.sequence.orNullIfBlank())
+        }
+    }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataProviderId.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/MetadataProviderId.kt
@@ -38,11 +38,37 @@ value class MetadataProviderId(
         /** Reserved pseudo-provider: the book's existing scan-derived value. */
         val LOCAL = MetadataProviderId("local")
 
-        /** Every id the router recognizes from config tokens. */
+        /** Every built-in id the router recognizes from config tokens. */
         val known: List<MetadataProviderId> = listOf(AUDIBLE, ITUNES, AUDNEXUS, LOCAL)
 
-        /** Resolves a config token (case-insensitive) to a known id, or `null` if unrecognized. */
-        fun fromToken(token: String): MetadataProviderId? =
-            known.firstOrNull { it.value.equals(token.trim(), ignoreCase = true) }
+        /**
+         * The prefix that marks an operator-declared custom provider id — the token
+         * `custom:<name>` a `LISTENUP_CUSTOM_PROVIDERS` entry and any route naming it
+         * share. Kept lowercase so a route token and the config-derived id always match.
+         */
+        const val CUSTOM_PREFIX: String = "custom:"
+
+        /**
+         * The id for an operator-declared custom provider named [name] — `custom:<name>`,
+         * with [name] trimmed and lowercased so config and route tokens resolve identically.
+         */
+        fun custom(name: String): MetadataProviderId = MetadataProviderId(CUSTOM_PREFIX + name.trim().lowercase())
+
+        /**
+         * Resolves a config token (case-insensitive) to an id, or `null` if unrecognized.
+         *
+         * A built-in token matches one of [known]; a `custom:<name>` token resolves to
+         * that operator-declared provider's id (so a route can name a custom source), as
+         * long as `<name>` is non-blank.
+         */
+        fun fromToken(token: String): MetadataProviderId? {
+            val trimmed = token.trim()
+            known.firstOrNull { it.value.equals(trimmed, ignoreCase = true) }?.let { return it }
+            if (trimmed.startsWith(CUSTOM_PREFIX, ignoreCase = true)) {
+                val name = trimmed.substring(CUSTOM_PREFIX.length).trim()
+                if (name.isNotEmpty()) return custom(name)
+            }
+            return null
+        }
     }
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/EnrichmentCoordinatorTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/EnrichmentCoordinatorTest.kt
@@ -240,6 +240,15 @@ class EnrichmentCoordinatorTest :
             }
         }
 
+        test("composeCharacters is empty by default — the honest empty slot, no built-in character source") {
+            // The DEFAULT routes leave CHARACTERS empty and no FakeProvider supplies characters, so the
+            // compose returns an empty list rather than fabricating data (the manual-entry story).
+            val audible = FakeProvider(id = MetadataProviderId.AUDIBLE, core = AppResult.Success(BookCoreMeta(title = "T")))
+            runTest {
+                coordinator(audible).composeCharacters(identity(), US).shouldBeEmpty()
+            }
+        }
+
         test("searchContributors returns the first non-empty hit list walking the CONTRIBUTORS order") {
             // CONTRIBUTORS order is [audnexus, audible]; Audible has no ContributorSource in production, but
             // here both are fakes — Audnexus (first) supplies the hits.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/custom/CustomHttpProviderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/custom/CustomHttpProviderTest.kt
@@ -1,0 +1,219 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.metadata.custom
+
+import com.calypsan.listenup.api.dto.ContributorRole
+import com.calypsan.listenup.api.error.MetadataError
+import com.calypsan.listenup.api.metadata.MetadataDomain
+import com.calypsan.listenup.api.metadata.MetadataLocale
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.metadata.EnrichmentCoordinator
+import com.calypsan.listenup.server.metadata.spi.BookCoreMeta
+import com.calypsan.listenup.server.metadata.spi.BookIdentity
+import com.calypsan.listenup.server.metadata.spi.CharacterMeta
+import com.calypsan.listenup.server.metadata.spi.EnrichmentRoutes
+import com.calypsan.listenup.server.metadata.spi.GenreKind
+import com.calypsan.listenup.server.metadata.spi.GenreMeta
+import com.calypsan.listenup.server.metadata.spi.MetadataProviderId
+import com.calypsan.listenup.server.metadata.spi.MetadataProviderRegistry
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.time.Duration
+
+private val US = MetadataLocale("us")
+private val ALL = CustomProviderSpec.SUPPORTED_CAPABILITIES
+
+private val JSON =
+    Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+private fun identity() = BookIdentity(asin = "B01", title = "The Way of Kings", primaryAuthor = "Brandon Sanderson")
+
+/**
+ * Builds a [CustomHttpProvider] over a MockEngine that records every request and responds
+ * per request path via [respondFor]. [capabilities] gates which domains the provider advertises.
+ */
+private fun provider(
+    capabilities: Set<MetadataDomain> = ALL,
+    requests: MutableList<Url> = mutableListOf(),
+    respondFor: (path: String) -> Pair<HttpStatusCode, String> = { HttpStatusCode.OK to "[]" },
+): CustomHttpProvider {
+    val engine =
+        MockEngine { request ->
+            requests += request.url
+            val (status, body) = respondFor(request.url.encodedPath)
+            respond(body, status, headersOf("Content-Type", ContentType.Application.Json.toString()))
+        }
+    val client =
+        CustomMetadataClient(
+            httpClient = HttpClient(engine),
+            json = JSON,
+            baseUrl = "https://custom.test",
+            rateLimiter = CustomRateLimiter(minInterval = Duration.ZERO),
+        )
+    val spec = CustomProviderSpec(MetadataProviderId.custom("mysource"), "mysource", "https://custom.test", capabilities)
+    return CustomHttpProvider(spec, client)
+}
+
+class CustomHttpProviderTest :
+    FunSpec({
+
+        test("getBookCore fetches /book and maps the JSON to BookCoreMeta with credits folded in") {
+            runTest {
+                val captured = mutableListOf<Url>()
+                val core =
+                    provider(requests = captured) { HttpStatusCode.OK to BOOK_JSON }
+                        .getBookCore(identity(), US, refresh = false)
+                        .shouldBeInstanceOf<AppResult.Success<BookCoreMeta?>>()
+                        .data
+                core.shouldNotBeNull()
+                core.title shouldBe "The Way of Kings"
+                core.description shouldBe "Stone and storms."
+                core.runtimeMinutes shouldBe 2734
+                core.authors.map { it.name to it.role } shouldContainExactly listOf("Brandon Sanderson" to ContributorRole.AUTHOR)
+                core.narrators.map { it.name to it.role } shouldContainExactly listOf("Kate Reading" to ContributorRole.NARRATOR)
+
+                // The lookup key params reach the endpoint.
+                val url = captured.single()
+                url.encodedPath shouldBe "/book"
+                url.parameters["asin"] shouldBe "B01"
+                url.parameters["title"] shouldBe "The Way of Kings"
+                url.parameters["author"] shouldBe "Brandon Sanderson"
+                url.parameters["region"] shouldBe "us"
+            }
+        }
+
+        test("getCharacters fetches /characters and maps the JSON to CharacterMeta") {
+            runTest {
+                val characters =
+                    provider { HttpStatusCode.OK to CHARACTERS_JSON }
+                        .getCharacters(identity(), US)
+                        .shouldBeInstanceOf<AppResult.Success<List<CharacterMeta>?>>()
+                        .data
+                characters.shouldNotBeNull()
+                characters.map { it.name } shouldContainExactly listOf("Kaladin", "Shallan")
+                characters.first().description shouldBe "A bridgeman."
+                characters[1].description.shouldBeNull()
+            }
+        }
+
+        test("getGenres maps kind=tag to a free-form tag and everything else to a formal genre") {
+            runTest {
+                val genres =
+                    provider { HttpStatusCode.OK to GENRES_JSON }
+                        .getGenres(identity(), US)
+                        .shouldBeInstanceOf<AppResult.Success<List<GenreMeta>?>>()
+                        .data
+                genres.shouldNotBeNull()
+                genres.map { it.name to it.kind } shouldContainExactly
+                    listOf("Fantasy" to GenreKind.GENRE, "Slow Burn" to GenreKind.TAG)
+            }
+        }
+
+        test("an undeclared capability is an immediate honest miss — no HTTP request is issued") {
+            runTest {
+                val captured = mutableListOf<Url>()
+                val result =
+                    provider(capabilities = setOf(MetadataDomain.CHARACTERS), requests = captured)
+                        .getBookCore(identity(), US, refresh = false)
+
+                result.shouldBeInstanceOf<AppResult.Success<*>>().data.shouldBeNull()
+                captured.shouldBeEmpty()
+            }
+        }
+
+        test("a declared capability whose endpoint 404s is an honest catalog miss, not a failure") {
+            runTest {
+                provider { HttpStatusCode.NotFound to "" }
+                    .getCharacters(identity(), US)
+                    .shouldBeInstanceOf<AppResult.Success<*>>()
+                    .data
+                    .shouldBeNull()
+            }
+        }
+
+        test("a 429 maps to ExternalRateLimited and a 500 to ExternalUnavailable") {
+            runTest {
+                provider { HttpStatusCode.TooManyRequests to "" }
+                    .getCharacters(identity(), US)
+                    .shouldBeInstanceOf<AppResult.Failure>()
+                    .error
+                    .shouldBeInstanceOf<MetadataError.ExternalRateLimited>()
+
+                provider { HttpStatusCode.InternalServerError to "" }
+                    .getCharacters(identity(), US)
+                    .shouldBeInstanceOf<AppResult.Failure>()
+                    .error
+                    .shouldBeInstanceOf<MetadataError.ExternalUnavailable>()
+            }
+        }
+
+        test("unparseable JSON maps to Malformed") {
+            runTest {
+                provider { HttpStatusCode.OK to """{"not":"an-array"}""" }
+                    .getCharacters(identity(), US)
+                    .shouldBeInstanceOf<AppResult.Failure>()
+                    .error
+                    .shouldBeInstanceOf<MetadataError.Malformed>()
+            }
+        }
+
+        test("a configured custom characters source flows through the coordinator when CHARACTERS is routed to it") {
+            runTest {
+                val custom = provider(capabilities = setOf(MetadataDomain.CHARACTERS)) { HttpStatusCode.OK to CHARACTERS_JSON }
+                val routes = EnrichmentRoutes.parse(order = null, routes = "characters=custom:mysource")
+                val coordinator = EnrichmentCoordinator(MetadataProviderRegistry(listOf(custom)), routes)
+
+                coordinator.composeCharacters(identity(), US).map { it.name } shouldContainExactly listOf("Kaladin", "Shallan")
+            }
+        }
+    })
+
+// ─── Fixture JSON (the documented custom-provider contract) ────────────────────
+
+private val BOOK_JSON =
+    """
+    {
+      "title": "The Way of Kings",
+      "subtitle": "Book 1",
+      "description": "Stone and storms.",
+      "publisher": "Macmillan Audio",
+      "releaseDate": "2010-08-31",
+      "language": "english",
+      "runtimeMinutes": 2734,
+      "authors": [ { "key": "A1", "name": "Brandon Sanderson" } ],
+      "narrators": [ { "name": "Kate Reading" } ]
+    }
+    """.trimIndent()
+
+private val CHARACTERS_JSON =
+    """
+    [
+      { "name": "Kaladin", "description": "A bridgeman." },
+      { "name": "Shallan" }
+    ]
+    """.trimIndent()
+
+private val GENRES_JSON =
+    """
+    [
+      { "name": "Fantasy", "kind": "genre" },
+      { "name": "Slow Burn", "kind": "tag" }
+    ]
+    """.trimIndent()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/custom/CustomProviderConfigTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/custom/CustomProviderConfigTest.kt
@@ -1,0 +1,73 @@
+package com.calypsan.listenup.server.metadata.custom
+
+import com.calypsan.listenup.api.metadata.MetadataDomain
+import com.calypsan.listenup.server.metadata.spi.MetadataProviderId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+class CustomProviderConfigTest :
+    FunSpec({
+
+        test("a blank or null value yields no providers") {
+            CustomProviderSpec.parse(null).shouldBeEmpty()
+            CustomProviderSpec.parse("   ").shouldBeEmpty()
+        }
+
+        test("a bare name=baseUrl entry advertises every supported capability") {
+            val spec = CustomProviderSpec.parse("catalog=https://meta.example.com").single()
+            spec.name shouldBe "catalog"
+            spec.id shouldBe MetadataProviderId.custom("catalog")
+            spec.id.value shouldBe "custom:catalog"
+            spec.baseUrl shouldBe "https://meta.example.com"
+            spec.capabilities shouldBe CustomProviderSpec.SUPPORTED_CAPABILITIES
+        }
+
+        test("a |caps suffix narrows the advertised capabilities to the declared domains") {
+            val spec = CustomProviderSpec.parse("mysource=https://x.y|characters,cover").single()
+            spec.capabilities shouldContainExactlyInAnyOrder listOf(MetadataDomain.CHARACTERS, MetadataDomain.COVER)
+        }
+
+        test("a trailing slash on the base URL is trimmed so appended paths stay well-formed") {
+            CustomProviderSpec.parse("s=https://x.y/").single().baseUrl shouldBe "https://x.y"
+        }
+
+        test("multiple semicolon-separated entries parse independently and in order") {
+            val specs = CustomProviderSpec.parse("a=https://a.test|characters; b=https://b.test|genres")
+            specs.map { it.name } shouldContainExactly listOf("a", "b")
+            specs[0].capabilities shouldContainExactly listOf(MetadataDomain.CHARACTERS)
+            specs[1].capabilities shouldContainExactly listOf(MetadataDomain.GENRES)
+        }
+
+        test("a malformed entry with no '=' is skipped, leaving the valid entries") {
+            val specs = CustomProviderSpec.parse("garbage-no-equals; good=https://good.test|characters")
+            specs.map { it.name } shouldContainExactly listOf("good")
+        }
+
+        test("an entry with a blank name or base URL is skipped") {
+            CustomProviderSpec.parse("=https://x.y").shouldBeEmpty()
+            CustomProviderSpec.parse("name=").shouldBeEmpty()
+        }
+
+        test("unknown and unsupported capability tokens are dropped, keeping the valid ones") {
+            // 'contributors' is a real domain but not supported by the custom client; 'bogus' is unknown.
+            val spec = CustomProviderSpec.parse("s=https://x.y|characters,contributors,bogus").single()
+            spec.capabilities shouldContainExactly listOf(MetadataDomain.CHARACTERS)
+        }
+
+        test("an entry whose |caps names no supported capability is skipped entirely") {
+            CustomProviderSpec.parse("s=https://x.y|contributors,chapters").shouldBeEmpty()
+        }
+
+        test("a duplicate name keeps the first entry and skips the rest") {
+            val specs = CustomProviderSpec.parse("dup=https://first.test|characters; dup=https://second.test|genres")
+            specs.single().baseUrl shouldBe "https://first.test"
+            specs.single().capabilities shouldContainExactly listOf(MetadataDomain.CHARACTERS)
+        }
+
+        test("names are lowercased so config and route tokens resolve to the same id") {
+            CustomProviderSpec.parse("MySource=https://x.y").single().id shouldBe MetadataProviderId.custom("mysource")
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/spi/EnrichmentRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/spi/EnrichmentRoutesTest.kt
@@ -117,6 +117,11 @@ class EnrichmentRoutesTest :
             EnrichmentRoutes.parse(order = "   ", routes = "  ;  ; ") shouldBe EnrichmentRoutes.DEFAULT
         }
 
+        test("a custom:<name> token resolves so a route can name an operator's custom provider") {
+            val parsed = EnrichmentRoutes.parse(order = null, routes = "characters=custom:mysource")
+            parsed.domainOrder.getValue(MetadataDomain.CHARACTERS) shouldBe listOf(MetadataProviderId.custom("mysource"))
+        }
+
         test("property: arbitrary garbage never throws and always leaves every domain routable") {
             checkAll(Arb.string(), Arb.string()) { order, routes ->
                 val parsed = EnrichmentRoutes.parse(order = order, routes = routes)


### PR DESCRIPTION
**Step 7 — the final step of the metadata rewrite.** Adds the operator extensibility seam and closes the CHARACTERS slot honestly. Server-internal; no `:contract` change.

## Custom-HTTP provider seam
An operator can now declare their own metadata source via `LISTENUP_CUSTOM_PROVIDERS` (never-strand parse; `name=baseUrl` entries) and have it participate in enrichment like any built-in. Each entry becomes a `CustomHttpProvider` with id `custom:<name>`, routable via `EnrichmentRoutes` exactly like `audible`/`audnexus`/`itunes` (e.g. `LISTENUP_ENRICHMENT_ROUTES=characters=custom:mysource`).

The provider speaks a **thin, documented JSON contract** (`CustomTypes.kt` — the operator's integration surface, fully KDoc'd): `GET {baseUrl}/book|characters|cover|genres|series` returning provider-neutral shapes that map to the SPI `*Meta` types. It implements `BookCoreSource`, `CoverSource`, `SeriesSource`, `GenreSource`, `CharacterSource`; an endpoint 404 is an honest catalog miss (`Success(null/empty)`), so an operator implements only what they have. Own rate limiter; `LISTENUP_CUSTOM_PROVIDERS` self-hostable.

New: `metadata/custom/` — `CustomHttpProvider`, `CustomMetadataClient`, `CustomProviderSpec` (config parse), `CustomRateLimiter`, `CustomTypes` (contract DTOs + mappers).

## CHARACTERS — the honest empty slot
No built-in provider implements `CharacterSource` (there is no public per-book character source — Audnexus has none). The coordinator's `composeCharacters` fans out over `CharacterSource` providers and returns empty by default (`characters=[]`) — so the story is manual character entry, and a custom provider pointed at a character source slots straight in. No fabricated data.

## Verification (fresh worktree)
**Full `:server:jvmTest`** — 2816 tests, only the 2 env `MulticastMdnsResponderTest`. `:contract:jvmTest :sharedLogic:jvmTest`, `:server:compileKotlinLinuxX64`, `spotlessCheck detekt` — green. ktor-mock custom-provider tests (a configured custom characters source flows through the coordinator; a bad config entry is skipped; unconfigured CHARACTERS composes empty).

---
**This completes the 7-step metadata-enrichment rewrite.** The subsystem is now capability-per-domain, field-level-provenance-aware, Audnexus-powered (contributors work again), locale-neutral, and operator-extensible — and the `first { AUDIBLE }` fiction, the graft chains, the closed `MetadataSource` enum, and the dead audible.com scrape are all gone.