### PR TITLE
🐛 fix(shared): sync-engine hardening from the 2026-07-16 pre-ship audit

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
@@ -127,6 +127,14 @@ internal interface ActivityDao {
      */
     @Query("SELECT COUNT(*) FROM activities")
     suspend fun count(): Int
+
+    /**
+     * Hard-delete every activity row, tombstones included. Unlike removal (soft-delete
+     * only, per [count]'s note), this is the sign-out / server-switch reset's full wipe —
+     * there is no server digest to converge against once the whole local mirror is gone.
+     */
+    @Query("DELETE FROM activities")
+    suspend fun deleteAll()
 }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AdminUserRosterEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AdminUserRosterEntity.kt
@@ -87,4 +87,8 @@ internal interface AdminUserRosterDao {
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */
     @Query("SELECT revision FROM admin_user_roster WHERE id = :id LIMIT 1")
     suspend fun revisionOf(id: String): Long?
+
+    /** Delete every roster row. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM admin_user_roster")
+    suspend fun deleteAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileDao.kt
@@ -26,4 +26,8 @@ internal interface AudioFileDao {
 
     @Query("DELETE FROM audio_files WHERE bookId = :bookId")
     suspend fun deleteForBook(bookId: String)
+
+    /** Delete every audio file row. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM audio_files")
+    suspend fun deleteAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDocumentDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDocumentDao.kt
@@ -26,4 +26,8 @@ internal interface BookDocumentDao {
 
     @Query("DELETE FROM book_documents WHERE bookId = :bookId")
     suspend fun deleteForBook(bookId: String)
+
+    /** Delete every document row. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM book_documents")
+    suspend fun deleteAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadershipEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadershipEntity.kt
@@ -53,6 +53,10 @@ internal interface BookReadershipDao {
     @Query("DELETE FROM book_readership WHERE bookId NOT IN (SELECT id FROM books WHERE deletedAt IS NULL)")
     suspend fun deleteWhereBookNotLive()
 
+    /** Delete every cached readership row. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM book_readership")
+    suspend fun deleteAll()
+
     /** Atomically replace [bookId]'s cached readership with [rows] (the latest server snapshot). */
     @Transaction
     suspend fun replaceForBook(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
@@ -348,4 +348,8 @@ internal interface ContributorAliasDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertAll(aliases: List<ContributorAliasCrossRef>)
+
+    /** Delete every alias row. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM contributor_aliases")
+    suspend fun deleteAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventEntity.kt
@@ -349,6 +349,10 @@ internal interface ListeningEventDao {
      */
     @Query("UPDATE listening_events SET userId = :userId WHERE userId = ''")
     suspend fun reassignBlankUserId(userId: String): Int
+
+    /** Delete every listening event, tombstones included. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM listening_events")
+    suspend fun deleteAll()
 }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PublicProfileEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PublicProfileEntity.kt
@@ -119,4 +119,8 @@ internal interface PublicProfileDao {
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */
     @Query("SELECT revision FROM public_profiles WHERE id = :id LIMIT 1")
     suspend fun revisionOf(id: String): Long?
+
+    /** Delete every public profile row. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM public_profiles")
+    suspend fun deleteAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryDao.kt
@@ -87,4 +87,8 @@ internal interface LibraryDao {
      */
     @Query("SELECT EXISTS(SELECT 1 FROM libraries WHERE deletedAt IS NULL AND initialScanCompletedAt IS NULL)")
     fun observeHasIncompleteInitialScan(): Flow<Boolean>
+
+    /** Delete every library row, tombstones included. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM libraries")
+    suspend fun deleteAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryFolderDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryFolderDao.kt
@@ -78,4 +78,8 @@ internal interface LibraryFolderDao {
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */
     @Query("SELECT revision FROM library_folders WHERE id = :id LIMIT 1")
     suspend fun revisionOf(id: String): Long?
+
+    /** Delete every folder row, tombstones included. Used by the sign-out / server-switch library reset. */
+    @Query("DELETE FROM library_folders")
+    suspend fun deleteAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperImpl.kt
@@ -29,13 +29,55 @@ internal class LibraryResetHelperImpl(
         logger.info { "Clearing library data (discardPendingOperations=$discardPendingOperations)" }
 
         transactionRunner.atomically {
+            // Children/junctions first — several carry a Room foreign key onto the parent
+            // table cleared below (library_folders -> libraries; book_contributors,
+            // book_series, book_genres, audio_files, book_documents -> books/contributors/
+            // series/genres; contributor_aliases -> contributors), so clearing child-first
+            // is required, not just tidy. The junctions with no declared FK (book_tags,
+            // book_moods, shelf_books, collection_books, collection_shares) are ordered the
+            // same way for uniformity. book_readership is a server-fetched cache keyed to
+            // books, not a mirrored sync domain, but it is cleared here for the same reason
+            // the books access-gate sweeps it: a stale reader list must not survive the reset.
             database.bookContributorDao().deleteAll()
             database.bookSeriesDao().deleteAll()
+            database.genreDao().deleteAllBookGenres()
+            database.audioFileDao().deleteAll()
+            database.bookDocumentDao().deleteAll()
+            database.contributorAliasDao().deleteAll()
             database.chapterDao().deleteAll()
+            database.bookReadershipDao().deleteAll()
+            database.bookTagDao().deleteAll()
+            database.bookMoodDao().deleteAll()
+            database.shelfBookDao().deleteAll()
+            database.collectionBookDao().deleteAll()
+            database.collectionShareDao().deleteAll()
             database.playbackPositionDao().deleteAll()
+            database.listeningEventDao().deleteAll()
+            database.activityDao().deleteAll()
+            database.libraryFolderDao().deleteAll()
+
+            // Every mirrored sync domain's root table (SyncDomainCatalog — 21 domains; see
+            // LibraryResetHelperTest's drift-proof coverage test for the full accounting).
             database.bookDao().deleteAll()
             database.seriesDao().deleteAll()
             database.contributorDao().deleteAll()
+            database.genreDao().deleteAll()
+            database.tagDao().deleteAll()
+            database.moodDao().deleteAll()
+            database.shelfDao().deleteAll()
+            database.collectionDao().deleteAll()
+            database.libraryDao().deleteAll()
+            database.userStatsDao().deleteAll()
+            database.publicProfileDao().deleteAll()
+            database.adminUserRosterDao().deleteAll()
+
+            // The local FTS5 index mirrors books/contributors/series content, not a domain of
+            // its own — clear it alongside its source tables so no stale entry lingers between
+            // the reset and the next FtsPopulator rebuild.
+            database.searchDao().clearBooksFts()
+            database.searchDao().clearContributorsFts()
+            database.searchDao().clearSeriesFts()
+
             database.userDao().clear()
 
             // Sync cursors share the library's lifecycle: if the rows are wiped

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -136,6 +136,12 @@ internal class SyncEventDispatcher(
             } catch (e: Exception) {
                 logger.warn(e) { "Failed to decode SyncEvent for domain '$domainName'" }
                 reportCompat("SSE event undecodable for domain '$domainName': ${e.message}")
+                // An undecodable frame is functionally "apply did not happen": for an OptOut domain
+                // the same freeze bookkeeping as a failed apply applies, else the un-decodable
+                // revision is permanently skipped once a later event's success would advance past it.
+                if (!typed.hasDigestBackstop) {
+                    frozenOptOutDomains += domainName
+                }
                 return
             }
         when (val result = typed.onEvent(event)) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
@@ -40,11 +40,14 @@ internal class SyncSseClient(
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
     connectTimeoutMillis: Long = DEFAULT_CONNECT_TIMEOUT_MS,
     onAuthExhausted: suspend () -> Unit = {},
+    // Test seam: a small capacity lets a test force `frameBus.emit` to suspend deterministically
+    // (SyncSseClientDeliveryOrderingTest) without depending on the production buffer depth.
+    frameBufferCapacity: Int = FRAME_BUFFER_CAPACITY,
 ) : SseClient {
     private val frameBus =
         MutableSharedFlow<ParsedSseFrame>(
             replay = 0,
-            extraBufferCapacity = FRAME_BUFFER_CAPACITY,
+            extraBufferCapacity = frameBufferCapacity,
             onBufferOverflow = BufferOverflow.SUSPEND,
         )
 
@@ -94,8 +97,14 @@ internal class SyncSseClient(
             }
     }
 
-    /** Fold one engine lifecycle event into the ambient [SyncEngineState] and re-broadcast frames. */
-    private suspend fun apply(event: SseEvent) {
+    /**
+     * Fold one engine lifecycle event into the ambient [SyncEngineState] and re-broadcast frames.
+     *
+     * `internal` (not `private`) so [SyncSseClientDeliveryOrderingTest] can drive it directly —
+     * exercising the real [connection]/[SseConnection] plumbing can't force a deterministic
+     * mid-emit suspension without a sleepy wall-clock race.
+     */
+    internal suspend fun apply(event: SseEvent) {
         when (event) {
             SseEvent.Connecting -> {
                 state.setConnection(ConnectionState.Connecting)
@@ -108,8 +117,12 @@ internal class SyncSseClient(
 
             is SseEvent.Frame -> {
                 val frame = event.frame
-                frame.id?.let { lastEventId = it }
+                // emit is the linearization point for "this frame will be delivered": advancing
+                // lastEventId before it returns would commit the watermark past a frame that a
+                // cancellation mid-suspend (the bounded frameBus can suspend on emit) never
+                // actually delivered — the server would then never resend it this session.
                 frameBus.emit(frame)
+                frame.id?.let { lastEventId = it }
                 state.setConnection(ConnectionState.Connected(lastEventId))
             }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ApplyEventAtomically.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ApplyEventAtomically.kt
@@ -17,7 +17,10 @@ import kotlinx.coroutines.withContext
  *
  * A [PostCommitSideEffects] collector is installed for the duration of [block] so an apply
  * can defer file-system/network side effects (via [deferUntilCommit]) past commit. The
- * collected actions run only when the transaction succeeds; a rollback discards them.
+ * collected actions run only when the transaction succeeds; a rollback discards them. Those
+ * actions are inherently best-effort (see [deferUntilCommit]'s callers) — a failure there must
+ * never turn an already-committed apply into a reported [AppResult.Failure], so [runAll] is
+ * outside the try/catch that maps [block] failures to [SyncError.SyncFailed].
  */
 internal suspend fun TransactionRunner.applyEventAtomically(
     domain: String,
@@ -26,14 +29,23 @@ internal suspend fun TransactionRunner.applyEventAtomically(
     block: suspend () -> Unit,
 ): AppResult<Unit> {
     val sideEffects = PostCommitSideEffects()
-    return try {
+    try {
         withContext(sideEffects) { atomically { block() } }
-        sideEffects.runAll()
-        AppResult.Success(Unit)
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
         log.warn(e) { "Failed to apply $domain sync event for $entityId" }
-        AppResult.Failure(SyncError.SyncFailed(debugInfo = "$domain/$entityId: ${e.message}"))
+        return AppResult.Failure(SyncError.SyncFailed(debugInfo = "$domain/$entityId: ${e.message}"))
     }
+
+    try {
+        sideEffects.runAll()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        // Best-effort by contract (see PostCommitSideEffects KDoc): the transaction already
+        // committed, so a deferred side effect failing here must not be reported as a failed apply.
+        log.warn(e) { "Post-commit side effect failed for $domain sync event $entityId (apply still succeeded)" }
+    }
+    return AppResult.Success(Unit)
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AvatarSingleSourceTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AvatarSingleSourceTest.kt
@@ -200,4 +200,6 @@ private class RecordingPublicProfileDao(
     override suspend fun digestRows(max: Long): List<IdRevision> = error("unused")
 
     override suspend fun revisionOf(id: String): Long? = rows.value[id]?.revision
+
+    override suspend fun deleteAll() = error("unused")
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImplTest.kt
@@ -308,6 +308,10 @@ private class FakeBookReadershipDao : BookReadershipDao {
     // not here. This repository test never triggers it, so a no-op keeps the interface satisfied.
     override suspend fun deleteWhereBookNotLive() = Unit
 
+    override suspend fun deleteAll() {
+        byBook.keys.forEach { flowFor(it).value = emptyList() }
+    }
+
     // Match the real DAO's @Transaction: one atomic replacement, not a delete-then-insert flicker.
     override suspend fun replaceForBook(
         bookId: String,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientDeliveryOrderingTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientDeliveryOrderingTest.kt
@@ -1,0 +1,64 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.client.data.sync
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+
+/**
+ * [SyncSseClient.apply] is driven directly rather than through the real [SseConnection] engine —
+ * forcing a deterministic mid-emit suspension on `frameBus.emit` through the real connect() path
+ * would need a sleepy wall-clock race (there is no other seam that reliably stalls a specific
+ * emit). `apply` is `internal` for exactly this reason; see its KDoc.
+ */
+class SyncSseClientDeliveryOrderingTest :
+    FunSpec({
+        test("lastEventId does not advance past a frame whose delivery never completed") {
+            val scope = TestScope(StandardTestDispatcher())
+            val state = SyncEngineState()
+            val client =
+                SyncSseClient(
+                    serverUrlProvider = { null },
+                    streamingClientProvider = { error("unused — apply() is driven directly, not via connect()") },
+                    state = state,
+                    scope = scope,
+                    nowMillis = { 0L },
+                    // Zero buffer: the second frame's emit has nowhere to land once the one
+                    // collector is stalled processing the first, so it suspends deterministically.
+                    frameBufferCapacity = 0,
+                )
+
+            // Consumes exactly one frame, then never returns to ask for the next — this is what a
+            // downstream consumer that stops draining (or a slow one) looks like from frameBus's side.
+            val collectorJob = scope.launch { client.frames.collect { awaitCancellation() } }
+            scope.testScheduler.runCurrent()
+
+            val frame1 = ParsedSseFrame(id = 1L, event = "tags", data = "{}")
+            val frame2 = ParsedSseFrame(id = 2L, event = "tags", data = "{}")
+
+            // Models the connection coroutine: applies frame1 (delivered), then frame2 — which
+            // suspends on emit because the sole collector is still stuck inside frame1's callback.
+            val connectionJob =
+                scope.launch {
+                    client.apply(SseEvent.Frame(frame1))
+                    client.apply(SseEvent.Frame(frame2))
+                }
+            scope.testScheduler.runCurrent()
+
+            client.currentLastEventId() shouldBe 1L
+
+            // The engine cancelling the connection coroutine while frame2's emit is still
+            // suspended — the exact scenario the fix protects: frame2 was never delivered.
+            connectionJob.cancel()
+            scope.testScheduler.runCurrent()
+
+            client.currentLastEventId() shouldBe 1L
+
+            collectorJob.cancel()
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/LeaderboardRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/LeaderboardRepositoryImplTest.kt
@@ -66,6 +66,8 @@ private class FakePublicProfileDao(
     override suspend fun digestRows(max: Long): List<IdRevision> = error("unused")
 
     override suspend fun revisionOf(id: String): Long? = error("unused")
+
+    override suspend fun deleteAll() = error("unused")
 }
 
 class LeaderboardRepositoryImplTest :

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/UserProfileRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/UserProfileRepositoryImplTest.kt
@@ -56,6 +56,8 @@ private class StubReadPublicProfileDao(
     override suspend fun digestRows(max: Long): List<IdRevision> = error("unused")
 
     override suspend fun revisionOf(id: String): Long? = error("unused")
+
+    override suspend fun deleteAll() = error("unused")
 }
 
 class UserProfileRepositoryImplTest :

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperTest.kt
@@ -1,12 +1,48 @@
 package com.calypsan.listenup.client.data.sync
 
+import com.calypsan.listenup.client.data.local.db.ActivityEntity
+import com.calypsan.listenup.client.data.local.db.AdminUserRosterEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.BookEntityMapper
+import com.calypsan.listenup.client.data.local.db.BookMoodEntity
+import com.calypsan.listenup.client.data.local.db.BookTagEntity
+import com.calypsan.listenup.client.data.local.db.CollectionBookEntity
+import com.calypsan.listenup.client.data.local.db.CollectionEntity
+import com.calypsan.listenup.client.data.local.db.CollectionShareEntity
+import com.calypsan.listenup.client.data.local.db.ContributorEntity
+import com.calypsan.listenup.client.data.local.db.GenreEntity
+import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
+import com.calypsan.listenup.client.data.local.db.MoodEntity
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
+import com.calypsan.listenup.client.data.local.db.PublicProfileEntity
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.local.db.SeriesEntity
+import com.calypsan.listenup.client.data.local.db.ShelfBookEntity
+import com.calypsan.listenup.client.data.local.db.ShelfEntity
 import com.calypsan.listenup.client.data.local.db.SyncCursorEntity
+import com.calypsan.listenup.client.data.local.db.TagEntity
+import com.calypsan.listenup.client.data.local.db.UserStatsEntity
+import com.calypsan.listenup.client.data.local.db.entity.LibraryEntity
+import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
+import com.calypsan.listenup.client.data.sync.domains.syncDomainCatalog
+import com.calypsan.listenup.client.data.sync.testing.StubAvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.LibrarySync
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.fake.FakeAuthSession
+import com.calypsan.listenup.client.test.stubImageStorage
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ContributorId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.core.SeriesId
+import com.calypsan.listenup.core.Timestamp
 import dev.mokkery.mock
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 /**
  * `clearLibraryData` is the sign-out / server-switch reset. It wipes the library
@@ -45,4 +81,368 @@ class LibraryResetHelperTest :
                 db.close()
             }
         }
+
+        test(
+            "clearLibraryData empties every mirrored sync domain's backing table " +
+                "(drift-proof against SyncDomainCatalog)",
+        ) {
+            val db = createInMemoryTestDatabase()
+            try {
+                val catalog =
+                    syncDomainCatalog(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                        authSession = FakeAuthSession(userId = "reset-user"),
+                        avatarDownloadRepository = StubAvatarDownloadRepository(),
+                        pingPresence = {},
+                        refetchServerInfo = {},
+                        refetchPreferences = {},
+                    )
+
+                // One probe per mirrored domain: seeds a single row into that domain's backing
+                // table and reports whether the row is still there. The equality check right below
+                // is the drift guard — it derives coverage from the catalog itself, so a domain
+                // ADDED to (or renamed in) SyncDomainCatalog without a matching probe here fails
+                // THIS assertion, before clearLibraryData's completeness could silently regress
+                // again. Seeded via each DAO's own upsert (not raw SQL) so the FK on
+                // library_folders -> libraries is honoured; libraries is probed before
+                // library_folders for that reason.
+                val probes =
+                    listOf(
+                        DomainProbe(
+                            domainName = "tags",
+                            seed = {
+                                db.tagDao().upsert(TagEntity(id = "seed-tag", name = "n", slug = "n", updatedAt = 0L))
+                            },
+                            isGone = { db.tagDao().revisionOf("seed-tag") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "genres",
+                            seed = {
+                                db.genreDao().upsert(GenreEntity(id = "seed-genre", name = "n", slug = "n", path = "/n"))
+                            },
+                            isGone = { db.genreDao().revisionOf("seed-genre") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "moods",
+                            seed = {
+                                db.moodDao().upsert(
+                                    MoodEntity(id = "seed-mood", name = "n", slug = "n", updatedAt = 0L),
+                                )
+                            },
+                            isGone = { db.moodDao().revisionOf("seed-mood") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "book_tags",
+                            seed = {
+                                db.bookTagDao().upsert(BookTagEntity(bookId = "b1", tagId = "t1", createdAt = 0L))
+                            },
+                            isGone = { db.bookTagDao().findByKey("b1", "t1") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "book_moods",
+                            seed = {
+                                db.bookMoodDao().upsert(BookMoodEntity(bookId = "b1", moodId = "m1", createdAt = 0L))
+                            },
+                            isGone = { db.bookMoodDao().findByKey("b1", "m1") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "libraries",
+                            seed = {
+                                db.libraryDao().upsert(
+                                    LibraryEntity(
+                                        id = "seed-lib",
+                                        name = "n",
+                                        metadataPrecedence = "embedded",
+                                        accessMode = "PRIVATE",
+                                        createdByUserId = null,
+                                        createdAt = 0L,
+                                        revision = 0L,
+                                        deletedAt = null,
+                                        initialScanCompletedAt = null,
+                                    ),
+                                )
+                            },
+                            isGone = { db.libraryDao().findById("seed-lib") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "library_folders",
+                            seed = {
+                                db.libraryFolderDao().upsert(
+                                    LibraryFolderEntity(
+                                        id = "seed-folder",
+                                        libraryId = "seed-lib",
+                                        rootPath = "/x",
+                                        createdAt = 0L,
+                                        revision = 0L,
+                                        deletedAt = null,
+                                    ),
+                                )
+                            },
+                            isGone = { db.libraryFolderDao().findById("seed-folder") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "shelves",
+                            seed = {
+                                db.shelfDao().upsert(
+                                    ShelfEntity(
+                                        id = "seed-shelf",
+                                        name = "n",
+                                        description = "",
+                                        isPrivate = false,
+                                        updatedAt = 0L,
+                                        createdAt = 0L,
+                                    ),
+                                )
+                            },
+                            isGone = { db.shelfDao().getById("seed-shelf") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "shelf_books",
+                            seed = {
+                                db.shelfBookDao().upsert(
+                                    ShelfBookEntity(
+                                        id = "seed-shelf:b1",
+                                        shelfId = "seed-shelf",
+                                        bookId = "b1",
+                                        sortOrder = 0,
+                                        updatedAt = 0L,
+                                        createdAt = 0L,
+                                    ),
+                                )
+                            },
+                            isGone = { db.shelfBookDao().findById("seed-shelf:b1") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "playback_positions",
+                            seed = {
+                                db.playbackPositionDao().save(
+                                    PlaybackPositionEntity(
+                                        bookId = BookId("b1"),
+                                        positionMs = 0L,
+                                        playbackSpeed = 1.0f,
+                                        updatedAt = 0L,
+                                    ),
+                                )
+                            },
+                            isGone = { db.playbackPositionDao().get(BookId("b1")) == null },
+                        ),
+                        DomainProbe(
+                            domainName = "listening_events",
+                            seed = {
+                                db.listeningEventDao().upsert(
+                                    ListeningEventEntity(
+                                        id = "seed-event",
+                                        userId = "u1",
+                                        bookId = "b1",
+                                        startPositionMs = 0L,
+                                        endPositionMs = 1000L,
+                                        startedAt = 0L,
+                                        endedAt = 1000L,
+                                        playbackSpeed = 1.0f,
+                                        tz = "UTC",
+                                        deviceLabel = null,
+                                    ),
+                                )
+                            },
+                            isGone = { db.listeningEventDao().getById("seed-event") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "activities",
+                            seed = {
+                                db.activityDao().upsert(
+                                    ActivityEntity(
+                                        id = "seed-activity",
+                                        userId = "u1",
+                                        type = "started_book",
+                                        occurredAt = 0L,
+                                        bookId = null,
+                                        isReread = false,
+                                        durationMs = 0L,
+                                        milestoneValue = 0,
+                                        milestoneUnit = null,
+                                        shelfId = null,
+                                        shelfName = null,
+                                    ),
+                                )
+                            },
+                            isGone = { db.activityDao().getById("seed-activity") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "user_stats",
+                            seed = {
+                                db.userStatsDao().upsert(
+                                    UserStatsEntity(
+                                        id = "u1",
+                                        totalSecondsAllTime = 0L,
+                                        totalSecondsLast7Days = 0L,
+                                        totalSecondsLast30Days = 0L,
+                                        booksStarted = 0,
+                                        booksFinished = 0,
+                                        currentStreakDays = 0,
+                                        longestStreakDays = 0,
+                                        lastEventDate = null,
+                                    ),
+                                )
+                            },
+                            isGone = { db.userStatsDao().getForUser("u1") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "public_profiles",
+                            seed = {
+                                db.publicProfileDao().upsert(
+                                    PublicProfileEntity(
+                                        id = "u1",
+                                        displayName = "n",
+                                        avatarType = "auto",
+                                        totalSecondsAllTime = 0L,
+                                        totalSecondsLast7Days = 0L,
+                                        totalSecondsLast30Days = 0L,
+                                        totalSecondsLast365Days = 0L,
+                                        booksFinished = 0,
+                                        currentStreakDays = 0,
+                                        longestStreakDays = 0,
+                                    ),
+                                )
+                            },
+                            isGone = { db.publicProfileDao().findById("u1") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "series",
+                            seed = {
+                                db.seriesDao().upsert(
+                                    SeriesEntity(
+                                        id = SeriesId("seed-series"),
+                                        name = "n",
+                                        description = null,
+                                        createdAt = Timestamp(0L),
+                                        updatedAt = Timestamp(0L),
+                                    ),
+                                )
+                            },
+                            isGone = { db.seriesDao().getById("seed-series") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "collections",
+                            seed = {
+                                db.collectionDao().upsert(
+                                    CollectionEntity(
+                                        id = "seed-collection",
+                                        libraryId = "seed-lib",
+                                        ownerId = "u1",
+                                        name = "n",
+                                        isInbox = false,
+                                        updatedAt = 0L,
+                                    ),
+                                )
+                            },
+                            isGone = { db.collectionDao().getById("seed-collection") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "collection_books",
+                            seed = {
+                                db.collectionBookDao().upsert(
+                                    CollectionBookEntity(
+                                        collectionId = "seed-collection",
+                                        bookId = "b1",
+                                        createdAt = 0L,
+                                    ),
+                                )
+                            },
+                            isGone = { db.collectionBookDao().findByKey("seed-collection", "b1") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "collection_shares",
+                            seed = {
+                                db.collectionShareDao().upsert(
+                                    CollectionShareEntity(
+                                        id = "seed-share",
+                                        collectionId = "seed-collection",
+                                        sharedWithUserId = "u2",
+                                        sharedByUserId = "u1",
+                                        permission = "read",
+                                        updatedAt = 0L,
+                                    ),
+                                )
+                            },
+                            isGone = { db.collectionShareDao().getById("seed-share") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "contributors",
+                            seed = {
+                                db.contributorDao().upsert(
+                                    ContributorEntity(
+                                        id = ContributorId("seed-contributor"),
+                                        name = "n",
+                                        description = null,
+                                        imagePath = null,
+                                        createdAt = Timestamp(0L),
+                                        updatedAt = Timestamp(0L),
+                                    ),
+                                )
+                            },
+                            isGone = { db.contributorDao().getById("seed-contributor") == null },
+                        ),
+                        DomainProbe(
+                            domainName = "books",
+                            seed = {
+                                db.bookDao().upsert(
+                                    BookEntity(
+                                        id = BookId("b1"),
+                                        libraryId = LibraryId("seed-lib"),
+                                        folderId = FolderId("seed-folder"),
+                                        title = "n",
+                                        totalDuration = 0L,
+                                        createdAt = Timestamp(0L),
+                                        updatedAt = Timestamp(0L),
+                                    ),
+                                )
+                            },
+                            isGone = { db.bookDao().getById(BookId("b1")) == null },
+                        ),
+                        DomainProbe(
+                            domainName = "admin_user_roster",
+                            seed = {
+                                db.adminUserRosterDao().upsert(
+                                    AdminUserRosterEntity(
+                                        id = "seed-roster-user",
+                                        email = "e@x.test",
+                                        displayName = "n",
+                                        role = "user",
+                                        status = "active",
+                                        canShare = false,
+                                        accountCreatedAt = 0L,
+                                    ),
+                                )
+                            },
+                            isGone = { db.adminUserRosterDao().findById("seed-roster-user") == null },
+                        ),
+                    )
+
+                probes.map { it.domainName }.toSet() shouldBe catalog.mirrored.map { it.key.name }.toSet()
+
+                for (probe in probes) probe.seed()
+                for (probe in probes) withClue(probe.domainName) { probe.isGone().shouldBeFalse() }
+
+                val helper =
+                    LibraryResetHelperImpl(
+                        database = db,
+                        transactionRunner = RoomTransactionRunner(db),
+                        librarySyncContract = mock<LibrarySync>(),
+                    )
+                helper.clearLibraryData(discardPendingOperations = true)
+
+                for (probe in probes) withClue(probe.domainName) { probe.isGone().shouldBeTrue() }
+            } finally {
+                db.close()
+            }
+        }
     })
+
+/** One mirrored domain's seed action + post-clear presence check, keyed by wire name. */
+private class DomainProbe(
+    val domainName: String,
+    val seed: suspend () -> Unit,
+    val isGone: suspend () -> Boolean,
+)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
@@ -532,6 +532,91 @@ class SyncEventDispatcherTest :
             }
         }
 
+        test("OptOut domain: an undecodable payload freezes the cursor exactly like a failed apply") {
+            runTest {
+                val registry = ClientSyncDomainRegistry()
+                // rev5's frame is undecodable — that's functionally "apply did not happen" for the
+                // hole it leaves; rev6 (another book) applies successfully but must NOT advance the
+                // cursor past the hole, or rev5's revision can never be redelivered.
+                val handler =
+                    ScriptedHandler(
+                        ArrayDeque(listOf(AppResult.Success(Unit))),
+                        hasBackstop = false,
+                    )
+                registry.register(handler)
+                var cursorAdvanced: Pair<String, Long>? = null
+                val dispatcher =
+                    SyncEventDispatcher(
+                        registry = registry,
+                        state = SyncEngineState(),
+                        cursorAdvance = { d, r -> cursorAdvanced = d to r },
+                    )
+
+                val undecodableFrame =
+                    ParsedSseFrame(id = 5L, event = "tags", data = "{not valid json for a Tag SyncEvent}")
+                dispatcher.handle(undecodableFrame) // undecodable — freezes at last-known-good
+
+                val succeededEvent =
+                    SyncEvent.Created(
+                        id = "b6",
+                        revision = 6L,
+                        occurredAt = 100L,
+                        clientOpId = null,
+                        payload = Tag("b6", "n", "n", 6L, 100L),
+                    )
+                val succeededFrame =
+                    ParsedSseFrame(
+                        id = 6L,
+                        event = "tags",
+                        data = contractJson.encodeToString(SyncEvent.serializer(Tag.serializer()), succeededEvent),
+                    )
+                dispatcher.handle(succeededFrame) // applies but frozen — must not advance to 6
+
+                cursorAdvanced shouldBe null
+            }
+        }
+
+        test("digest-backed domain: an undecodable payload does not freeze — a later event still advances") {
+            runTest {
+                val registry = ClientSyncDomainRegistry()
+                val handler =
+                    ScriptedHandler(
+                        ArrayDeque(listOf(AppResult.Success(Unit))),
+                        hasBackstop = true,
+                    )
+                registry.register(handler)
+                var cursorAdvanced: Pair<String, Long>? = null
+                val dispatcher =
+                    SyncEventDispatcher(
+                        registry = registry,
+                        state = SyncEngineState(),
+                        cursorAdvance = { d, r -> cursorAdvanced = d to r },
+                    )
+
+                val undecodableFrame =
+                    ParsedSseFrame(id = 5L, event = "tags", data = "{not valid json for a Tag SyncEvent}")
+                dispatcher.handle(undecodableFrame) // undecodable — but digest backstop, no freeze
+
+                val succeededEvent =
+                    SyncEvent.Created(
+                        id = "b6",
+                        revision = 6L,
+                        occurredAt = 100L,
+                        clientOpId = null,
+                        payload = Tag("b6", "n", "n", 6L, 100L),
+                    )
+                val succeededFrame =
+                    ParsedSseFrame(
+                        id = 6L,
+                        event = "tags",
+                        data = contractJson.encodeToString(SyncEvent.serializer(Tag.serializer()), succeededEvent),
+                    )
+                dispatcher.handle(succeededFrame)
+
+                cursorAdvanced shouldBe ("tags" to 6L)
+            }
+        }
+
         test("digest-backed domain: a failed apply does not freeze — a later event still advances (unchanged)") {
             runTest {
                 val registry = ClientSyncDomainRegistry()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/ApplyEventAtomicallyTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/ApplyEventAtomicallyTest.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.client.data.sync.domains
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+private val logger = KotlinLogging.logger {}
+
+private class FakeTransactionRunner : TransactionRunner {
+    override suspend fun <R> atomically(block: suspend () -> R): R = block()
+}
+
+class ApplyEventAtomicallyTest :
+    FunSpec({
+        val runner = FakeTransactionRunner()
+
+        test("a deferred post-commit action that throws does not fail an otherwise-successful apply") {
+            var blockRan = false
+            val result =
+                runner.applyEventAtomically("test", "e1", logger) {
+                    blockRan = true
+                    deferUntilCommit { throw IllegalStateException("best-effort cleanup failed") }
+                }
+
+            result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+            blockRan.shouldBeTrue()
+        }
+
+        test("block() throwing still fails the apply and never runs the deferred action") {
+            var deferredRan = false
+            val result =
+                runner.applyEventAtomically("test", "e1", logger) {
+                    deferUntilCommit { deferredRan = true }
+                    error("write failed")
+                }
+
+            result.shouldBeInstanceOf<AppResult.Failure>()
+            deferredRan.shouldBeFalse()
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/discover/LeaderboardViewModelRealRepoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/discover/LeaderboardViewModelRealRepoTest.kt
@@ -256,4 +256,6 @@ private class FakePublicProfileDao(
     override suspend fun digestRows(max: Long): List<IdRevision> = error("unused in VM test")
 
     override suspend fun revisionOf(id: String): Long? = error("unused in VM test")
+
+    override suspend fun deleteAll() = error("unused in VM test")
 }


### PR DESCRIPTION
Four vetted findings from the pre-ship sync audit (baseline 9ad7e179f):

- **Post-commit side effects** (`ApplyEventAtomically`): a failing deferred side effect (e.g. best-effort cover delete) no longer reports an already-committed apply as a sync failure — it previously withheld cursor advance and fed the user-visible error threshold.
- **Decode-failure freeze** (`SyncEventDispatcher`): an undecodable payload now freezes an OptOut domain's cursor exactly like a failed apply, so a later success can't advance past the hole and permanently skip the revision.
- **Complete sign-out reset** (`LibraryResetHelperImpl`): sign-out previously cleared only 9 of 21 mirrored domains — the next user on a shared device inherited shelves, collections, listening events, and stats. Now clears every mirrored domain (FK-ordered), the FTS mirrors, and the readership cache, with a drift-proof test that derives coverage from `SyncDomainCatalog` itself.
- **SSE resume watermark** (`SyncSseClient`): `lastEventId` now advances only after the frame is handed to the delivery buffer, closing a cancellation window that silently dropped an event for the rest of the session.

All TDD (red→green verified), gates green: spotless+detekt, `:sharedLogic:jvmTest`, commonMain metadata compile.