### PR TITLE
✨ feat(sharedUI): ember presence FAB for backgrounded campfire

### DIFF
--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -5061,6 +5061,16 @@
         }
       }
     },
+    "campfire.return_count": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$d around the fire"
+          }
+        }
+      }
+    },
     "campfire.spoiler_cancel": {
       "localizations": {
         "en": {

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -496,6 +496,7 @@
     "flow_room_system_left": "%1$s left the fire",
     "flow_room_system_host_changed": "%1$s is now hosting",
     "return": "Return to campfire",
+    "return_count": "%1$d around the fire",
     "end_to_play_title": "End the campfire?",
     "end_to_play_body": "Playing another book will end the campfire for everyone. Continue?",
     "end_to_play_confirm": "End & play",

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -18,13 +20,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -50,6 +53,7 @@ import listenup.composeapp.generated.resources.campfire_leave_to_play_body
 import listenup.composeapp.generated.resources.campfire_leave_to_play_confirm
 import listenup.composeapp.generated.resources.campfire_leave_to_play_title
 import listenup.composeapp.generated.resources.campfire_return
+import listenup.composeapp.generated.resources.campfire_return_count
 import listenup.composeapp.generated.resources.common_cancel
 import listenup.composeapp.generated.resources.common_retry
 import listenup.composeapp.generated.resources.error_book_not_connected
@@ -77,6 +81,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import com.calypsan.listenup.client.design.components.FullScreenLoadingIndicator
 import com.calypsan.listenup.client.design.components.ListenUpButton
 import com.calypsan.listenup.client.design.components.LocalSnackbarHostState
+import com.calypsan.listenup.client.design.components.LocalNowPlayingInsets
 import com.calypsan.listenup.client.design.components.ProvideNowPlayingInsets
 import com.calypsan.listenup.client.design.components.latchFootprint
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -94,6 +99,7 @@ import com.calypsan.listenup.client.presentation.nowplaying.PlaybackGuardEvent
 import com.calypsan.listenup.client.features.nowplaying.DockedNowPlayingBarHeight
 import com.calypsan.listenup.client.features.shell.ShellDestination
 import com.calypsan.listenup.client.features.shell.components.ConnectionHealthBanner
+import com.calypsan.listenup.client.features.shell.components.NavigationBarHeight
 import com.calypsan.listenup.client.features.shell.shellDestinationSaver
 import com.calypsan.listenup.client.presentation.auth.PendingApprovalViewModel
 import com.calypsan.listenup.client.presentation.connection.ConnectionHealthViewModel
@@ -814,6 +820,7 @@ private fun authenticatedNavEntries(
 private class CampfireMinimizeState(
     val sessionActive: Boolean,
     val minimized: Boolean,
+    val memberCount: Int,
     val setMinimized: (Boolean) -> Unit,
 )
 
@@ -821,24 +828,44 @@ private class CampfireMinimizeState(
 private fun rememberCampfireMinimizeState(campfireViewModel: CampfireViewModel): CampfireMinimizeState {
     var minimized by rememberSaveable { mutableStateOf(false) }
     val campfireState by campfireViewModel.state.collectAsStateWithLifecycle()
-    val sessionActive = campfireState is CampfireScreenUiState.Active
+    val active = campfireState as? CampfireScreenUiState.Active
+    val sessionActive = active != null
     LaunchedEffect(sessionActive) {
         if (!sessionActive) minimized = false
     }
-    return CampfireMinimizeState(sessionActive, minimized) { minimized = it }
+    return CampfireMinimizeState(sessionActive, minimized, active?.members?.size ?: 0) { minimized = it }
 }
 
-/** Return-to-campfire affordance (B1 non-stranding placeholder; styled ember FAB is deferred). */
+/**
+ * Return-to-campfire affordance (B2): a warm ember Extended FAB shown whenever a live campfire is
+ * backgrounded. It doubles as a presence indicator ("N around the fire") — the only signal that a
+ * fire is still burning when there's no now-playing bar (the silent-lobby case) — and jumps back
+ * into the session on tap. The ember palette is intentionally warm rather than the app's Material
+ * You accent, so it reads as "a fire is lit" on any normal app surface.
+ *
+ * [bottomClearance] floats it above whatever occupies the bottom edge — the shell's bottom nav bar,
+ * the now-playing bar, or just the system nav inset — so it never occludes the navigation.
+ */
 @Composable
-private fun BoxScope.CampfireReturnFab(state: CampfireMinimizeState) {
-    if (state.sessionActive && state.minimized) {
-        FloatingActionButton(
-            onClick = { state.setMinimized(false) },
-            modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
-        ) {
-            Icon(Icons.Default.LocalFireDepartment, contentDescription = stringResource(Res.string.campfire_return))
-        }
-    }
+private fun BoxScope.CampfireReturnFab(state: CampfireMinimizeState, bottomClearance: Dp) {
+    if (!state.sessionActive || !state.minimized) return
+    val ember = Color(0xFFF0512F)
+    ExtendedFloatingActionButton(
+        onClick = { state.setMinimized(false) },
+        icon = {
+            Icon(
+                Icons.Default.LocalFireDepartment,
+                contentDescription = stringResource(Res.string.campfire_return),
+                tint = Color.White,
+            )
+        },
+        text = {
+            Text(stringResource(Res.string.campfire_return_count, state.memberCount), color = Color.White)
+        },
+        expanded = true,
+        containerColor = ember,
+        modifier = Modifier.align(Alignment.BottomEnd).padding(end = 16.dp, bottom = bottomClearance + 16.dp),
+    )
 }
 
 /**
@@ -950,7 +977,15 @@ private fun BoxScope.AuthenticatedNavOverlays(
         onBarFootprintChanged = onBarFootprintChanged,
     )
 
-    CampfireReturnFab(campfireMinimize)
+    // Float the return FAB above whatever holds the bottom edge so it never occludes the nav: the
+    // now-playing bar's animated inset when one is showing, otherwise the shell's bottom nav bar
+    // (only on Shell screens) plus the system nav inset.
+    val onShell = backStack.lastOrNull() == Shell
+    val systemNavBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val nowPlayingInset = LocalNowPlayingInsets.current.asPaddingValues().calculateBottomPadding()
+    val fabBottomClearance =
+        maxOf(nowPlayingInset, (if (onShell) NavigationBarHeight else 0.dp) + systemNavBottom)
+    CampfireReturnFab(campfireMinimize, fabBottomClearance)
     PlayOverCampfireDialog(
         nowPlayingViewModel = nowPlayingViewModel,
         campfireViewModel = campfireViewModel,

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -507,6 +507,7 @@ One beautiful library.</string>
     <string name="campfire_rejoin_message">The room has moved on without you. Jump to where everyone else is listening.</string>
     <string name="campfire_rejoin_title">Catch up with the room</string>
     <string name="campfire_return">Return to campfire</string>
+    <string name="campfire_return_count">%1$d around the fire</string>
     <string name="campfire_spoiler_cancel">Not yet</string>
     <string name="campfire_spoiler_confirm">Join anyway</string>
     <string name="campfire_spoiler_message">This room is further along in the story than you are. Joining will move your progress forward.</string>


### PR DESCRIPTION
Replaces the B1 placeholder return-to-campfire FAB (a bare fire icon) with a warm ember Material 3 Expressive **Extended FAB** that doubles as a presence indicator — **"N around the fire"**, driven by the live campfire member count. It's the only signal a fire is still burning in the silent-lobby case (no now-playing bar), and jumps back into the session on tap. The ember palette is intentionally warm rather than the app's Material You accent, so it reads as "a fire is lit" on any normal app surface.

Also fixes a nav-occlusion bug the placeholder shared: the FAB now floats above whatever holds the bottom edge — the now-playing bar's animated inset (`LocalNowPlayingInsets`) when present, otherwise the shell's bottom nav bar (Shell screens only) plus the system nav inset — so it never covers the navigation.

Verified on-device (Pixel 9 Pro Fold + Pixel 9 emulator, two real clients):
- FAB renders ember with the live count, reading cleanly on the light app surface.
- Bottom nav (Home/Library/Discover) fully reachable with the FAB present.
- 2-device E2E: a second user joined the host's lobby → the FAB ticked live from "1 around the fire" to "2 around the fire".

Gate: `spotlessCheck detekt` + `:androidApp:assembleDebug` + `:sharedUI:verifyStrings` all green. New string added via `en.json` + `generateStrings` (Android + iOS artifacts regenerated). `sharedUI`-only.