### PR TITLE
🐛 fix(shared): outbox determinism + deterministic sync-timing tests

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
@@ -30,14 +30,28 @@ internal interface PendingOperationV2Dao {
      * Earliest-enqueued op per (domainName, entityId) group with retry budget remaining.
      * Per-entity FIFO: if an op for entity `E` is in flight, the next op for `E` waits;
      * ops on other entities can drain in parallel.
+     *
+     * Same-`enqueuedAt` ties (same-millisecond enqueue) are broken deterministically by
+     * `clientOpId ASC` via the `ROW_NUMBER()` window function, rather than relying on
+     * SQLite's undocumented bare-column `GROUP BY` tie-break. In practice ties are also
+     * prevented at the source — [PendingOperationV2Dao] callers (see `PendingOperationQueue.enqueue`)
+     * bump `enqueuedAt` so a second op for an entity that already has one queued is never
+     * enqueued at the same instant — but this ordering holds even if that invariant is
+     * ever violated.
      */
     @Query(
         """
-        SELECT * FROM pending_operation
-         WHERE failureCount <= :maxAttempts
-         GROUP BY domainName, entityId
-        HAVING enqueuedAt = MIN(enqueuedAt)
-         ORDER BY enqueuedAt ASC
+        SELECT clientOpId, domainName, entityId, opType, payload, enqueuedAt, lastAttemptAt, failureCount, lastError, ownerUserId
+          FROM (
+              SELECT *, ROW_NUMBER() OVER (
+                  PARTITION BY domainName, entityId
+                  ORDER BY enqueuedAt ASC, clientOpId ASC
+              ) AS rn
+                FROM pending_operation
+               WHERE failureCount <= :maxAttempts
+          )
+         WHERE rn = 1
+         ORDER BY enqueuedAt ASC, clientOpId ASC
         """,
     )
     suspend fun nextDispatchable(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): List<PendingOperationV2Entity>
@@ -45,6 +59,17 @@ internal interface PendingOperationV2Dao {
     /** Count of ops still within retry budget — i.e. rows a future drain wave could dispatch. */
     @Query("SELECT COUNT(*) FROM pending_operation WHERE failureCount <= :maxAttempts")
     suspend fun countDispatchable(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Int
+
+    /**
+     * Latest `enqueuedAt` among all ops (dispatchable or dead-lettered) for (domainName, entityId),
+     * or null if none are queued. Backs the enqueue-time monotonic bump in `PendingOperationQueue.enqueue`
+     * that keeps same-entity ops from ever tying on `enqueuedAt`.
+     */
+    @Query("SELECT MAX(enqueuedAt) FROM pending_operation WHERE domainName = :domainName AND entityId = :entityId")
+    suspend fun maxEnqueuedAtFor(
+        domainName: String,
+        entityId: String,
+    ): Long?
 
     /**
      * True when a still-dispatchable (within retry budget) op exists for (domainName, entityId).

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -158,8 +158,12 @@ private fun classifyFailure(
  *   so the caller can correlate later echoes.
  * - [drain] dispatches one op per (domain, entityId) group via [PendingOperationSender]
  *   sequentially within a single call; cross-entity parallelism emerges across
- *   concurrent drain() schedulings, not within one. Per-entity FIFO comes from
- *   the SQL filter, not Mutex coordination.
+ *   concurrent drain() schedulings, not within one. Per-entity FIFO is a two-part
+ *   guarantee: [enqueue] bumps `enqueuedAt` strictly past any op already queued for
+ *   the same entity so same-entity ops never tie at the source, and
+ *   [PendingOperationV2Dao.nextDispatchable]'s window-function query breaks any
+ *   remaining tie deterministically by `clientOpId` — neither depends on Mutex
+ *   coordination or SQLite's undocumented bare-column `GROUP BY` tie-break.
  * - [hasQueuedOpFor] is the anti-flicker shield's primitive: a still-dispatchable
  *   op for (domain, entity) means a local edit is in flight, so an inbound echo/
  *   catch-up for that entity is shielded rather than clobbering the optimistic state.
@@ -254,6 +258,13 @@ internal class PendingOperationQueue(
             dao.deleteQueuedOps(channel.name, entityId, op.wire)
         }
         val opId = Uuid.random().toString()
+        val requestedAt = nowMillis()
+        val lastEnqueuedAt = dao.maxEnqueuedAtFor(channel.name, entityId)
+        // Bump strictly past any op already queued for this entity so two ops for the same
+        // entity never tie on enqueuedAt, even when enqueued in the same clock millisecond
+        // (fast double-actions, batch paths). Makes per-entity FIFO hold by construction at
+        // the source, ahead of nextDispatchable()'s own clientOpId tie-break.
+        val enqueuedAt = if (lastEnqueuedAt != null) maxOf(requestedAt, lastEnqueuedAt + 1) else requestedAt
         dao.insert(
             PendingOperationV2Entity(
                 clientOpId = opId,
@@ -261,7 +272,7 @@ internal class PendingOperationQueue(
                 entityId = entityId,
                 opType = op.wire,
                 payload = payload,
-                enqueuedAt = nowMillis(),
+                enqueuedAt = enqueuedAt,
                 lastAttemptAt = null,
                 failureCount = 0,
                 lastError = null,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 private val logger = KotlinLogging.logger {}
 
@@ -192,6 +194,11 @@ internal class PendingOperationQueue(
     private val sender: PendingOperationSender,
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
+    // Serializes drain() waves so the class is safe by construction against ANY caller —
+    // concurrent drain() calls both reading nextDispatchable() before either deletes its
+    // dispatched row would double-send. See [drain]'s KDoc.
+    private val drainMutex = Mutex()
+
     // The engine subscribes to this counter to schedule a drain whenever a new
     // op lands. A monotonic-counter StateFlow rather than a unit SharedFlow
     // because StateFlow's "new subscriber sees current value" semantics avoid
@@ -309,8 +316,12 @@ internal class PendingOperationQueue(
      * Per-entity FIFO is enforced by the SQL filter (one earliest op per
      * group), not by intra-call concurrency. Cross-entity parallelism emerges
      * across concurrent drain() schedulings: rows for different entities are
-     * independent and the SQL filter never picks the same row twice, so
-     * concurrent drain() calls do not contend on the same entity.
+     * independent and the SQL filter never picks the same row twice.
+     *
+     * The whole body runs under [drainMutex], so `drain()` is safe by construction
+     * against ANY caller — concurrent calls serialize rather than both reading
+     * [PendingOperationV2Dao.nextDispatchable] before either deletes its dispatched
+     * row (which would double-send). Callers do not need an external lock.
      *
      * One call = one wave. Caller schedules subsequent waves; drain() does not
      * loop. Returns a [DrainOutcome] so the engine can decide whether a retry
@@ -327,107 +338,112 @@ internal class PendingOperationQueue(
      * on the first throw would permanently lose a queued offline write. The op is
      * retried (bounded by [MAX_RETRYABLE_ATTEMPTS]) and the loop continues.
      */
-    suspend fun drain(): DrainOutcome {
-        dao.gcDeadLetters(cutoffMillis = nowMillis() - DEAD_LETTER_RETENTION_MILLIS)
-        val ops = dao.nextDispatchable()
-        var sent = 0
-        var retryableFailures = 0
-        var parkedFailures = 0
-        var terminalFailures = 0
-        val sentEntities = mutableListOf<SentEntityRef>()
-        for (entity in ops) {
-            val op = entity.toDomain()
-            val result =
-                try {
-                    sender.send(op)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // A thrown sender exception is a TRANSIENT (retryable) failure, never an instant
-                    // terminal dead-letter. A raw-proxy transport fault — a dead RpcClient after the
-                    // self-hosted server restarts, a dropped WebSocket — escapes as an untyped throwable
-                    // that ErrorMapper misclassifies as non-retryable, permanently losing a queued
-                    // position/edit on the first blip (a "never lose the user's position" violation).
-                    // Treating a throw as retryable keeps the op queued to retry once the connection
-                    // heals (the firehose reconnect invalidates the dead proxy); a genuinely buggy sender
-                    // burns the bounded retry budget and then dead-letters — the same bounded-waste
-                    // tradeoff a permanently-corrupt payload already accepts.
-                    logger.warn(e) { "Sender threw for op ${op.clientOpId} (${op.domainName}); retrying as transient" }
-                    dao.update(
-                        entity.copy(
-                            failureCount = entity.failureCount + 1,
-                            lastAttemptAt = nowMillis(),
-                            lastError = e::class.simpleName ?: "SenderException",
-                        ),
-                    )
-                    retryableFailures++
-                    continue
-                }
-            when (result) {
-                is AppResult.Success -> {
-                    dao.delete(op.clientOpId)
-                    sent++
-                    sentEntities += SentEntityRef(op.domainName, op.entityId)
-                }
+    suspend fun drain(): DrainOutcome =
+        drainMutex.withLock {
+            dao.gcDeadLetters(cutoffMillis = nowMillis() - DEAD_LETTER_RETENTION_MILLIS)
+            val ops = dao.nextDispatchable()
+            var sent = 0
+            var retryableFailures = 0
+            var parkedFailures = 0
+            var terminalFailures = 0
+            val sentEntities = mutableListOf<SentEntityRef>()
+            for (entity in ops) {
+                val op = entity.toDomain()
+                val result =
+                    try {
+                        sender.send(op)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // A thrown sender exception is a TRANSIENT (retryable) failure, never an instant
+                        // terminal dead-letter. A raw-proxy transport fault — a dead RpcClient after the
+                        // self-hosted server restarts, a dropped WebSocket — escapes as an untyped throwable
+                        // that ErrorMapper misclassifies as non-retryable, permanently losing a queued
+                        // position/edit on the first blip (a "never lose the user's position" violation).
+                        // Treating a throw as retryable keeps the op queued to retry once the connection
+                        // heals (the firehose reconnect invalidates the dead proxy); a genuinely buggy sender
+                        // burns the bounded retry budget and then dead-letters — the same bounded-waste
+                        // tradeoff a permanently-corrupt payload already accepts.
+                        logger.warn(
+                            e,
+                        ) { "Sender threw for op ${op.clientOpId} (${op.domainName}); retrying as transient" }
+                        dao.update(
+                            entity.copy(
+                                failureCount = entity.failureCount + 1,
+                                lastAttemptAt = nowMillis(),
+                                lastError = e::class.simpleName ?: "SenderException",
+                            ),
+                        )
+                        retryableFailures++
+                        continue
+                    }
+                when (result) {
+                    is AppResult.Success -> {
+                        dao.delete(op.clientOpId)
+                        sent++
+                        sentEntities += SentEntityRef(op.domainName, op.entityId)
+                    }
 
-                is AppResult.Failure -> {
-                    val error = result.error
-                    when (classifyFailure(error, op.domainName)) {
-                        FailureDisposition.Parked -> {
-                            // No server verdict (unreachable, or idempotent lost-response): record the
-                            // attempt for diagnostics but KEEP failureCount, so an outage can never
-                            // silently exhaust an op's budget. It stays dispatchable and re-sends on the
-                            // next reachability edge.
-                            dao.update(entity.copy(lastAttemptAt = nowMillis(), lastError = error.code))
-                            parkedFailures++
-                            logger.warn {
-                                "Pending op ${op.clientOpId} parked (no server verdict): ${error.code} " +
-                                    "(count=${entity.failureCount}, unburned)"
+                    is AppResult.Failure -> {
+                        val error = result.error
+                        when (classifyFailure(error, op.domainName)) {
+                            FailureDisposition.Parked -> {
+                                // No server verdict (unreachable, or idempotent lost-response): record the
+                                // attempt for diagnostics but KEEP failureCount, so an outage can never
+                                // silently exhaust an op's budget. It stays dispatchable and re-sends on the
+                                // next reachability edge.
+                                dao.update(entity.copy(lastAttemptAt = nowMillis(), lastError = error.code))
+                                parkedFailures++
+                                logger.warn {
+                                    "Pending op ${op.clientOpId} parked (no server verdict): ${error.code} " +
+                                        "(count=${entity.failureCount}, unburned)"
+                                }
                             }
-                        }
 
-                        FailureDisposition.Burn -> {
-                            // Server ANSWERED with a retryable failure (5xx): spend one attempt. A
-                            // persistently-5xx-ing op quarantines after MAX; a transient one costs ≤MAX.
-                            val newCount = entity.failureCount + 1
-                            dao.update(
-                                entity.copy(
-                                    failureCount = newCount,
-                                    lastAttemptAt = nowMillis(),
-                                    lastError = error.code,
-                                ),
-                            )
-                            retryableFailures++
-                            logger.warn {
-                                "Pending op ${op.clientOpId} failed (server-answered retryable): ${error.code} (count=$newCount)"
+                            FailureDisposition.Burn -> {
+                                // Server ANSWERED with a retryable failure (5xx): spend one attempt. A
+                                // persistently-5xx-ing op quarantines after MAX; a transient one costs ≤MAX.
+                                val newCount = entity.failureCount + 1
+                                dao.update(
+                                    entity.copy(
+                                        failureCount = newCount,
+                                        lastAttemptAt = nowMillis(),
+                                        lastError = error.code,
+                                    ),
+                                )
+                                retryableFailures++
+                                logger.warn {
+                                    "Pending op ${op.clientOpId} failed (server-answered retryable): ${error.code} (count=$newCount)"
+                                }
                             }
-                        }
 
-                        FailureDisposition.Terminal -> {
-                            // Non-retryable: leap past MAX so the SQL filter never picks it up again.
-                            dao.update(
-                                entity.copy(
-                                    failureCount = MAX_RETRYABLE_ATTEMPTS + 1,
-                                    lastAttemptAt = nowMillis(),
-                                    lastError = error.code,
-                                ),
-                            )
-                            terminalFailures++
-                            logger.warn { "Pending op ${op.clientOpId} dead-lettered (non-retryable): ${error.code}" }
+                            FailureDisposition.Terminal -> {
+                                // Non-retryable: leap past MAX so the SQL filter never picks it up again.
+                                dao.update(
+                                    entity.copy(
+                                        failureCount = MAX_RETRYABLE_ATTEMPTS + 1,
+                                        lastAttemptAt = nowMillis(),
+                                        lastError = error.code,
+                                    ),
+                                )
+                                terminalFailures++
+                                logger.warn {
+                                    "Pending op ${op.clientOpId} dead-lettered (non-retryable): ${error.code}"
+                                }
+                            }
                         }
                     }
                 }
             }
+            DrainOutcome(
+                sent = sent,
+                retryableFailures = retryableFailures,
+                parkedFailures = parkedFailures,
+                terminalFailures = terminalFailures,
+                remainingDispatchable = dao.countDispatchable(),
+                sentEntities = sentEntities,
+            )
         }
-        return DrainOutcome(
-            sent = sent,
-            retryableFailures = retryableFailures,
-            parkedFailures = parkedFailures,
-            terminalFailures = terminalFailures,
-            remainingDispatchable = dao.countDispatchable(),
-            sentEntities = sentEntities,
-        )
-    }
 
     /** Live count of ops still within retry budget. Engine forwards this to `SyncEngineState`. */
     fun observeQueueDepth(): Flow<Int> = dao.observeQueueDepth()

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -96,13 +96,6 @@ internal class SyncEngine(
     private var reconnectRefreshJob: Job? = null
     private var authGateJob: Job? = null
 
-    // Serializes drain waves so concurrent triggers (connection-up + enqueue +
-    // retry) coalesce into one wave at a time. drain() reads from the DAO and
-    // mutates rows; without a Mutex two concurrent drains would dispatch the
-    // same op twice. The Mutex is per-engine, not per-op — per-op FIFO is the
-    // queue's SQL filter responsibility.
-    private val drainMutex = Mutex()
-
     // The ONE shared choke point for cursor-advancing catch-up + digest reconcile — the same
     // "single dispatch seam" move the RpcChannel seam made for RPC. Every reconcile/catch-up entry
     // point ([runStart], [lifecycleReconcile], [handleCursorStale], [forceReconcile]) drives
@@ -116,8 +109,8 @@ internal class SyncEngine(
     // orchestration), and is never acquired while any other engine mutex is held — the caller-level
     // coalescers ([cursorStaleMutex], [lifecycleReconcileMutex]) and [startMutex] all release their
     // bookkeeping lock BEFORE the pass runs, so there is no lock-order inversion with this guard or
-    // with [drainMutex] (which the drain path holds independently and which never pages catch-up).
-    // Each caller's DISTINCT surrounding behavior (cursorStale's coalescing + await, lifecycle's
+    // with [PendingOperationQueue.drain]'s own internal mutex (held independently by the drain path,
+    // which never pages catch-up). Each caller's DISTINCT surrounding behavior (cursorStale's coalescing + await, lifecycle's
     // debounce + digest, start's ordering) is preserved above this seam; only the paging serializes.
     private val catchUpMutex = Mutex()
 
@@ -1004,8 +997,9 @@ internal class SyncEngine(
      * wave made progress (something sent or terminally quarantined) and more
      * dispatchable ops remain beyond this wave's own retryable failures.
      *
-     * Each wave runs under [drainMutex] so concurrent triggers (connect-up,
-     * enqueue, retry) coalesce. Retry scheduling is budget-aware:
+     * Concurrent triggers (connect-up, enqueue, retry) coalesce because
+     * [PendingOperationQueue.drain] itself is safe by construction — it serializes internally on
+     * its own mutex, so no wrapping lock is needed here. Retry scheduling is budget-aware:
      *  - **Server-answered retryable failures** (5xx, [DrainOutcome.hasRetryableFailures]) schedule
      *    a backoff-delayed re-drain — the server is up but erroring transiently, so a bounded timer
      *    retry is right.
@@ -1018,26 +1012,24 @@ internal class SyncEngine(
     private suspend fun runDrain() {
         while (true) {
             val outcome =
-                drainMutex.withLock {
-                    try {
-                        queue.drain()
-                    } catch (e: kotlinx.coroutines.CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        // Re-throwing here would tear down the trigger collector
-                        // and silently stop all future drains. Log and continue —
-                        // a future trigger will re-attempt.
-                        logger.warn(e) { "Drain wave failed unexpectedly; will retry on next trigger" }
-                        return
-                    }
+                try {
+                    queue.drain()
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Re-throwing here would tear down the trigger collector
+                    // and silently stop all future drains. Log and continue —
+                    // a future trigger will re-attempt.
+                    logger.warn(e) { "Drain wave failed unexpectedly; will retry on next trigger" }
+                    return
                 }
             // Reconcile-on-drain-success: an entity whose optimistic write was INCOMPLETE (e.g. a
             // new-by-name contributor that couldn't be linked offline) stayed stale because the
             // entity-level anti-flicker shield DROPPED the server echo while this op was in flight,
             // and the op is now gone. Targeted-fetch just-sent entities so the current server state
-            // lands promptly instead of waiting for the next lifecycle digest. Deliberately AFTER the
-            // drainMutex block: fetchTransient serializes on catchUpMutex (a leaf lock), which must
-            // never be acquired while drainMutex is held (non-inversion).
+            // lands promptly instead of waiting for the next lifecycle digest. Deliberately AFTER
+            // queue.drain() returns: fetchTransient serializes on catchUpMutex (a leaf lock), which
+            // must never be acquired while the queue's own drain mutex is held (non-inversion).
             reconcileSentEntities(outcome.sentEntities)
             val madeProgress = outcome.sent > 0 || outcome.terminalFailures > 0
             // Both this wave's server-answered retries AND its parked ops remain dispatchable (still
@@ -1072,9 +1064,10 @@ internal class SyncEngine(
      *    would 500 and buy nothing; its echo converges via `?since=` catch-up / newer-wins instead.
      *
      * Runs under the shared [catchUpMutex] so it serializes with catch-up/reconcile paging (never
-     * concurrent), and NOT under [drainMutex] (released by the caller before this runs) so there is
-     * no lock-order inversion. Best-effort: a failed fetch logs and moves on — the digest reconcile
-     * is the convergence backstop.
+     * concurrent), and NOT under [PendingOperationQueue.drain]'s own mutex (already released by the
+     * caller before this runs, since `queue.drain()` has returned) so there is no lock-order
+     * inversion. Best-effort: a failed fetch logs and moves on — the digest reconcile is the
+     * convergence backstop.
      */
     private suspend fun reconcileSentEntities(sentEntities: List<SentEntityRef>) {
         if (sentEntities.isEmpty()) return

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ProfileEditRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ProfileEditRepositoryImplTest.kt
@@ -86,7 +86,11 @@ class ProfileEditRepositoryImplTest :
          * these unit tests); the transaction runner runs [OfflineEditor]'s local write inline.
          */
         fun buildOfflineEditor(
-            pendingDao: PendingOperationV2Dao = mock<PendingOperationV2Dao> { everySuspend { insert(any()) } returns Unit },
+            pendingDao: PendingOperationV2Dao =
+                mock<PendingOperationV2Dao> {
+                    everySuspend { insert(any()) } returns Unit
+                    everySuspend { maxEnqueuedAtFor(any(), any()) } returns null
+                },
             authSession: AuthSession = FakeAuthSession(userId = userId),
         ): OfflineEditor {
             val queue =
@@ -130,6 +134,7 @@ class ProfileEditRepositoryImplTest :
                 val userDao = mock<UserDao>()
                 val pendingDao = mock<PendingOperationV2Dao>()
                 everySuspend { pendingDao.insert(any()) } returns Unit
+                everySuspend { pendingDao.maxEnqueuedAtFor(any(), any()) } returns null
                 everySuspend { userDao.getCurrentUser() } returns userEntity
                 everySuspend { userDao.updateTagline(any(), any(), any()) } returns Unit
 
@@ -178,6 +183,7 @@ class ProfileEditRepositoryImplTest :
                 val userDao = mock<UserDao>()
                 val pendingDao = mock<PendingOperationV2Dao>()
                 everySuspend { pendingDao.insert(any()) } returns Unit
+                everySuspend { pendingDao.maxEnqueuedAtFor(any(), any()) } returns null
                 everySuspend { userDao.getCurrentUser() } returns userEntity
                 everySuspend { userDao.updateName(any(), any(), any(), any(), any()) } returns Unit
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
@@ -117,6 +117,11 @@ private class FakePendingOperationV2Dao : PendingOperationV2Dao {
         inserted.clear()
     }
 
+    override suspend fun maxEnqueuedAtFor(
+        domainName: String,
+        entityId: String,
+    ): Long? = inserted.filter { it.domainName == domainName && it.entityId == entityId }.maxOfOrNull { it.enqueuedAt }
+
     override suspend fun gcDeadLetters(
         cutoffMillis: Long,
         maxAttempts: Int,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2DaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2DaoTest.kt
@@ -81,6 +81,21 @@ class PendingOperationV2DaoTest :
             }
         }
 
+        test("nextDispatchable breaks same-enqueuedAt ties by clientOpId, not insertion order") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val dao = db.pendingOperationV2Dao()
+                val tiedEnqueuedAt = 500L
+                // Insert the alphabetically-larger clientOpId FIRST so a pass here can't be explained
+                // by SQLite happening to pick the earliest-inserted row.
+                dao.insert(row("z-op", "tags", "t1", tiedEnqueuedAt))
+                dao.insert(row("a-op", "tags", "t1", tiedEnqueuedAt))
+                val next = dao.nextDispatchable()
+                next.map { it.clientOpId } shouldContainExactly listOf("a-op")
+                db.close()
+            }
+        }
+
         test("nextDispatchable orders globally by enqueuedAt across groups") {
             runTest {
                 val db = createInMemoryTestDatabase()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -27,6 +27,16 @@ import kotlinx.serialization.builtins.serializer
 private val upsertOnlyChannel =
     OutboxChannel("undeclared_test_domain", String.serializer(), setOf(OpKind.Upsert), idempotent = true)
 
+// A second synthetic channel (also not one of OutboxChannels.all) for tests that need both
+// Update and Delete op kinds on the same entity.
+private val updateDeleteChannel =
+    OutboxChannel(
+        "undeclared_update_delete_domain",
+        String.serializer(),
+        setOf(OpKind.Update, OpKind.Delete),
+        idempotent = true,
+    )
+
 class PendingOperationQueueTest :
     FunSpec({
 
@@ -172,6 +182,49 @@ class PendingOperationQueueTest :
                 val second = queue.drain()
                 second.sent shouldBe 1
                 second.remainingDispatchable shouldBe 0
+                db.close()
+            }
+        }
+
+        test("enqueue bumps enqueuedAt so two same-clock ops for one entity never tie") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                        nowMillis = { 1_000L },
+                    )
+                val first = queue.enqueue(upsertOnlyChannel, "t1", OpKind.Upsert, "{}", "u1")
+                val second = queue.enqueue(upsertOnlyChannel, "t1", OpKind.Upsert, "{}", "u1")
+                val firstRow = db.pendingOperationV2Dao().get(first)!!
+                val secondRow = db.pendingOperationV2Dao().get(second)!!
+                (secondRow.enqueuedAt > firstRow.enqueuedAt) shouldBe true
+                db.close()
+            }
+        }
+
+        test("update then delete for the same entity at the same instant drains update first, delete second") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val sent = mutableListOf<String>()
+                val sender =
+                    PendingOperationSender { op ->
+                        sent += op.opType
+                        AppResult.Success(Unit)
+                    }
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = sender,
+                        nowMillis = { 1_000L },
+                    )
+                queue.enqueue(updateDeleteChannel, "t1", OpKind.Update, "{}", "u1")
+                queue.enqueue(updateDeleteChannel, "t1", OpKind.Delete, "{}", "u1")
+                queue.drain()
+                sent shouldContainExactly listOf("update")
+                queue.drain()
+                sent shouldContainExactly listOf("update", "delete")
                 db.close()
             }
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -16,7 +16,12 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.builtins.serializer
 
@@ -392,6 +397,49 @@ class PendingOperationQueueTest :
                 dao.get("dead-ancient") shouldBe null
                 dao.get("dead-recent") shouldNotBe null
                 db.close()
+            }
+        }
+
+        test("concurrent drain() calls never dispatch the same op twice") {
+            runBlocking {
+                val db = createInMemoryTestDatabase()
+                try {
+                    val dispatchCount = AtomicInteger(0)
+                    val firstSenderEntered = CompletableDeferred<Unit>()
+                    val releaseFirstSender = CompletableDeferred<Unit>()
+                    val sender =
+                        PendingOperationSender {
+                            // The FIRST dispatch parks mid-send (holding the op's row un-deleted) so a
+                            // concurrent second drain() gets a real chance to read the same still-queued
+                            // row before the first drain deletes it — the exact double-send window
+                            // `PendingOperationQueue.drain` must close by construction.
+                            if (dispatchCount.incrementAndGet() == 1) {
+                                firstSenderEntered.complete(Unit)
+                                releaseFirstSender.await()
+                            }
+                            AppResult.Success(Unit)
+                        }
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = sender,
+                        )
+                    queue.enqueue(upsertOnlyChannel, "t1", OpKind.Upsert, "{}", "u1")
+
+                    val firstDrain = async { queue.drain() }
+                    firstSenderEntered.await()
+                    val secondDrain = async { queue.drain() }
+                    // Give the second drain a real chance to race the first drain's still-unfinished
+                    // dispatch before releasing it.
+                    delay(50)
+                    releaseFirstSender.complete(Unit)
+                    firstDrain.await()
+                    secondDrain.await()
+
+                    dispatchCount.get() shouldBe 1
+                } finally {
+                    db.close()
+                }
             }
         }
     })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -610,6 +610,11 @@ private class CountingDao(
 
     override suspend fun deleteAll() = delegate.deleteAll()
 
+    override suspend fun maxEnqueuedAtFor(
+        domainName: String,
+        entityId: String,
+    ) = delegate.maxEnqueuedAtFor(domainName, entityId)
+
     override suspend fun gcDeadLetters(
         cutoffMillis: Long,
         maxAttempts: Int,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -12,7 +12,9 @@ import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -35,6 +37,31 @@ private const val TIMEOUT_SECONDS = 5L
 private const val RETRY_TIMEOUT_SECONDS = 10L
 private const val MIN_RETRY_ATTEMPTS = 2
 private const val POLL_DELAY_MILLIS = 20L
+
+/**
+ * Proves a negative — [current] stays at [expected] for the whole [windowMillis] window — by
+ * polling every [POLL_DELAY_MILLIS] and failing IMMEDIATELY the instant a deviation is observed,
+ * rather than a single point-in-time read after a fixed sleep. A fixed-sleep-then-single-read is
+ * inherently load-sensitive: it only catches a deviation that happens to still hold at the exact
+ * moment the assertion runs, and gives no information about when the deviation actually happened.
+ * Passes once the full window elapses without any deviation.
+ */
+private suspend fun assertStaysAt(
+    expected: Int,
+    windowMillis: Long = POLL_DELAY_MILLIS * 10,
+    current: () -> Int,
+) {
+    val deadline = TimeSource.Monotonic.markNow() + windowMillis.milliseconds
+    while (deadline.hasNotPassedNow()) {
+        val observed = current()
+        if (observed != expected) {
+            throw AssertionError(
+                "expected to stay at $expected for ${windowMillis}ms but observed $observed mid-window",
+            )
+        }
+        delay(POLL_DELAY_MILLIS)
+    }
+}
 
 /**
  * Verifies `SyncEngine` schedules `PendingOperationQueue.drain()` on the three
@@ -187,13 +214,10 @@ class PendingQueueDrainSchedulingTest :
                     state.setConnection(ConnectionState.Connected(lastEventId = 1L))
                     state.setConnection(ConnectionState.Connected(lastEventId = 2L))
 
-                    // Give the engine plenty of time to (incorrectly) re-fire drain.
-                    delay(POLL_DELAY_MILLIS * 10)
-
                     // The two re-emissions must NOT trigger additional drain
                     // waves: the trigger fires once per transition into
                     // Connected, not per Connected snapshot.
-                    dispatchCalls.get() shouldBe baseline
+                    assertStaysAt(expected = baseline) { dispatchCalls.get() }
                 } finally {
                     // Order matters: cancel-and-join the scope BEFORE closing
                     // the DB. Closing the DB while a runDrain is mid-transaction
@@ -308,8 +332,7 @@ class PendingQueueDrainSchedulingTest :
                         while (attempts.get() < 1) delay(POLL_DELAY_MILLIS)
                     }
                     // Parked: no busy-loop. Across many backoff windows the count must NOT climb.
-                    delay(POLL_DELAY_MILLIS * 10)
-                    attempts.get() shouldBe 1
+                    assertStaysAt(expected = 1) { attempts.get() }
                     db.pendingOperationV2Dao().get(opId)?.failureCount shouldBe 0
 
                     // Server returns; a reconnect (Disconnected→Connected edge) re-drives drain and delivers.
@@ -403,10 +426,8 @@ class PendingQueueDrainSchedulingTest :
 
                     val opId = queue.enqueue(tagsChannel, "t-offline", OpKind.Upsert, "{}", "u1")
 
-                    // Give the engine ample time to (wrongly) attempt a drain.
-                    delay(POLL_DELAY_MILLIS * 10)
-
-                    attempts.get() shouldBe 0
+                    // The engine must never attempt a drain while offline.
+                    assertStaysAt(expected = 0) { attempts.get() }
                     // The op is still queued, its retry budget untouched, ready for the next online edge.
                     db.pendingOperationV2Dao().get(opId)?.failureCount shouldBe 0
                 } finally {

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStateObserversTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStateObserversTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.builtins.serializer
 
 private const val TIMEOUT_SECONDS = 5L
+private const val DEAD_LETTER_OBSERVER_TIMEOUT_SECONDS = 15L
 
 // "tags" is not a real outbox channel — a minimal local fixture for a hypothetical
 // un-mirrored domain, matching the queue's payload-agnostic contract.
@@ -122,7 +123,16 @@ class SyncEngineStateObserversTest :
                             ),
                         )
 
+                    // Await the DAO's own visibility of the insert BEFORE asserting on the engine's
+                    // observer pipeline — Room's InvalidationTracker propagation latency is a separate
+                    // (and separately load-sensitive) concern from whether SyncEngineState correctly
+                    // forwards observeDeadLetterCount(). Splitting the two means a failure here can only
+                    // mean the engine's forwarding is broken, never that the write hadn't landed yet.
                     withTimeout(TIMEOUT_SECONDS.seconds) {
+                        db.pendingOperationV2Dao().observeDeadLetterCount().first { it == 1 }
+                    }
+
+                    withTimeout(DEAD_LETTER_OBSERVER_TIMEOUT_SECONDS.seconds) {
                         state.observe().first { it.deadLetterCount == 1 }
                     }
                 } finally {


### PR DESCRIPTION
From the 2026-07-16 pre-ship audit (baseline 9ad7e179f):

- **Per-entity FIFO is now contractual** (`PendingOperationV2Dao.nextDispatchable`): rewritten as a `ROW_NUMBER()` window query with an explicit tie-break, replacing reliance on SQLite's undocumented bare-column GROUP BY behavior; `enqueue` additionally bumps `enqueuedAt` past any queued op for the same entity so same-entity ops never tie at the source. No schema change.
- **`PendingOperationQueue.drain()` is safe by construction**: the serialization mutex moved from `SyncEngine` into the queue itself, so any future caller is race-free; `SyncEngine.drainMutex` (which exclusively wrapped this call) removed with lock-ordering docs updated.
- **Flaky-test hardening**: `PendingQueueDrainSchedulingTest`'s three sleep-then-single-read negative assertions replaced with a fail-fast bounded poll; `SyncEngineStateObserversTest`'s deadLetterCount test now separates Room invalidation propagation from the engine-observer assertion (15s headroom). Both ran 10/10 green locally.

Also includes the audit's OUTBOX-03 investigation (cross-user drain window): confirmed real but not safely cheap to patch piecemeal — full analysis in the session notes; follow-up recommended to consolidate the divergent sign-out paths (navigation/Desktop inline teardown vs SettingsViewModel→LogoutUseCase; correction: LogoutUseCase IS called from SettingsViewModel — the "never called" investigation claim was wrong).

All TDD (red→green verified), gates green: spotless+detekt, `:sharedLogic:jvmTest` (3376+ tests).
