### PR TITLE
🎨 fix(sharedUI): campfire flow uses Material You dynamic color, not brand orange

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/theme/Theme.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/theme/Theme.kt
@@ -44,6 +44,13 @@ private val ExpressiveShapes =
 val LocalDarkTheme = staticCompositionLocalOf { false }
 
 /**
+ * Composition local exposing whether dynamic color (Material You) is currently enabled, so a
+ * sub-tree that re-themes itself (e.g. the always-dark Campfire flow) can honor the user's setting
+ * rather than forcing dynamic color on.
+ */
+val LocalDynamicColor = staticCompositionLocalOf { true }
+
+/**
  * Platform-specific color scheme selection.
  *
  * On Android 12+: Uses dynamic color from system wallpaper when dynamicColor is true.
@@ -78,7 +85,10 @@ fun ListenUpTheme(
 ) {
     val colorScheme = platformColorScheme(darkTheme, dynamicColor)
 
-    CompositionLocalProvider(LocalDarkTheme provides darkTheme) {
+    CompositionLocalProvider(
+        LocalDarkTheme provides darkTheme,
+        LocalDynamicColor provides dynamicColor,
+    ) {
         MaterialExpressiveTheme(
             colorScheme = colorScheme,
             motionScheme = MotionScheme.expressive(),

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireAmbientChat.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireAmbientChat.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -159,14 +160,15 @@ internal fun CampfireAmbientChat(
                             Modifier
                                 .size(34.dp)
                                 .clip(CircleShape)
-                                .background(if (draft.isNotBlank()) CampfireFlowColors.Coral else Color(0x1FFFFFFF))
-                                .clickable(enabled = draft.isNotBlank()) { send() },
+                                .background(
+                                    if (draft.isNotBlank()) MaterialTheme.colorScheme.primary else Color(0x1FFFFFFF),
+                                ).clickable(enabled = draft.isNotBlank()) { send() },
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             Icons.AutoMirrored.Filled.Send,
                             contentDescription = null,
-                            tint = Color.White,
+                            tint = MaterialTheme.colorScheme.onPrimary,
                             modifier = Modifier.size(17.dp),
                         )
                     }
@@ -177,16 +179,16 @@ internal fun CampfireAmbientChat(
                         unfocusedTextColor = CampfireFlowColors.OnGlass,
                         focusedContainerColor = CampfireFlowColors.Glass.copy(alpha = 0.55f),
                         unfocusedContainerColor = CampfireFlowColors.Glass.copy(alpha = 0.55f),
-                        focusedBorderColor = CampfireFlowColors.Coral,
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
                         unfocusedBorderColor = CampfireFlowColors.GlassBorder,
                         unfocusedPlaceholderColor = CampfireFlowColors.OnGlassFaint,
                         focusedPlaceholderColor = CampfireFlowColors.OnGlassFaint,
-                        cursorColor = CampfireFlowColors.CoralBright,
+                        cursorColor = MaterialTheme.colorScheme.primary,
                     ),
             )
             val addButtonColor =
                 if (pickerOpen) {
-                    CampfireFlowColors.Coral.copy(
+                    MaterialTheme.colorScheme.primary.copy(
                         alpha = 0.3f,
                     )
                 } else {
@@ -208,7 +210,7 @@ internal fun CampfireAmbientChat(
                     Modifier
                         .size(46.dp)
                         .clip(CircleShape)
-                        .background(CampfireFlowColors.Coral.copy(alpha = 0.28f))
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.28f))
                         .clickable { onQuickReact(quickEmoji) },
                 contentAlignment = Alignment.Center,
             ) {
@@ -225,7 +227,7 @@ private fun CampfireFeedRowView(row: CampfireFeedRow) {
             Box(
                 modifier =
                     Modifier.background(
-                        CampfireFlowColors.Coral.copy(alpha = 0.18f),
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.18f),
                         RoundedCornerShape(percent = 50),
                     ),
             ) {
@@ -252,7 +254,7 @@ private fun CampfireFeedRowView(row: CampfireFeedRow) {
                     Column {
                         Text(
                             text = row.senderName,
-                            color = if (row.isSelf) CampfireFlowColors.CoralBright else CampfireFlowColors.OnGlass,
+                            color = if (row.isSelf) MaterialTheme.colorScheme.primary else CampfireFlowColors.OnGlass,
                             fontWeight = FontWeight.Bold,
                             fontSize = 12.sp,
                         )

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireBackdrop.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireBackdrop.kt
@@ -49,6 +49,8 @@ import com.calypsan.listenup.client.campfire.flameLickColor
 import com.calypsan.listenup.client.campfire.flameRadiusScale
 import com.calypsan.listenup.client.campfire.glowLayerCenteringOffsetPx
 import com.calypsan.listenup.client.campfire.glowValue
+import com.calypsan.listenup.client.design.theme.ListenUpTheme
+import com.calypsan.listenup.client.design.theme.LocalDynamicColor
 import kotlinx.coroutines.isActive
 import kotlin.math.PI
 import kotlin.math.abs
@@ -276,7 +278,16 @@ internal fun CampfireBackdrop(
         // Legibility scrim: darkest at the top where header chrome sits, fading toward the fire glow.
         Box(modifier = Modifier.fillMaxSize().background(CampfireScrimBrush))
 
-        content()
+        // The Campfire flow is always a night scene, regardless of the app's light/dark setting — so
+        // its content re-themes into the dark dynamic scheme here rather than inheriting whatever
+        // scheme is ambient at the call site (see this file's KDoc).
+        val backdropScope = this
+        ListenUpTheme(
+            darkTheme = true,
+            dynamicColor = LocalDynamicColor.current,
+        ) {
+            with(backdropScope) { content() }
+        }
     }
 }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireCreateScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireCreateScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -31,7 +32,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -193,7 +193,7 @@ internal fun CampfireCreateScreen(
                         Icon(
                             Icons.Default.LocalFireDepartment,
                             contentDescription = null,
-                            tint = Color.White,
+                            tint = MaterialTheme.colorScheme.onPrimary,
                         )
                     },
                     modifier =
@@ -228,7 +228,7 @@ private fun CampfireBookStrip(book: CampfireFlowBook) {
             Column {
                 Text(
                     text = stringResource(Res.string.campfire_flow_listening_to),
-                    color = CampfireFlowColors.CoralBright,
+                    color = MaterialTheme.colorScheme.primary,
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 10.5.sp,
                     letterSpacing = 1.sp,
@@ -293,9 +293,9 @@ private fun CampfireNameField(
                 unfocusedTextColor = CampfireFlowColors.OnGlass,
                 focusedContainerColor = CampfireFlowColors.Glass.copy(alpha = 0.62f),
                 unfocusedContainerColor = CampfireFlowColors.Glass.copy(alpha = 0.62f),
-                focusedBorderColor = CampfireFlowColors.Coral,
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
                 unfocusedBorderColor = CampfireFlowColors.GlassBorder,
-                cursorColor = CampfireFlowColors.CoralBright,
+                cursorColor = MaterialTheme.colorScheme.primary,
             ),
     )
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireFlowStyle.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireFlowStyle.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,8 +39,6 @@ import androidx.compose.ui.unit.sp
  * always a night scene.
  */
 internal object CampfireFlowColors {
-    val Coral = Color(0xFFF0512F)
-    val CoralBright = Color(0xFFFF6A3D)
     val NightTop = Color(0xFF07060D)
     val NightBottom = Color(0xFF14101A)
     val Glass = Color(0xFF16111C)
@@ -99,9 +98,11 @@ internal fun CampfireFireButton(
     isLoading: Boolean = false,
     leadingIcon: (@Composable () -> Unit)? = null,
 ) {
+    val primary = MaterialTheme.colorScheme.primary
+    val onPrimary = MaterialTheme.colorScheme.onPrimary
     val brush =
         if (enabled) {
-            Brush.linearGradient(listOf(CampfireFlowColors.CoralBright, CampfireFlowColors.Coral))
+            Brush.linearGradient(listOf(primary, primary))
         } else {
             Brush.linearGradient(listOf(Color(0x1FFFFFFF), Color(0x1FFFFFFF)))
         }
@@ -117,7 +118,7 @@ internal fun CampfireFireButton(
             contentAlignment = Alignment.Center,
         ) {
             if (isLoading) {
-                CircularProgressIndicator(modifier = Modifier.size(22.dp), color = CampfireFlowColors.OnGlass)
+                CircularProgressIndicator(modifier = Modifier.size(22.dp), color = onPrimary)
             } else {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(9.dp),
@@ -127,7 +128,7 @@ internal fun CampfireFireButton(
                     leadingIcon?.invoke()
                     Text(
                         text = text,
-                        color = if (enabled) CampfireFlowColors.OnGlass else CampfireFlowColors.OnGlassMuted,
+                        color = if (enabled) onPrimary else CampfireFlowColors.OnGlassMuted,
                         fontWeight = FontWeight.Bold,
                         fontSize = 16.5.sp,
                     )
@@ -182,7 +183,7 @@ internal fun CampfireFlowHeader(
         androidx.compose.foundation.layout.Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = eyebrow,
-                color = CampfireFlowColors.CoralBright,
+                color = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.ExtraBold,
                 fontSize = 11.5.sp,
                 letterSpacing = 1.4.sp,
@@ -234,12 +235,12 @@ internal fun <T> CampfireSegmentedControl(
                     onClick = { onSelect(value) },
                     modifier = Modifier.weight(1f).height(40.dp),
                     shape = RoundedCornerShape(10.dp),
-                    color = if (isSelected) CampfireFlowColors.Coral else Color.Transparent,
+                    color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         Text(
                             text = label,
-                            color = CampfireFlowColors.OnGlass,
+                            color = if (isSelected) MaterialTheme.colorScheme.onPrimary else CampfireFlowColors.OnGlass,
                             fontWeight = if (isSelected) FontWeight.ExtraBold else FontWeight.Medium,
                             fontSize = 13.5.sp,
                         )
@@ -273,8 +274,8 @@ internal fun CampfireToggleRow(
             onCheckedChange = onCheckedChange,
             colors =
                 androidx.compose.material3.SwitchDefaults.colors(
-                    checkedTrackColor = CampfireFlowColors.Coral,
-                    checkedThumbColor = CampfireFlowColors.OnGlass,
+                    checkedTrackColor = MaterialTheme.colorScheme.primary,
+                    checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
                     uncheckedTrackColor = Color(0x2EFFFFFF),
                     uncheckedThumbColor = CampfireFlowColors.OnGlass,
                 ),

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireInviteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireInviteScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -167,11 +168,11 @@ private fun CampfireInviteSearchField(
                 unfocusedTextColor = CampfireFlowColors.OnGlass,
                 focusedContainerColor = CampfireFlowColors.Glass.copy(alpha = 0.62f),
                 unfocusedContainerColor = CampfireFlowColors.Glass.copy(alpha = 0.62f),
-                focusedBorderColor = CampfireFlowColors.Coral,
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
                 unfocusedBorderColor = CampfireFlowColors.GlassBorder,
                 unfocusedPlaceholderColor = CampfireFlowColors.OnGlassFaint,
                 focusedPlaceholderColor = CampfireFlowColors.OnGlassFaint,
-                cursorColor = CampfireFlowColors.CoralBright,
+                cursorColor = MaterialTheme.colorScheme.primary,
             ),
     )
 }
@@ -188,7 +189,7 @@ private fun CampfireInviteBody(
     when (inviteState) {
         CampfireInviteUiState.Idle, CampfireInviteUiState.Loading -> {
             Box(modifier = Modifier.fillMaxWidth().padding(top = 32.dp), contentAlignment = Alignment.TopCenter) {
-                CircularProgressIndicator(color = CampfireFlowColors.CoralBright)
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
             }
         }
 
@@ -250,14 +251,14 @@ private fun CampfireInviteUserRow(
                 Modifier
                     .size(26.dp)
                     .clip(CircleShape)
-                    .background(if (isSelected) CampfireFlowColors.Coral else Color.Transparent),
+                    .background(if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent),
             contentAlignment = Alignment.Center,
         ) {
             if (isSelected) {
                 Icon(
                     Icons.Default.Check,
                     contentDescription = null,
-                    tint = Color.White,
+                    tint = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.size(16.dp),
                 )
             }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireLobbyScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireLobbyScreen.kt
@@ -22,12 +22,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -167,7 +167,7 @@ internal fun CampfireLobbyScreen(
                                 Icon(
                                     Icons.Default.PlayArrow,
                                     contentDescription = null,
-                                    tint = Color.White,
+                                    tint = MaterialTheme.colorScheme.onPrimary,
                                 )
                             },
                             modifier = Modifier.fillMaxWidth(),
@@ -199,7 +199,8 @@ private fun LobbyRosterAvatar(
     isHost: Boolean,
     joined: Boolean,
 ) {
-    val ringColor = if (joined) CampfireFlowColors.Coral.copy(alpha = 0.7f) else CampfireFlowColors.OnGlassFaint
+    val ringColor =
+        if (joined) MaterialTheme.colorScheme.primary.copy(alpha = 0.7f) else CampfireFlowColors.OnGlassFaint
     // Column width tracks the avatar's own diameter so the square avatar is never clamped narrower
     // than it is tall — a non-square box under CircleShape renders as a pill, not a circle.
     Column(
@@ -218,11 +219,11 @@ private fun LobbyRosterAvatar(
                     modifier =
                         Modifier
                             .offset(y = 4.dp)
-                            .background(CampfireFlowColors.Coral, RoundedCornerShape(percent = 50)),
+                            .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(percent = 50)),
                 ) {
                     Text(
                         text = stringResource(Res.string.campfire_flow_lobby_host_badge),
-                        color = Color.White,
+                        color = MaterialTheme.colorScheme.onPrimary,
                         fontWeight = FontWeight.ExtraBold,
                         fontSize = 8.5.sp,
                         modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireRoomScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/campfire/CampfireRoomScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay10
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -156,7 +157,11 @@ internal fun CampfireRoomScreen(
                         }
                     }
                     if (isPlaying) {
-                        Icon(Icons.Default.GraphicEq, contentDescription = null, tint = CampfireFlowColors.CoralBright)
+                        Icon(
+                            Icons.Default.GraphicEq,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
                     }
                 }
             }
@@ -209,7 +214,7 @@ private fun RoomTopBar(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(CampfireFlowColors.CoralBright))
+                    Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
                     Text(
                         text = stringResource(Res.string.campfire_flow_room_live),
                         color = CampfireFlowColors.OnGlass,
@@ -299,7 +304,7 @@ private fun RoomTransport(
                 colors =
                     androidx.compose.material3.SliderDefaults.colors(
                         thumbColor = CampfireFlowColors.OnGlass,
-                        activeTrackColor = CampfireFlowColors.Coral,
+                        activeTrackColor = MaterialTheme.colorScheme.primary,
                         inactiveTrackColor =
                             androidx.compose.ui.graphics
                                 .Color(0x2EFFFFFF),
@@ -319,7 +324,7 @@ private fun RoomTransport(
                             .clip(CircleShape)
                             .background(
                                 androidx.compose.ui.graphics.Brush.linearGradient(
-                                    listOf(CampfireFlowColors.CoralBright, CampfireFlowColors.Coral),
+                                    listOf(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.primary),
                                 ),
                             ).clickable(onClick = onPlayPause),
                     contentAlignment = Alignment.Center,
@@ -327,7 +332,7 @@ private fun RoomTransport(
                     Icon(
                         if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
                         contentDescription = null,
-                        tint = androidx.compose.ui.graphics.Color.White,
+                        tint = MaterialTheme.colorScheme.onPrimary,
                         modifier = Modifier.size(30.dp),
                     )
                 }


### PR DESCRIPTION
The Campfire flow's fire buttons and chrome accents used a hard-coded brand coral (`#F0512F`). They now pull from `MaterialTheme.colorScheme.primary`, and the always-dark Campfire backdrop re-themes into the **dark dynamic** scheme while honoring the user's Dynamic Colors setting via a new `LocalDynamicColor` composition local. The fire scene (particle engine / ember brushes) is untouched.

Verified on-device (Pixel 9 Pro Fold) across create → invite → lobby:

- **Dynamic Colors ON** → wallpaper-derived Material You primary (green on the test device); reads cleanly on the near-black night backdrop, dark `onPrimary` text legible.
- **Dynamic Colors OFF** → falls back to the static brand coral — i.e. unchanged from before. No regression for non-dynamic users.

Gate: `spotlessCheck detekt` green; `:androidApp:assembleDebug` built and ran on-device. Change is `:sharedUI`-only (Compose + theme), so no Swift-export surface impact.