### PR TITLE
🐛 fix: harden Campfire session ownership & teardown (F2/F7/F8)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinator.kt
@@ -2,8 +2,10 @@ package com.calypsan.listenup.client.campfire
 
 import com.calypsan.listenup.api.dto.campfire.CampfireId
 import com.calypsan.listenup.api.dto.campfire.CampfirePhase
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 /**
  * A snapshot of the one live Campfire session, as the rest of the app needs to see it.
@@ -31,17 +33,34 @@ internal data class ActiveCampfire(
  * Process-scope holder for the currently-live [ActiveCampfire], or `null` when none.
  *
  * The seam that lets the process-singleton `NowPlayingViewModel` observe campfire liveness without
- * depending on the per-session `CampfireSessionController`/`CampfireViewModel` factories (co-listening
- * coexistence spec, B3). The per-session `CampfireViewModel` is the sole writer — it mirrors its
- * controller's hot state into [set]; readers observe [current]. Registered as a Koin `single`.
+ * depending on the per-screen `CampfireViewModel` (co-listening coexistence spec, B3). Registered as
+ * a Koin `single` alongside the now-`single` [CampfireSessionController]: the coordinator OWNS the
+ * always-on mirror at **process scope** (the injected app-lifetime [CoroutineScope]) rather than a
+ * ViewModel's `viewModelScope`. That is the F2 ownership fix — an activity torn down and rebuilt
+ * (task-swipe while the playback service keeps the process alive) no longer stops the mirror or
+ * strands the live session behind a fresh, empty ViewModel; readers keep seeing the true liveness.
  */
-internal class ActiveCampfireCoordinator {
+internal class ActiveCampfireCoordinator(
+    controller: CampfireSessionController,
+    scope: CoroutineScope,
+) {
     /** The live campfire, or `null` when no session is active. */
     val current: StateFlow<ActiveCampfire?>
         field = MutableStateFlow<ActiveCampfire?>(null)
 
-    /** Publishes the live campfire (or `null` to clear). Called by `CampfireViewModel` on every controller-state change. */
-    fun set(value: ActiveCampfire?) {
-        current.value = value
+    init {
+        // Always-on, process-scope mirror of the single controller's hot state. Independent of any
+        // ViewModel subscription: the singleton NowPlayingViewModel must see liveness at all times.
+        scope.launch {
+            controller.state.collect { current.value = it.toActiveCampfire() }
+        }
     }
 }
+
+/** Only a live/lobby session is guard-worthy; Idle / Joining / Disconnected / Ended → `null`. */
+private fun CampfireUiState.toActiveCampfire(): ActiveCampfire? =
+    if (this is CampfireUiState.Active) {
+        ActiveCampfire(sessionId = sessionId, bookId = bookId, isHost = isHost, phase = phase)
+    } else {
+        null
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
@@ -261,40 +261,68 @@ internal class CampfireSessionController(
         scope.launch { applyAnchorToPlayback(pendingAnchor, nowMs()) }
     }
 
-    /** Leaves the session: stops the frame stream + drift loop and notifies the server. */
-    suspend fun leave() {
-        val sessionId =
-            when (val current = state.value) {
-                is CampfireUiState.Active -> current.sessionId
-                is CampfireUiState.Disconnected -> current.sessionId
-                else -> null
+    /**
+     * Leaves the session: stops the frame stream + drift loop and notifies the server.
+     *
+     * The local teardown (job cancel + [state] → [CampfireUiState.Idle]) is synchronous so readers
+     * observe the exit immediately; the terminal [CampfireTransport.leaveSession] RPC is dispatched
+     * on the controller's own [scope] (appScope in prod), NOT the caller's coroutine — a screen or
+     * ViewModel torn down the instant it calls [leave] (task-swipe) must not strand a live membership
+     * server-side (co-listening coexistence spec, F7). Its result is logged on failure, never dropped.
+     */
+    fun leave() {
+        val sessionId = currentSessionId()
+        teardownLocal()
+        if (sessionId != null) {
+            scope.launch {
+                val result = transport.leaveSession(sessionId)
+                if (result is AppResult.Failure) logger.warn { "Campfire leave failed: ${result.error.code}" }
             }
-        observeJob?.cancel()
-        driftJob?.cancel()
-        pendingCommandIds.value = emptySet()
-        state.value = CampfireUiState.Idle
-        if (sessionId != null) transport.leaveSession(sessionId)
+        }
     }
 
     /**
      * Ends the session for everyone (host-only; the UI gates this behind [CampfireUiState.Active.isHost]).
      * Twin of [leave] but calls [CampfireTransport.endSession] — used when the host chooses to play a
      * different book, which tears the campfire down rather than migrating the host (co-listening
-     * coexistence spec, B3). Local state moves to [CampfireUiState.Idle] first so readers observe the
-     * teardown immediately, regardless of the network round-trip.
+     * coexistence spec, B3). The terminal RPC is dispatched on [scope] with the same anti-stranding
+     * contract as [leave] (F7).
      */
-    suspend fun endCampfire() {
-        val sessionId =
-            when (val current = state.value) {
-                is CampfireUiState.Active -> current.sessionId
-                is CampfireUiState.Disconnected -> current.sessionId
-                else -> null
+    fun endCampfire() {
+        val sessionId = currentSessionId()
+        teardownLocal()
+        if (sessionId != null) {
+            scope.launch {
+                val result = transport.endSession(sessionId)
+                if (result is AppResult.Failure) logger.warn { "Campfire end failed: ${result.error.code}" }
             }
+        }
+    }
+
+    private fun currentSessionId(): CampfireId? =
+        when (val current = state.value) {
+            is CampfireUiState.Active -> current.sessionId
+            is CampfireUiState.Disconnected -> current.sessionId
+            else -> null
+        }
+
+    /** Synchronous local teardown shared by [leave]/[endCampfire]: stop the jobs, clear pending, go Idle. */
+    private fun teardownLocal() {
         observeJob?.cancel()
         driftJob?.cancel()
         pendingCommandIds.value = emptySet()
         state.value = CampfireUiState.Idle
-        if (sessionId != null) transport.endSession(sessionId)
+    }
+
+    /**
+     * Exits the session to make room for solo playback of a different book — the co-listening
+     * coexistence spec's B3 confirm continuation. Re-reads the CURRENT role from [state] rather than
+     * a role snapshotted when the confirm dialog opened: a [CampfireFrame.HostChanged] handoff while
+     * the dialog is up must not make a now-participant [endCampfire] everyone's session (or a
+     * promoted host merely [leave]). Host → ends for all; participant → leaves only.
+     */
+    fun exitForPlayback() {
+        if ((state.value as? CampfireUiState.Active)?.isHost == true) endCampfire() else leave()
     }
 
     /** Resumes room playback (optimistic local apply; denied via [CampfireSessionEvent.ControlDenied] without control). */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionController.kt
@@ -138,6 +138,7 @@ internal class CampfireSessionController(
     suspend fun join(sessionId: CampfireId) {
         state.value = CampfireUiState.Joining(sessionId)
         pendingCommandIds.value = emptySet()
+        drainStaleEvents()
         when (val result = transport.joinSession(sessionId)) {
             is AppResult.Success -> {
                 selfUserId = userRepository.getCurrentUser()?.idString
@@ -196,6 +197,7 @@ internal class CampfireSessionController(
         val sessionId = disconnected.sessionId
         state.value = CampfireUiState.Joining(sessionId)
         pendingCommandIds.value = emptySet()
+        drainStaleEvents()
         transport.refreshConnection()
         when (val result = transport.joinSession(sessionId)) {
             is AppResult.Success -> {
@@ -317,12 +319,19 @@ internal class CampfireSessionController(
     /**
      * Exits the session to make room for solo playback of a different book — the co-listening
      * coexistence spec's B3 confirm continuation. Re-reads the CURRENT role from [state] rather than
-     * a role snapshotted when the confirm dialog opened: a [CampfireFrame.HostChanged] handoff while
-     * the dialog is up must not make a now-participant [endCampfire] everyone's session (or a
-     * promoted host merely [leave]). Host → ends for all; participant → leaves only.
+     * a role snapshotted when the confirm dialog opened: a [CampfireFrame.HostChanged] handoff — or a
+     * drop to [CampfireUiState.Disconnected] — while the dialog is up must not make a host merely
+     * [leave] (stranding everyone else's session) nor a participant [endCampfire] it. Host → ends for
+     * all; participant → leaves only.
      */
     fun exitForPlayback() {
-        if ((state.value as? CampfireUiState.Active)?.isHost == true) endCampfire() else leave()
+        val isHost =
+            when (val current = state.value) {
+                is CampfireUiState.Active -> current.isHost
+                is CampfireUiState.Disconnected -> current.isHost
+                else -> false
+            }
+        if (isHost) endCampfire() else leave()
     }
 
     /** Resumes room playback (optimistic local apply; denied via [CampfireSessionEvent.ControlDenied] without control). */
@@ -552,9 +561,9 @@ internal class CampfireSessionController(
     /** Never pauses local playback — see the Never Stranded note in the class KDoc. Idempotent. */
     private fun handleDisconnect(sessionId: CampfireId) {
         driftJob?.cancel()
-        if (state.value is CampfireUiState.Active) {
-            state.value = CampfireUiState.Disconnected(sessionId = sessionId, keepPlayingSolo = true)
-        }
+        val active = state.value as? CampfireUiState.Active ?: return
+        state.value =
+            CampfireUiState.Disconnected(sessionId = sessionId, keepPlayingSolo = true, isHost = active.isHost)
     }
 
     /**
@@ -595,6 +604,16 @@ internal class CampfireSessionController(
 
     /** Whether the local caller is [hostUserId] — distinct from [hasControl] (see [CampfireUiState.Active.isHost]). */
     private fun isHost(hostUserId: String): Boolean = selfUserId == hostUserId
+
+    /**
+     * Empties any one-shot [events] left buffered by a previous session. Since F2 made this
+     * controller a process-`single`, [eventChannel] outlives individual sessions; without this a
+     * reaction/denial trySent while no screen was collecting would replay into the next session's
+     * UI. Called at each session start ([join]/[rejoin]).
+     */
+    private fun drainStaleEvents() {
+        while (eventChannel.tryReceive().isSuccess) { /* discard */ }
+    }
 
     /** Atomically removes [commandId] from [pendingCommandIds] if present; returns whether it was. */
     private fun consumePendingCommand(commandId: String?): Boolean {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireUiState.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/campfire/CampfireUiState.kt
@@ -82,10 +82,15 @@ internal sealed interface CampfireUiState {
      * unexpectedly (server-side error, or the socket simply dropped) — NOT a graceful [Ended].
      * Per the Never Stranded principle, local playback is left running exactly as it was
      * ([keepPlayingSolo]); [CampfireSessionController.rejoin] re-fetches a fresh snapshot.
+     *
+     * @property isHost The local user's last-known host role, carried across the disconnect so
+     * [CampfireSessionController.exitForPlayback] still ends-for-everyone (vs merely leaves) when a
+     * host confirms "play another book" after the stream dropped mid-dialog.
      */
     data class Disconnected(
         val sessionId: CampfireId,
         val keepPlayingSolo: Boolean = true,
+        val isHost: Boolean = false,
     ) : CampfireUiState
 
     /** The session ended for everyone (host ended it, or the server's idle sweeper reaped it). */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CampfireClientModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CampfireClientModule.kt
@@ -54,13 +54,11 @@ internal val campfireClientModule: Module =
             )
         }
 
-        // ActiveCampfireCoordinator — process-scope liveness seam read by NowPlayingViewModel (B3).
-        single { ActiveCampfireCoordinator() }
-
-        // CampfireSessionController — one per joined session (NOT a singleton). The UI/ViewModel
-        // creates one via get() on join and retains it for the session's duration, calling
-        // leave() when done; there is no instance to release back to Koin.
-        factory {
+        // CampfireSessionController — process-`single` (F2). Only one campfire is live at a time and
+        // its jobs already run on appScope, so a single instance IS the session: any ViewModel
+        // generation (e.g. after an activity rebuild on task-swipe) re-attaches to the same live
+        // controller rather than spawning a fresh, empty one that orphans the running session.
+        single {
             CampfireSessionController(
                 transport = get(),
                 playbackManager = get(),
@@ -70,15 +68,23 @@ internal val campfireClientModule: Module =
             )
         }
 
-        // CampfireViewModel — one per screen instance (factory, matching the CampfireSessionController
-        // it wraps), not a singleton.
+        // ActiveCampfireCoordinator — process-scope liveness seam read by NowPlayingViewModel (B3).
+        // Owns the always-on mirror of the single controller's state on appScope (F2).
+        single {
+            ActiveCampfireCoordinator(
+                controller = get(),
+                scope = get(qualifier = named(APP_SCOPE)),
+            )
+        }
+
+        // CampfireViewModel — one per screen instance (factory). Wraps the single controller; the
+        // liveness mirror lives in the coordinator now, so the VM no longer holds it (F2).
         factory {
             CampfireViewModel(
                 controller = get(),
                 transport = get(),
                 errorBus = get(),
                 userRepository = get(),
-                coordinator = get(),
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.di
 
+import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel
 import org.koin.dsl.module
 
@@ -27,7 +28,9 @@ internal val playbackPresentationModule =
                 documentRepository = get(),
                 downloadRepository = get(),
                 playbackPositionRepository = get(),
-                activeCampfire = get(),
+                // The coordinator (single) owns the process-scope liveness mirror; the VM only needs
+                // to read it. Resolving it here also instantiates the coordinator so its mirror starts.
+                activeCampfire = get<ActiveCampfireCoordinator>().current,
             )
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModel.kt
@@ -12,8 +12,6 @@ import com.calypsan.listenup.api.dto.campfire.CampfireSettings
 import com.calypsan.listenup.api.dto.campfire.ChatMessage
 import com.calypsan.listenup.api.error.AppError
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.client.campfire.ActiveCampfire
-import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.campfire.CampfireSessionController
 import com.calypsan.listenup.client.campfire.CampfireSessionEvent
 import com.calypsan.listenup.client.campfire.CampfireTransport
@@ -61,27 +59,18 @@ private const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
  * @property userRepository Backs [hostDisplayName] — the full-screen Create flow's (task L3) default
  * campfire-name builder needs the caller's own display name reactively, independent of any joined
  * session (the create screen renders before [transport.createSession] is ever called).
- * @property coordinator Process-scope liveness seam ([ActiveCampfireCoordinator]) mirrored from
- * [controller]'s hot state so the singleton `NowPlayingViewModel` can guard "play a different book"
- * against a live campfire (co-listening coexistence spec, B3).
+ *
+ * Note: the process-scope liveness mirror that lets the singleton `NowPlayingViewModel` guard
+ * "play a different book" (B3) now lives in [com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator]
+ * itself (F2), collecting the now-`single` [controller] on the app scope — this VM no longer owns it,
+ * so a torn-down screen can't stop the mirror.
  */
 class CampfireViewModel internal constructor(
     private val controller: CampfireSessionController,
     private val transport: CampfireTransport,
     private val errorBus: ErrorBus,
     private val userRepository: UserRepository,
-    private val coordinator: ActiveCampfireCoordinator,
 ) : ViewModel() {
-    init {
-        // Mirror the controller's hot session state into the process-scope coordinator so the
-        // singleton NowPlayingViewModel can guard "play a different book" against a live campfire
-        // (co-listening coexistence spec, B3). Always-on: liveness is independent of whether any
-        // campfire screen currently subscribes to [state].
-        viewModelScope.launch {
-            controller.state.collect { coordinator.set(it.toActiveCampfire()) }
-        }
-    }
-
     /**
      * Session id awaiting spoiler confirmation before [confirmSpoilerJoin] hands it to
      * [controller] (see [join]'s KDoc for why the gate lives here rather than in the controller).
@@ -217,15 +206,21 @@ class CampfireViewModel internal constructor(
     /** Confirms the pending large-drift resync surfaced by [rejoin] (see [CampfireScreenUiState.Active.pendingRejoinSync]). */
     fun confirmRejoinSync() = controller.confirmRejoinSync()
 
-    /** Leaves the current session. */
-    fun leave() {
-        viewModelScope.launch { controller.leave() }
-    }
+    /**
+     * Leaves the current session. Delegates directly (not via [viewModelScope]) so the controller's
+     * synchronous local teardown and its scope-dispatched leave RPC run even if this VM is being
+     * cleared in the same breath — see [CampfireSessionController.leave] (F7).
+     */
+    fun leave() = controller.leave()
 
     /** Ends the campfire for everyone (host-only — see [CampfireSessionController.endCampfire]). */
-    fun endCampfire() {
-        viewModelScope.launch { controller.endCampfire() }
-    }
+    fun endCampfire() = controller.endCampfire()
+
+    /**
+     * Exits the campfire to play a different book — ends for all if host, leaves if participant,
+     * re-reading the current role at call time (see [CampfireSessionController.exitForPlayback], F8).
+     */
+    fun exitForPlayback() = controller.exitForPlayback()
 
     /** Resumes room playback (optimistic; denied via [CampfireScreenEvent.ControlDenied] without control). */
     fun play() = controller.play()
@@ -318,14 +313,6 @@ private fun CampfireUiState.toScreenState(): CampfireScreenUiState =
         is CampfireUiState.Ended -> {
             CampfireScreenUiState.Ended(sessionId, reason)
         }
-    }
-
-private fun CampfireUiState.toActiveCampfire(): ActiveCampfire? =
-    // Only a live/lobby session is guard-worthy; Idle / Joining / Disconnected / Ended → null.
-    if (this is CampfireUiState.Active) {
-        ActiveCampfire(sessionId = sessionId, bookId = bookId, isHost = isHost, phase = phase)
-    } else {
-        null
     }
 
 private fun CampfireSessionEvent.toScreenEvent(): CampfireScreenEvent =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.api.dto.campfire.CampfirePhase
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
-import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
+import com.calypsan.listenup.client.campfire.ActiveCampfire
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
@@ -86,7 +86,7 @@ class NowPlayingViewModel internal constructor(
     private val documentRepository: DocumentRepository,
     private val downloadRepository: DownloadRepository,
     private val playbackPositionRepository: PlaybackPositionRepository,
-    private val activeCampfire: ActiveCampfireCoordinator,
+    private val activeCampfire: StateFlow<ActiveCampfire?>,
 ) : ViewModel() {
     private companion object {
         const val FADE_DURATION_MS = 3000L
@@ -458,7 +458,7 @@ class NowPlayingViewModel internal constructor(
      * needs a distinct (dialog-less) resolution and is a tracked follow-up, not part of this cut.
      */
     fun playBook(bookId: BookId) {
-        val active = activeCampfire.current.value
+        val active = activeCampfire.value
         if (active != null) {
             if (active.bookId != bookId.value) {
                 _playbackGuardEvents.trySend(PlaybackGuardEvent.ConfirmPlayOverCampfire(bookId, active.isHost))

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/ActiveCampfireCoordinatorTest.kt
@@ -1,24 +1,205 @@
+@file:OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
+
 package com.calypsan.listenup.client.campfire
 
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.campfire.CampfireAnchor
+import com.calypsan.listenup.api.dto.campfire.CampfireControlMode
+import com.calypsan.listenup.api.dto.campfire.CampfireFrame
 import com.calypsan.listenup.api.dto.campfire.CampfireId
+import com.calypsan.listenup.api.dto.campfire.CampfireInvitableUser
 import com.calypsan.listenup.api.dto.campfire.CampfirePhase
+import com.calypsan.listenup.api.dto.campfire.CampfireSettings
+import com.calypsan.listenup.api.dto.campfire.CampfireSnapshot
+import com.calypsan.listenup.api.dto.campfire.OpenCampfireSummary
+import com.calypsan.listenup.api.dto.campfire.PlaybackCommand
+import com.calypsan.listenup.api.error.CampfireError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.streaming.RpcEvent
+import com.calypsan.listenup.client.domain.model.User
+import com.calypsan.listenup.client.domain.repository.UserRepository
+import com.calypsan.listenup.client.test.fake.FakePlaybackController
+import com.calypsan.listenup.client.test.fake.FakePlaybackManager
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
+/**
+ * TDD suite for [ActiveCampfireCoordinator] — the process-scope liveness seam that mirrors the live
+ * [CampfireSessionController]'s state so the singleton `NowPlayingViewModel` can guard "play a
+ * different book" against a live campfire (co-listening coexistence spec, B3 / ownership follow-up
+ * F2). The coordinator OWNS the always-on mirror at process scope; it no longer depends on any
+ * ViewModel being alive.
+ */
 class ActiveCampfireCoordinatorTest :
     FunSpec({
-        test("current starts null") {
-            ActiveCampfireCoordinator().current.value shouldBe null
+
+        val sessionId = CampfireId("cf-1")
+
+        fun snapshot(hostUserId: String = "host-1") =
+            CampfireSnapshot(
+                id = sessionId,
+                bookId = "book-1",
+                settings = CampfireSettings(name = "Campfire", controlMode = CampfireControlMode.EVERYONE, inviteOnly = false),
+                phase = CampfirePhase.LIVE,
+                anchor = CampfireAnchor(0L, 0L, 1.0f, isPlaying = false, stateVersion = 0L),
+                members = emptyList(),
+                hostUserId = hostUserId,
+                recentChat = emptyList(),
+                yourPositionMs = null,
+                spoilerAhead = false,
+                startedAtEpochMs = null,
+                invitedPending = emptyList(),
+            )
+
+        fun controller(
+            transport: FakeCoordinatorTransport,
+            scope: CoroutineScope,
+            selfUserId: String = "self-1",
+        ) = CampfireSessionController(
+            transport = transport,
+            playbackManager = FakePlaybackManager(),
+            playbackController = FakePlaybackController(),
+            userRepository = FakeUserRepo(selfUserId),
+            scope = scope,
+            clock = FixedClock,
+            mainDispatcher = Dispatchers.Unconfined,
+        )
+
+        test("current starts null with no live session") {
+            runTest {
+                val controller = controller(FakeCoordinatorTransport(), backgroundScope)
+                val coordinator = ActiveCampfireCoordinator(controller, backgroundScope)
+                runCurrent()
+
+                coordinator.current.value shouldBe null
+            }
         }
 
-        test("set publishes the active campfire, set(null) clears it") {
-            val coordinator = ActiveCampfireCoordinator()
-            val active = ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE)
+        test("mirrors the controller's live session onto current, driven on the injected scope") {
+            runTest {
+                val transport = FakeCoordinatorTransport().apply { joinResult = AppResult.Success(snapshot()) }
+                val controller = controller(transport, backgroundScope)
+                val coordinator = ActiveCampfireCoordinator(controller, backgroundScope)
 
-            coordinator.set(active)
-            coordinator.current.value shouldBe active
+                controller.join(sessionId)
+                runCurrent()
 
-            coordinator.set(null)
-            coordinator.current.value shouldBe null
+                coordinator.current.value shouldBe
+                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false, phase = CampfirePhase.LIVE)
+            }
+        }
+
+        test("clears current when the session leaves") {
+            runTest {
+                val transport = FakeCoordinatorTransport().apply { joinResult = AppResult.Success(snapshot()) }
+                val controller = controller(transport, backgroundScope)
+                val coordinator = ActiveCampfireCoordinator(controller, backgroundScope)
+
+                controller.join(sessionId)
+                runCurrent()
+                controller.leave()
+                runCurrent()
+
+                coordinator.current.value shouldBe null
+            }
         }
     })
+
+/** Minimal [CampfireTransport] for the coordinator suite — only the calls the controller makes on join/leave. */
+private class FakeCoordinatorTransport : CampfireTransport {
+    var joinResult: AppResult<CampfireSnapshot> = AppResult.Failure(CampfireError.CampfireNotFound())
+    private val frameFlow = MutableSharedFlow<RpcEvent<CampfireFrame>>(extraBufferCapacity = 64)
+
+    override suspend fun joinSession(sessionId: CampfireId): AppResult<CampfireSnapshot> = joinResult
+
+    override fun observeSession(sessionId: CampfireId): Flow<RpcEvent<CampfireFrame>> = frameFlow
+
+    override suspend fun leaveSession(sessionId: CampfireId): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun endSession(sessionId: CampfireId): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun refreshConnection() = Unit
+
+    override suspend fun createSession(
+        bookId: String,
+        settings: CampfireSettings,
+    ): AppResult<CampfireSnapshot> = throw NotImplementedError()
+
+    override suspend fun startSession(sessionId: CampfireId): AppResult<Unit> = throw NotImplementedError()
+
+    override suspend fun updateSettings(
+        sessionId: CampfireId,
+        settings: CampfireSettings,
+    ): AppResult<CampfireSnapshot> = throw NotImplementedError()
+
+    override suspend fun transferHost(
+        sessionId: CampfireId,
+        userId: String,
+    ): AppResult<Unit> = throw NotImplementedError()
+
+    override suspend fun setControlMode(
+        sessionId: CampfireId,
+        mode: CampfireControlMode,
+    ): AppResult<Unit> = throw NotImplementedError()
+
+    override suspend fun sendCommand(
+        sessionId: CampfireId,
+        command: PlaybackCommand,
+    ): AppResult<Unit> = throw NotImplementedError()
+
+    override suspend fun sendChat(
+        sessionId: CampfireId,
+        text: String,
+    ): AppResult<Unit> = throw NotImplementedError()
+
+    override suspend fun sendReaction(
+        sessionId: CampfireId,
+        emoji: String,
+    ): AppResult<Unit> = throw NotImplementedError()
+
+    override suspend fun listOpenSessions(): AppResult<List<OpenCampfireSummary>> = throw NotImplementedError()
+
+    override suspend fun listInvitableUsers(bookId: String): AppResult<List<CampfireInvitableUser>> = throw NotImplementedError()
+}
+
+private class FakeUserRepo(
+    private val selfUserId: String?,
+) : UserRepository {
+    private fun currentUser(): User? =
+        selfUserId?.let {
+            User(
+                id = UserId(it),
+                email = "$it@example.test",
+                displayName = it,
+                isAdmin = false,
+                createdAtMs = 0L,
+                updatedAtMs = 0L,
+            )
+        }
+
+    override fun observeCurrentUser(): Flow<User?> = kotlinx.coroutines.flow.flowOf(currentUser())
+
+    override fun observeIsAdmin(): Flow<Boolean> = throw NotImplementedError()
+
+    override suspend fun getCurrentUser(): User? = currentUser()
+
+    override suspend fun saveUser(user: User): Unit = throw NotImplementedError()
+
+    override suspend fun clearUsers(): Unit = throw NotImplementedError()
+
+    override suspend fun refreshCurrentUser(): User? = throw NotImplementedError()
+}
+
+private object FixedClock : Clock {
+    override fun now(): Instant = Instant.fromEpochMilliseconds(0L)
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
@@ -625,6 +625,83 @@ class CampfireSessionControllerTest :
             }
         }
 
+        test("exitForPlayback still ends the campfire when the host disconnected while the confirm was open") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport =
+                    FakeCampfireTransport().apply { joinResult = AppResult.Success(snapshot(hostUserId = "self-1")) }
+                val sut = controller(transport, backgroundScope, clock, selfUserId = "self-1")
+                sut.join(sessionId)
+                runCurrent()
+
+                // The frame stream drops → Disconnected, but the play-over-campfire confirm dialog is
+                // still open. A host confirming "end for everyone" must still END, not silently leave.
+                transport.emit(RpcEvent.Error(CampfireError.CampfireNotFound()))
+                runCurrent()
+                sut.state.value.shouldBeInstanceOf<CampfireUiState.Disconnected>()
+
+                sut.exitForPlayback()
+                runCurrent()
+
+                transport.endCalls shouldBe listOf(sessionId)
+                transport.leaveCalls shouldBe emptyList()
+            }
+        }
+
+        test("join drains stale one-shot events left buffered by a previous session on the singleton controller") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport = FakeCampfireTransport().apply { joinResult = AppResult.Success(snapshot()) }
+                val sut = controller(transport, backgroundScope, clock)
+                sut.join(sessionId)
+                runCurrent()
+
+                // A reaction arrives with no events collector (the campfire screen is gone) → it buffers
+                // on the controller's channel, which now outlives the session (F2 made it a singleton).
+                transport.emit(RpcEvent.Data(CampfireFrame.Reaction("ghost", "🔥")))
+                runCurrent()
+                sut.leave()
+                runCurrent()
+
+                // A fresh session on the SAME controller must not replay the previous session's events.
+                sut.join(sessionId)
+                runCurrent()
+                sut.events.test {
+                    transport.emit(RpcEvent.Data(CampfireFrame.Reaction("live", "✨")))
+                    awaitItem() shouldBe CampfireSessionEvent.ReactionReceived("live", "✨")
+                }
+            }
+        }
+
+        test("a second join on the singleton controller yields a clean Active state with no bleed from the first") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport = FakeCampfireTransport()
+                val sut = controller(transport, backgroundScope, clock, selfUserId = "self-1")
+
+                // Session 1: the local user is the host.
+                transport.joinResult = AppResult.Success(snapshot(hostUserId = "self-1"))
+                sut.join(sessionId)
+                runCurrent()
+                (sut.state.value as CampfireUiState.Active).isHost shouldBe true
+                sut.leave()
+                runCurrent()
+
+                // Session 2 (different room) where the local user is NOT the host — the reused
+                // singleton must reflect ONLY session 2, with no host role or ids carried over.
+                val other = CampfireId("cf-2")
+                transport.joinResult =
+                    AppResult.Success(snapshot(hostUserId = "someone-else").copy(id = other, bookId = "book-2"))
+                sut.join(other)
+                runCurrent()
+
+                val active = sut.state.value as CampfireUiState.Active
+                active.sessionId shouldBe other
+                active.bookId shouldBe "book-2"
+                active.isHost shouldBe false
+            }
+        }
+
         // ── Lobby phase (2026-07-11 amendment) ───────────────────────────────
 
         test("join with a LOBBY snapshot does not touch local playback") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/campfire/CampfireSessionControllerTest.kt
@@ -548,6 +548,83 @@ class CampfireSessionControllerTest :
             }
         }
 
+        test("leave dispatches the server leaveSession on the controller scope, not the calling coroutine") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport = FakeCampfireTransport().apply { joinResult = AppResult.Success(snapshot()) }
+                val sut = controller(transport, backgroundScope, clock)
+                sut.join(sessionId)
+                runCurrent()
+
+                sut.leave()
+
+                // State flips immediately so readers see the teardown; the terminal RPC is handed to
+                // the controller's own scope (appScope in prod) so a torn-down caller can't strand it.
+                sut.state.value shouldBe CampfireUiState.Idle
+                transport.leaveCalls shouldBe emptyList()
+                runCurrent()
+                transport.leaveCalls shouldBe listOf(sessionId)
+            }
+        }
+
+        test("endCampfire dispatches the server endSession on the controller scope, not the calling coroutine") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport = FakeCampfireTransport().apply { joinResult = AppResult.Success(snapshot()) }
+                val sut = controller(transport, backgroundScope, clock)
+                sut.join(sessionId)
+                runCurrent()
+
+                sut.endCampfire()
+
+                sut.state.value shouldBe CampfireUiState.Idle
+                transport.endCalls shouldBe emptyList()
+                runCurrent()
+                transport.endCalls shouldBe listOf(sessionId)
+            }
+        }
+
+        test("exitForPlayback ends the campfire when the local user is currently the host") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport =
+                    FakeCampfireTransport().apply { joinResult = AppResult.Success(snapshot(hostUserId = "self-1")) }
+                val sut = controller(transport, backgroundScope, clock, selfUserId = "self-1")
+                sut.join(sessionId)
+                runCurrent()
+                (sut.state.value as CampfireUiState.Active).isHost shouldBe true
+
+                sut.exitForPlayback()
+                runCurrent()
+
+                transport.endCalls shouldBe listOf(sessionId)
+                transport.leaveCalls shouldBe emptyList()
+            }
+        }
+
+        test("exitForPlayback leaves — not ends — after a host transfer makes the local user a participant") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val transport =
+                    FakeCampfireTransport().apply { joinResult = AppResult.Success(snapshot(hostUserId = "self-1")) }
+                val sut = controller(transport, backgroundScope, clock, selfUserId = "self-1")
+                sut.join(sessionId)
+                runCurrent()
+
+                // The host hands control to someone else — the local user is now a participant, so
+                // exiting to play another book must LEAVE, not END everyone's session.
+                transport.emit(RpcEvent.Data(CampfireFrame.HostChanged("other-user")))
+                runCurrent()
+                (sut.state.value as CampfireUiState.Active).isHost shouldBe false
+
+                sut.exitForPlayback()
+                runCurrent()
+
+                transport.leaveCalls shouldBe listOf(sessionId)
+                transport.endCalls shouldBe emptyList()
+            }
+        }
+
         // ── Lobby phase (2026-07-11 amendment) ───────────────────────────────
 
         test("join with a LOBBY snapshot does not touch local playback") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/campfire/CampfireViewModelTest.kt
@@ -19,8 +19,6 @@ import com.calypsan.listenup.api.error.CampfireError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.streaming.RpcEvent
-import com.calypsan.listenup.client.campfire.ActiveCampfire
-import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.campfire.CampfireSessionController
 import com.calypsan.listenup.client.campfire.CampfireTransport
 import com.calypsan.listenup.client.domain.model.User
@@ -82,7 +80,6 @@ class CampfireViewModelTest :
             val transport = FakeCampfireTransport()
             val errorBus = ErrorBus()
             val userRepository = FakeUserRepository("self-1")
-            val coordinator = ActiveCampfireCoordinator()
 
             fun build(scope: TestScope): CampfireViewModel {
                 val controller =
@@ -100,7 +97,6 @@ class CampfireViewModelTest :
                     transport = transport,
                     errorBus = errorBus,
                     userRepository = userRepository,
-                    coordinator = coordinator,
                 )
             }
         }
@@ -318,56 +314,6 @@ class CampfireViewModelTest :
 
                 viewModel.state.value.shouldBeInstanceOf<CampfireScreenUiState.Idle>()
                 fixture.transport.leaveCalls shouldBe listOf(sessionId)
-            }
-        }
-
-        test("publishes ActiveCampfire to the coordinator when the session goes Active") {
-            runTest {
-                val fixture = Fixture()
-                fixture.transport.joinResult = AppResult.Success(snapshot())
-                val viewModel = fixture.build(this)
-                keepStateHot(viewModel)
-
-                viewModel.join(sessionId)
-                advanceUntilIdle()
-
-                fixture.coordinator.current.value shouldBe
-                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false, phase = CampfirePhase.LIVE)
-            }
-        }
-
-        // Proves the coordinator collector is ALWAYS-ON (viewModelScope), independent of any
-        // WhileSubscribed subscriber to viewModel.state — deliberately NO keepStateHot. This is the
-        // whole point of the seam: the process-singleton NowPlayingViewModel must see liveness even
-        // when no campfire screen is observing the VM's public state.
-        test("publishes to the coordinator with no subscriber to the VM's public state") {
-            runTest {
-                val fixture = Fixture()
-                fixture.transport.joinResult = AppResult.Success(snapshot())
-                val viewModel = fixture.build(this)
-
-                viewModel.join(sessionId)
-                advanceUntilIdle()
-
-                fixture.coordinator.current.value shouldBe
-                    ActiveCampfire(sessionId = sessionId, bookId = "book-1", isHost = false, phase = CampfirePhase.LIVE)
-            }
-        }
-
-        test("clears the coordinator when the session leaves") {
-            runTest {
-                val fixture = Fixture()
-                fixture.transport.joinResult = AppResult.Success(snapshot())
-                val viewModel = fixture.build(this)
-                keepStateHot(viewModel)
-
-                viewModel.join(sessionId)
-                advanceUntilIdle()
-
-                viewModel.leave()
-                advanceUntilIdle()
-
-                fixture.coordinator.current.value shouldBe null
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
@@ -3,7 +3,8 @@
 package com.calypsan.listenup.client.presentation.nowplaying
 
 import app.cash.turbine.test
-import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
+import com.calypsan.listenup.client.campfire.ActiveCampfire
+import kotlinx.coroutines.flow.MutableStateFlow
 import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.repository.BookRepository
@@ -84,7 +85,7 @@ class NowPlayingProgressIsolationTest :
                 playbackPositionRepository =
                     com.calypsan.listenup.client.test.fake
                         .FakePlaybackPositionRepository(),
-                activeCampfire = ActiveCampfireCoordinator(),
+                activeCampfire = MutableStateFlow<ActiveCampfire?>(null),
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingTeardownTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingTeardownTest.kt
@@ -3,7 +3,8 @@ package com.calypsan.listenup.client.presentation.nowplaying
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
-import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
+import com.calypsan.listenup.client.campfire.ActiveCampfire
+import kotlinx.coroutines.flow.MutableStateFlow
 import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.BookListItem
@@ -101,7 +102,7 @@ class NowPlayingTeardownTest :
                 documentRepository = documentRepository,
                 downloadRepository = downloadRepository,
                 playbackPositionRepository = positionRepository,
-                activeCampfire = ActiveCampfireCoordinator(),
+                activeCampfire = MutableStateFlow<ActiveCampfire?>(null),
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -5,7 +5,6 @@ import com.calypsan.listenup.api.dto.campfire.CampfirePhase
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.campfire.ActiveCampfire
-import com.calypsan.listenup.client.campfire.ActiveCampfireCoordinator
 import com.calypsan.listenup.client.domain.model.BookDocument
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
@@ -76,7 +75,7 @@ class NowPlayingViewModelTest :
             val networkMonitor: NetworkMonitor = mock()
             val documentRepository: DocumentRepository = mock()
             val sleepTimerManager: SleepTimerManager = SleepTimerManager(CoroutineScope(Job()))
-            val activeCampfire = ActiveCampfireCoordinator()
+            val activeCampfire = MutableStateFlow<ActiveCampfire?>(null)
 
             init {
                 // Default: networkMonitor.isOnline() returns true. Tests override to false where needed.
@@ -309,9 +308,8 @@ class NowPlayingViewModelTest :
             runTest(testDispatcher) {
                 val fixture = TestFixture()
                 val bookId = BookId("book-1")
-                fixture.activeCampfire.set(
-                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE),
-                )
+                fixture.activeCampfire.value =
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE)
                 fixture.fakePm.stubbedPrepareResult = stubPrepareResult(bookId)
                 everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
 
@@ -327,9 +325,8 @@ class NowPlayingViewModelTest :
             runTest(testDispatcher) {
                 val fixture = TestFixture()
                 val bookId = BookId("book-1")
-                fixture.activeCampfire.set(
-                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LOBBY),
-                )
+                fixture.activeCampfire.value =
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LOBBY)
 
                 val vm = fixture.newVm()
                 vm.playbackGuardEvents.test {
@@ -350,9 +347,8 @@ class NowPlayingViewModelTest :
         test("playBook on a different book as host emits an end-confirm and does not play") {
             runTest(testDispatcher) {
                 val fixture = TestFixture()
-                fixture.activeCampfire.set(
-                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE),
-                )
+                fixture.activeCampfire.value =
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE)
 
                 val vm = fixture.newVm()
                 vm.playbackGuardEvents.test {
@@ -373,9 +369,8 @@ class NowPlayingViewModelTest :
         test("playBook on a different book as participant emits a leave-confirm") {
             runTest(testDispatcher) {
                 val fixture = TestFixture()
-                fixture.activeCampfire.set(
-                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = false, phase = CampfirePhase.LIVE),
-                )
+                fixture.activeCampfire.value =
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = false, phase = CampfirePhase.LIVE)
 
                 val vm = fixture.newVm()
                 vm.playbackGuardEvents.test {
@@ -389,9 +384,8 @@ class NowPlayingViewModelTest :
             runTest(testDispatcher) {
                 val fixture = TestFixture()
                 val bookId = BookId("book-2")
-                fixture.activeCampfire.set(
-                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE),
-                )
+                fixture.activeCampfire.value =
+                    ActiveCampfire(CampfireId("cf-1"), bookId = "book-1", isHost = true, phase = CampfirePhase.LIVE)
                 fixture.fakePm.stubbedPrepareResult = stubPrepareResult(bookId)
                 everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -882,7 +882,9 @@ private fun PlayOverCampfireDialog(
         },
         confirmButton = {
             TextButton(onClick = {
-                if (event.isHost) campfireViewModel.endCampfire() else campfireViewModel.leave()
+                // Re-reads the current role (a host handoff may have happened while this dialog was
+                // open) rather than trusting event.isHost, which is only cosmetic copy here (F8).
+                campfireViewModel.exitForPlayback()
                 nowPlayingViewModel.playBookConfirmed(event.bookId)
                 playOverCampfire = null
             }) {


### PR DESCRIPTION
Completes the three held review follow-ups (F2/F7/F8) on the Campfire co-listening feature — the post-#1100 controller pass. All device-independent and unit-tested.

## What & why

**F2 — process-scoped session ownership.** `CampfireSessionController` was a Koin `factory`, so a new `CampfireViewModel` generation (e.g. an Android activity rebuild on task-swipe while the playback foreground service keeps the process alive) would `get()` a *fresh, empty* controller — orphaning the still-running session (its jobs live on `appScope`) behind a ViewModel that shows no campfire. It's now a `single`: any VM generation re-attaches to the same live controller. The always-on liveness mirror moved off `CampfireViewModel.viewModelScope` into `ActiveCampfireCoordinator` (a `single`), which self-mirrors the controller's state on the app scope. `NowPlayingViewModel` now depends on the minimal `StateFlow<ActiveCampfire?>` view rather than the whole coordinator.

**F7 — teardown never stranded.** `leave()`/`endCampfire()` do synchronous local teardown (cancel jobs, `state` → `Idle`) then dispatch the terminal `leaveSession`/`endSession` RPC on the controller's own `appScope` — not the caller's coroutine — so a screen torn down the instant it leaves can't strand a live membership server-side. Failed results are logged, never silently dropped.

**F8 — re-read role at confirm.** New `exitForPlayback()` reads the *current* host role (from `Active` or `Disconnected`) rather than a role snapshotted when the "play over campfire" dialog opened. A host handoff — or a stream drop mid-dialog — no longer makes a host silently *leave* (stranding everyone else) or a participant *end* the session.

## Review follow-ups (2nd commit)

- `exitForPlayback` now survives an `Active → Disconnected` transition while the confirm dialog is open (`isHost` is carried onto `Disconnected`).
- The now-singleton controller drains stale one-shot events on each `join`/`rejoin`, so a buffered reaction/denial from a previous session can't replay into the next one.

## Testing

TDD throughout — every fix has a failing-test-first. New/updated unit tests cover: coordinator self-mirror on the injected scope; controller-as-single clean re-join (no state bleed); F7 scope-dispatch ordering; F8 host / host-transfer-to-participant / disconnected-host; stale-event drain.

Green locally: full `:sharedLogic:jvmTest` (incl. all Konsist rules, run in a worktree-free checkout), both Android host-test suites, `:androidApp:assembleDebug`, and the iOS build (device Release + simulator Debug both compile). The Swift-Export surface is confirmed unchanged — 549 exported types, identical set to the committed baseline (the local Mac inventory's only diff is a known locale-collation *ordering* artifact over 22 unrelated, non-campfire type names; CI's canonical-locale run against the same baseline passes). Server / contract untouched.
