### PR TITLE
🐛 fix(server/shared): playback-position integrity from the 2026-07-16 pre-ship audit

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
@@ -15,6 +15,7 @@ import com.calypsan.listenup.server.sync.IdRev
 import com.calypsan.listenup.server.sync.SqlSyncableRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.sync.SyncableSubstrateQueries
+import kotlin.math.min
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -207,14 +208,17 @@ class PlaybackPositionRepository(
      * returned unchanged — a stale offline write never clobbers a fresher position from another
      * device.
      *
+     * `lastPlayedAt` arrives verbatim from the client's device clock, so it is clamped against the
+     * server clock before it does anything else — see the *why* comment at the clamp site.
+     *
      * The position row commits via [SqlSyncableRepository.upsert]; the completion/start cascade hooks
      * are de-nested and fire sequentially afterwards (see the class KDoc).
      *
      * [startedBookOccurredAt] overrides ONLY the `STARTED_BOOK` activity date (both the new-start and
      * the re-read [StatsEvent.BookRestarted] branches). The ABS-import backfill uses it to date the
      * imported start strictly before the book's imported sessions; live callers leave it null and the
-     * activity keeps using [lastPlayedAt]. Position `lastPlayedAt` semantics (the wins-guard, the
-     * payload, the `BookCompleted` date) are untouched by this parameter.
+     * activity keeps using the clamped `lastPlayedAt`. Position `lastPlayedAt` semantics (the
+     * wins-guard, the payload, the `BookCompleted` date) are untouched by this parameter.
      */
     suspend fun recordPosition(
         userId: String,
@@ -226,9 +230,31 @@ class PlaybackPositionRepository(
         currentChapterId: String?,
         startedBookOccurredAt: Long? = null,
     ): AppResult<PlaybackPositionSyncPayload> {
+        val now = clock.now().toEpochMilliseconds()
+        // Clamp #1 (persisted): a device with a clock set into the future must not be able to plant
+        // a `lastPlayedAt` that permanently outranks every honest write that follows — that write
+        // would poison this row forever, since positions are digest-opt-out and nothing else ever
+        // reconciles them. SKEW_TOLERANCE is generous for honest clock drift; an offline-for-days
+        // device has an OLD timestamp, which this clamp never touches — only future-dating is capped.
+        // This clamped value is what gets persisted below and what ships in the sync payload.
+        val clampedLastPlayedAt = min(lastPlayedAt, now + SKEW_TOLERANCE_MS)
+
         val existing = getPosition(userId, bookId)
+        // Clamp #2 (comparison-only, never rewrites the stored row): a row poisoned before this
+        // clamp existed — or written by any path that bypasses it — can carry a raw `lastPlayedAt`
+        // arbitrarily far in the future. Holding it to the SAME `now + SKEW_TOLERANCE` ceiling the
+        // incoming side is held to keeps every comparison symmetric: neither side can ever hold a
+        // bigger "budget" than the other is allowed. It never makes a currently-poisoned row lose
+        // any sooner (a still-future raw value pins to the identical ceiling on both sides, so the
+        // guard below still no-ops until the row is genuinely superseded) — its job is to prevent a
+        // legacy/foreign-written row from being trusted MORE than a row this method would itself
+        // produce, so nothing about the write path's own guarantees is undermined by data it didn't
+        // write. Recovery for such a row still runs on ordinary lastPlayedAt-wins once an honest
+        // write's own timestamp genuinely overtakes the raw stored value (clamp #1 guarantees THAT
+        // never takes longer than SKEW_TOLERANCE for any row written through this method).
+        val existingForComparison = existing?.let { min(it.lastPlayedAt, now + SKEW_TOLERANCE_MS) }
         // lastPlayedAt-wins: a stale write is a no-op, returning the stored payload and firing no hooks.
-        if (existing != null && existing.lastPlayedAt >= lastPlayedAt) {
+        if (existing != null && existingForComparison!! >= clampedLastPlayedAt) {
             return AppResult.Success(existing)
         }
 
@@ -239,7 +265,7 @@ class PlaybackPositionRepository(
                 id = id,
                 bookId = bookId,
                 positionMs = positionMs,
-                lastPlayedAt = lastPlayedAt,
+                lastPlayedAt = clampedLastPlayedAt,
                 finished = finished,
                 playbackSpeed = playbackSpeed,
                 currentChapterId = currentChapterId,
@@ -260,7 +286,7 @@ class PlaybackPositionRepository(
                 StatsEvent.BookCompleted(
                     userId = userId,
                     bookId = bookId,
-                    occurredAt = Instant.fromEpochMilliseconds(lastPlayedAt),
+                    occurredAt = Instant.fromEpochMilliseconds(clampedLastPlayedAt),
                 ),
             )
         } else if (!finished) {
@@ -270,7 +296,7 @@ class PlaybackPositionRepository(
                     StatsEvent.BookRestarted(
                         userId = userId,
                         bookId = bookId,
-                        occurredAt = Instant.fromEpochMilliseconds(startedBookOccurredAt ?: lastPlayedAt),
+                        occurredAt = Instant.fromEpochMilliseconds(startedBookOccurredAt ?: clampedLastPlayedAt),
                         isReread = false,
                     ),
                 )
@@ -279,7 +305,7 @@ class PlaybackPositionRepository(
                     StatsEvent.BookRestarted(
                         userId = userId,
                         bookId = bookId,
-                        occurredAt = Instant.fromEpochMilliseconds(startedBookOccurredAt ?: lastPlayedAt),
+                        occurredAt = Instant.fromEpochMilliseconds(startedBookOccurredAt ?: clampedLastPlayedAt),
                         isReread = true,
                     ),
                 )
@@ -326,19 +352,28 @@ class PlaybackPositionRepository(
                 .forEach { existing -> existingByKey[userId to existing.bookId] = existing }
         }
 
+        // Same two-clamp reasoning as recordPosition: ABS import rows carry historical timestamps
+        // that are legitimately old (untouched by this clamp — only future-dating is capped), but a
+        // corrupt/future-dated import row must not be able to poison a row the same way a bad device
+        // clock would. One `now` reading for the whole batch — every prepared row is clamped against it.
+        val now = clock.now().toEpochMilliseconds()
+
         val prepared = ArrayList<PreparedPositionWrite>(rows.size)
         for (row in rows) {
             val key = row.userId to row.bookId
             val existing = existingByKey[key]
+            val clampedLastPlayedAt = min(row.lastPlayedAt, now + SKEW_TOLERANCE_MS)
+            // Comparison-only clamp on the existing side — see recordPosition's Clamp #2 comment.
+            val existingForComparison = existing?.let { min(it.lastPlayedAt, now + SKEW_TOLERANCE_MS) }
             // lastPlayedAt-wins: a stale write is a no-op, exactly as recordPosition returns early.
-            if (existing != null && existing.lastPlayedAt >= row.lastPlayedAt) continue
+            if (existing != null && existingForComparison!! >= clampedLastPlayedAt) continue
 
             val payload =
                 PlaybackPositionSyncPayload(
                     id = existing?.id ?: Uuid.random().toString(),
                     bookId = row.bookId,
                     positionMs = row.positionMs,
-                    lastPlayedAt = row.lastPlayedAt,
+                    lastPlayedAt = clampedLastPlayedAt,
                     finished = row.finished,
                     playbackSpeed = row.playbackSpeed,
                     currentChapterId = row.currentChapterId,
@@ -539,6 +574,14 @@ class PlaybackPositionRepository(
 
         /** Import rows per write transaction — one [suspendTransaction] commits a whole chunk. */
         const val PERSIST_CHUNK_SIZE = 200
+
+        /**
+         * How far into the future a client-reported `lastPlayedAt` is trusted, relative to the
+         * server clock — generous for honest clock drift, but nothing further out survives the
+         * clamp in [recordPosition] / [recordAllForImport]. Never bounds the past: an
+         * offline-for-days device's old timestamp is untouched.
+         */
+        const val SKEW_TOLERANCE_MS = 5 * 60 * 1000L
 
         /** SQLite stores booleans as INTEGER 0/1; map at the write boundary. */
         private fun Boolean.toDbLong(): Long = if (this) 1L else 0L

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
@@ -242,19 +242,15 @@ class PlaybackPositionRepository(
         val existing = getPosition(userId, bookId)
         // Clamp #2 (comparison-only, never rewrites the stored row): a row poisoned before this
         // clamp existed — or written by any path that bypasses it — can carry a raw `lastPlayedAt`
-        // arbitrarily far in the future. Holding it to the SAME `now + SKEW_TOLERANCE` ceiling the
-        // incoming side is held to keeps every comparison symmetric: neither side can ever hold a
-        // bigger "budget" than the other is allowed. It never makes a currently-poisoned row lose
-        // any sooner (a still-future raw value pins to the identical ceiling on both sides, so the
-        // guard below still no-ops until the row is genuinely superseded) — its job is to prevent a
-        // legacy/foreign-written row from being trusted MORE than a row this method would itself
-        // produce, so nothing about the write path's own guarantees is undermined by data it didn't
-        // write. Recovery for such a row still runs on ordinary lastPlayedAt-wins once an honest
-        // write's own timestamp genuinely overtakes the raw stored value (clamp #1 guarantees THAT
-        // never takes longer than SKEW_TOLERANCE for any row written through this method).
-        val existingForComparison = existing?.let { min(it.lastPlayedAt, now + SKEW_TOLERANCE_MS) }
+        // arbitrarily far in the future. No row this method writes can EVER legitimately exceed
+        // `now + SKEW_TOLERANCE` (clamp #1 guarantees that), so a stored value beyond that ceiling
+        // is definitionally corrupt — it can only have gotten there some other way. Such a row
+        // unconditionally LOSES to a fresh honest write, immediately, regardless of how far in the
+        // future its raw value is: healing must not depend on real time closing a gap that could be
+        // years wide.
+        val existingIsPoisoned = existing != null && existing.lastPlayedAt > now + SKEW_TOLERANCE_MS
         // lastPlayedAt-wins: a stale write is a no-op, returning the stored payload and firing no hooks.
-        if (existing != null && existingForComparison!! >= clampedLastPlayedAt) {
+        if (existing != null && !existingIsPoisoned && existing.lastPlayedAt >= clampedLastPlayedAt) {
             return AppResult.Success(existing)
         }
 
@@ -363,10 +359,10 @@ class PlaybackPositionRepository(
             val key = row.userId to row.bookId
             val existing = existingByKey[key]
             val clampedLastPlayedAt = min(row.lastPlayedAt, now + SKEW_TOLERANCE_MS)
-            // Comparison-only clamp on the existing side — see recordPosition's Clamp #2 comment.
-            val existingForComparison = existing?.let { min(it.lastPlayedAt, now + SKEW_TOLERANCE_MS) }
+            // Poisoned-row override — see recordPosition's Clamp #2 comment.
+            val existingIsPoisoned = existing != null && existing.lastPlayedAt > now + SKEW_TOLERANCE_MS
             // lastPlayedAt-wins: a stale write is a no-op, exactly as recordPosition returns early.
-            if (existing != null && existingForComparison!! >= clampedLastPlayedAt) continue
+            if (existing != null && !existingIsPoisoned && existing.lastPlayedAt >= clampedLastPlayedAt) continue
 
             val payload =
                 PlaybackPositionSyncPayload(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/PlaybackPositionClockSkewTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/PlaybackPositionClockSkewTest.kt
@@ -47,12 +47,11 @@ class PlaybackPositionClockSkewTest :
                     val poisoned = repo.getPosition("u1", "book-1").shouldNotBeNull()
                     poisoned.lastPlayedAt shouldBe now0 + 5 * 60 * 1000L
 
-                    // Distinct clock instant — the server clock advances past the clamp ceiling
-                    // before the next (honest) write arrives, exactly as it would once real wall-clock
-                    // time passes. Since the clamp already bounded the stored value to now0 + 5min,
-                    // any later write with a genuinely honest (near-current) timestamp beats it via
-                    // ordinary lastPlayedAt-wins — no waiting for the clock to catch up to the raw
-                    // 3-day skew the device originally reported.
+                    // A row THIS METHOD wrote is never classified poisoned by the guard (it can never
+                    // exceed writeTimeNow + SKEW_TOLERANCE <= currentNow + SKEW_TOLERANCE) — so this is
+                    // ordinary lastPlayedAt-wins, not the poisoned-row override: the later honest write
+                    // must genuinely exceed the clamped now0 + 5min ceiling to win. Advance the clock so
+                    // the honest write's own (near-current) timestamp does.
                     clock.instant = Instant.fromEpochMilliseconds(now0 + 6 * 60 * 1000L)
                     val honestLastPlayedAt = clock.instant.toEpochMilliseconds() + 1_000L
                     val result =
@@ -74,17 +73,17 @@ class PlaybackPositionClockSkewTest :
             }
         }
 
-        test("recordPosition heals a pre-poisoned row inserted directly with a far-future lastPlayedAt") {
+        test("recordPosition immediately overrides a pre-poisoned row inserted directly with a far-future lastPlayedAt") {
             withSqlDatabase {
+                val now0 = 1_730_000_000_000L
                 // Simulates a row poisoned before this clamp existed (or written by a path that
                 // bypasses recordPosition entirely) — inserted straight through SQLDelight, never
-                // touching the write-time clamp. Clamp #2 bounds this row's comparison "budget" to
-                // now + SKEW_TOLERANCE just like a fresh write, but can never make it LOSE any sooner
-                // than plain lastPlayedAt-wins already would (both sides collapse to the same ceiling
-                // while still in the future, so nothing ever beats it until real time reaches the raw
-                // value) — this pins that a pre-fix poisoned row is still eventually recoverable once
-                // an honest write's own timestamp genuinely supersedes it, not stuck forever.
-                val poisonedAt = 1_730_300_000_000L
+                // touching the write-time clamp. No row this method writes could ever be 3 days in
+                // the future, so this raw value is definitionally corrupt: the poisoned-row override
+                // must reject it OUTRIGHT, at the CURRENT wall-clock time — a device clock a year fast
+                // must not poison a row for a year while honest writes wait for real time to close a
+                // gap that could be arbitrarily wide.
+                val poisonedAt = now0 + 3L * 24 * 60 * 60 * 1000
                 sql.playbackPositionsQueries.insert(
                     id = "pos-1",
                     user_id = "u1",
@@ -101,18 +100,19 @@ class PlaybackPositionClockSkewTest :
                     client_op_id = null,
                 )
 
-                // The server clock has caught up to (just past) the raw poisoned timestamp — modeling
-                // wall-clock time genuinely reaching it. An honest write dated after it must win.
-                val clock = MutableClock(Instant.fromEpochMilliseconds(poisonedAt))
+                // The clock stays at a realistic "now", days before the poisoned timestamp — no
+                // waiting for wall-clock time to close the gap.
+                val clock = MutableClock(Instant.fromEpochMilliseconds(now0))
                 val repo =
                     PlaybackPositionRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry(), clock = clock)
                 runTest {
+                    val honestLastPlayedAt = now0 + 1_000L
                     val result =
                         repo.recordPosition(
                             userId = "u1",
                             bookId = "book-1",
                             positionMs = 5_000L,
-                            lastPlayedAt = poisonedAt + 1_000L,
+                            lastPlayedAt = honestLastPlayedAt,
                             finished = false,
                             playbackSpeed = 1.0f,
                             currentChapterId = null,
@@ -120,7 +120,7 @@ class PlaybackPositionClockSkewTest :
                     result.shouldBeInstanceOf<AppResult.Success<*>>()
 
                     val healed = repo.getPosition("u1", "book-1").shouldNotBeNull()
-                    healed.lastPlayedAt shouldBe poisonedAt + 1_000L
+                    healed.lastPlayedAt shouldBe honestLastPlayedAt
                     healed.positionMs shouldBe 5_000L
                 }
             }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/PlaybackPositionClockSkewTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/PlaybackPositionClockSkewTest.kt
@@ -1,0 +1,193 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.MutableClock
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * POSITION-01 — [PlaybackPositionRepository.recordPosition]'s clock-skew clamp. `lastPlayedAt`
+ * arrives verbatim from the client's device clock; a device with a clock set into the future must
+ * not be able to plant a value that permanently outranks every honest write that follows —
+ * positions are digest-opt-out, so nothing else ever reconciles a poisoned row. Split out of
+ * [PlaybackPositionRepositoryTest] (which is already at detekt's `LargeClass` ceiling) the same way
+ * [PlaybackPositionImportBatchTest] is.
+ */
+class PlaybackPositionClockSkewTest :
+    FunSpec({
+
+        test("recordPosition clamps a future-skewed lastPlayedAt, and a later honest write heals the row") {
+            withSqlDatabase {
+                val now0 = 1_730_000_000_000L
+                val clock = MutableClock(Instant.fromEpochMilliseconds(now0))
+                val repo =
+                    PlaybackPositionRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry(), clock = clock)
+                runTest {
+                    val threeDaysAhead = now0 + 3L * 24 * 60 * 60 * 1000
+                    repo.recordPosition(
+                        userId = "u1",
+                        bookId = "book-1",
+                        positionMs = 1_000L,
+                        lastPlayedAt = threeDaysAhead,
+                        finished = false,
+                        playbackSpeed = 1.0f,
+                        currentChapterId = null,
+                    )
+
+                    // Clamped to now0 + 5min, NOT the raw 3-days-ahead value the device reported.
+                    val poisoned = repo.getPosition("u1", "book-1").shouldNotBeNull()
+                    poisoned.lastPlayedAt shouldBe now0 + 5 * 60 * 1000L
+
+                    // Distinct clock instant — the server clock advances past the clamp ceiling
+                    // before the next (honest) write arrives, exactly as it would once real wall-clock
+                    // time passes. Since the clamp already bounded the stored value to now0 + 5min,
+                    // any later write with a genuinely honest (near-current) timestamp beats it via
+                    // ordinary lastPlayedAt-wins — no waiting for the clock to catch up to the raw
+                    // 3-day skew the device originally reported.
+                    clock.instant = Instant.fromEpochMilliseconds(now0 + 6 * 60 * 1000L)
+                    val honestLastPlayedAt = clock.instant.toEpochMilliseconds() + 1_000L
+                    val result =
+                        repo.recordPosition(
+                            userId = "u1",
+                            bookId = "book-1",
+                            positionMs = 2_000L,
+                            lastPlayedAt = honestLastPlayedAt,
+                            finished = false,
+                            playbackSpeed = 1.0f,
+                            currentChapterId = null,
+                        )
+                    result.shouldBeInstanceOf<AppResult.Success<*>>()
+
+                    val healed = repo.getPosition("u1", "book-1").shouldNotBeNull()
+                    healed.lastPlayedAt shouldBe honestLastPlayedAt
+                    healed.positionMs shouldBe 2_000L
+                }
+            }
+        }
+
+        test("recordPosition heals a pre-poisoned row inserted directly with a far-future lastPlayedAt") {
+            withSqlDatabase {
+                // Simulates a row poisoned before this clamp existed (or written by a path that
+                // bypasses recordPosition entirely) — inserted straight through SQLDelight, never
+                // touching the write-time clamp. Clamp #2 bounds this row's comparison "budget" to
+                // now + SKEW_TOLERANCE just like a fresh write, but can never make it LOSE any sooner
+                // than plain lastPlayedAt-wins already would (both sides collapse to the same ceiling
+                // while still in the future, so nothing ever beats it until real time reaches the raw
+                // value) — this pins that a pre-fix poisoned row is still eventually recoverable once
+                // an honest write's own timestamp genuinely supersedes it, not stuck forever.
+                val poisonedAt = 1_730_300_000_000L
+                sql.playbackPositionsQueries.insert(
+                    id = "pos-1",
+                    user_id = "u1",
+                    book_id = "book-1",
+                    position_ms = 1_000L,
+                    last_played_at = poisonedAt,
+                    finished = 0L,
+                    playback_speed = 1.0,
+                    current_chapter_id = null,
+                    revision = 1L,
+                    created_at = poisonedAt,
+                    updated_at = poisonedAt,
+                    deleted_at = null,
+                    client_op_id = null,
+                )
+
+                // The server clock has caught up to (just past) the raw poisoned timestamp — modeling
+                // wall-clock time genuinely reaching it. An honest write dated after it must win.
+                val clock = MutableClock(Instant.fromEpochMilliseconds(poisonedAt))
+                val repo =
+                    PlaybackPositionRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry(), clock = clock)
+                runTest {
+                    val result =
+                        repo.recordPosition(
+                            userId = "u1",
+                            bookId = "book-1",
+                            positionMs = 5_000L,
+                            lastPlayedAt = poisonedAt + 1_000L,
+                            finished = false,
+                            playbackSpeed = 1.0f,
+                            currentChapterId = null,
+                        )
+                    result.shouldBeInstanceOf<AppResult.Success<*>>()
+
+                    val healed = repo.getPosition("u1", "book-1").shouldNotBeNull()
+                    healed.lastPlayedAt shouldBe poisonedAt + 1_000L
+                    healed.positionMs shouldBe 5_000L
+                }
+            }
+        }
+
+        test("recordPosition: an older honest lastPlayedAt still loses when both values are within tolerance") {
+            withSqlDatabase {
+                val now0 = 1_730_000_000_000L
+                val clock = MutableClock(Instant.fromEpochMilliseconds(now0))
+                val repo =
+                    PlaybackPositionRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry(), clock = clock)
+                runTest {
+                    repo.recordPosition(
+                        userId = "u1",
+                        bookId = "book-1",
+                        positionMs = 99_000L,
+                        lastPlayedAt = now0 + 60_000L,
+                        finished = false,
+                        playbackSpeed = 1.0f,
+                        currentChapterId = null,
+                    )
+
+                    // Older, but still well within SKEW_TOLERANCE on both sides — no clamping in
+                    // play, this is the plain stale-write no-op regression pin.
+                    val result =
+                        repo.recordPosition(
+                            userId = "u1",
+                            bookId = "book-1",
+                            positionMs = 10_000L,
+                            lastPlayedAt = now0 + 30_000L,
+                            finished = true,
+                            playbackSpeed = 2.0f,
+                            currentChapterId = "chap-stale",
+                        )
+                    result.shouldBeInstanceOf<AppResult.Success<*>>()
+
+                    val stored = repo.getPosition("u1", "book-1").shouldNotBeNull()
+                    stored.positionMs shouldBe 99_000L
+                    stored.lastPlayedAt shouldBe now0 + 60_000L
+                }
+            }
+        }
+
+        test("recordPosition stores an old lastPlayedAt from a long-offline device unmodified") {
+            withSqlDatabase {
+                val now0 = 1_730_000_000_000L
+                val clock = MutableClock(Instant.fromEpochMilliseconds(now0))
+                val repo =
+                    PlaybackPositionRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry(), clock = clock)
+                runTest {
+                    val sixDaysAgo = now0 - 6L * 24 * 60 * 60 * 1000
+                    val result =
+                        repo.recordPosition(
+                            userId = "u1",
+                            bookId = "book-1",
+                            positionMs = 42_000L,
+                            lastPlayedAt = sixDaysAgo,
+                            finished = false,
+                            playbackSpeed = 1.0f,
+                            currentChapterId = null,
+                        )
+                    result.shouldBeInstanceOf<AppResult.Success<*>>()
+
+                    // Old timestamps are never touched by the clamp — only future-dating is capped.
+                    val stored = repo.getPosition("u1", "book-1").shouldNotBeNull()
+                    stored.lastPlayedAt shouldBe sixDaysAgo
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/AndroidPlaybackModuleRecorderBindingTest.kt
+++ b/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/AndroidPlaybackModuleRecorderBindingTest.kt
@@ -1,0 +1,53 @@
+package com.calypsan.listenup.client.di
+
+import com.calypsan.listenup.client.playback.PlaybackProgressReporter
+import com.calypsan.listenup.client.playback.ProgressTracker
+import com.calypsan.listenup.client.test.di.KoinTestRule
+import com.calypsan.listenup.client.test.fake.FakeDownloadRepository
+import com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository
+import com.calypsan.listenup.client.test.fake.FakeProgressTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatform
+
+/**
+ * POSITION-05 — pins the single-recorder DI invariant for Android by resolving
+ * [PlaybackProgressReporter] from the REAL [androidPlaybackModule], not a hand-built
+ * fixture.
+ *
+ * `PlaybackService` already drives `ListeningEventRecorder` directly to integrate with
+ * Media3, so [androidPlaybackModule] MUST bind [PlaybackProgressReporter] with a `null`
+ * recorder — a careless module edit that starts resolving a recorder here would silently
+ * double-record every listening span (see [PlaybackProgressReporter]'s class KDoc). This
+ * test only fakes [androidPlaybackModule]'s non-playback dependencies
+ * ([com.calypsan.listenup.client.playback.ProgressTracker], [CoroutineScope]); the module
+ * under test is loaded unmodified. No Android [android.content.Context] is required —
+ * `PlaybackProgressReporter`'s own binding needs none — so this runs on the plain JVM
+ * androidHostTest target without Robolectric, matching [KoinModuleVerifyTest]'s pattern.
+ */
+class AndroidPlaybackModuleRecorderBindingTest :
+    FunSpec({
+        val fixtureModule =
+            module {
+                single<ProgressTracker> {
+                    FakeProgressTracker(
+                        downloadRepository = FakeDownloadRepository(),
+                        positionRepository = FakePlaybackPositionRepository(),
+                        scope = get(),
+                    )
+                }
+                single { CoroutineScope(SupervisorJob()) }
+            }
+        val koinRule = KoinTestRule(listOf(fixtureModule, androidPlaybackModule))
+
+        beforeTest { koinRule.setUp() }
+        afterTest { koinRule.tearDown() }
+
+        test("androidPlaybackModule binds PlaybackProgressReporter with recorder = null") {
+            val reporter = KoinPlatform.getKoin().get<PlaybackProgressReporter>()
+            reporter.recorderForTest().shouldBeNull()
+        }
+    })

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TentativeSpanDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TentativeSpanDao.kt
@@ -24,6 +24,13 @@ internal interface TentativeSpanDao {
     suspend fun get(): TentativeSpanEntity?
 
     /**
+     * Number of rows currently in the table — asserts the single-row invariant [get] otherwise
+     * takes on faith (its `LIMIT 1` silently hides a second row instead of surfacing it).
+     */
+    @Query("SELECT COUNT(*) FROM tentative_span")
+    suspend fun countRows(): Int
+
+    /**
      * Write or replace the open span. Because there is at most one row, this
      * effectively replaces any existing row.
      */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ListeningEventRecorder.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ListeningEventRecorder.kt
@@ -168,6 +168,12 @@ class ListeningEventRecorder internal constructor(
      *
      * The finalized span's wire payload carries the old speed — the span covers audio played
      * at that speed from its [TentativeSpanEntity.startPositionMs] to [positionMs].
+     *
+     * If the finalize's enqueue fails, the tentative row survives as the [recoverOrphan] breadcrumb
+     * (see [finalizeCurrentSpan]) — this does NOT open a new span on top of it (that would destroy
+     * the breadcrumb and silently lose the whole original span). The player's next `onPlay` /
+     * `onPeriodicTick` re-establishes recording, and [recoverOrphan] re-promotes the breadcrumb on
+     * the next launch.
      */
     suspend fun onSpeedChange(
         positionMs: Long,
@@ -175,7 +181,14 @@ class ListeningEventRecorder internal constructor(
     ) {
         val existing = tentativeSpanDao.get() ?: return
         val nowMs = clock.now().toEpochMilliseconds()
-        finalizeCurrentSpan(endPositionMs = positionMs, endedAt = nowMs)
+        val cleared =
+            finalizeThenCheckCleared(
+                endPositionMs = positionMs,
+                endedAt = nowMs,
+                bookId = existing.bookId,
+                caller = "onSpeedChange",
+            )
+        if (!cleared) return
         onPlay(existing.bookId, positionMs, newSpeed)
     }
 
@@ -190,6 +203,12 @@ class ListeningEventRecorder internal constructor(
      * The pre-seek end is clamped to the span's own start so a backward seek reported with a
      * stale before-position can never produce an inverted span (`endPositionMs < startPositionMs`),
      * which the server has no defined handling for.
+     *
+     * If the finalize's enqueue fails, the tentative row survives as the [recoverOrphan] breadcrumb
+     * (see [finalizeCurrentSpan]) — this does NOT open a new span on top of it (that would destroy
+     * the breadcrumb and silently lose the whole original span). The player's next `onPlay` /
+     * `onPeriodicTick` re-establishes recording, and [recoverOrphan] re-promotes the breadcrumb on
+     * the next launch.
      */
     suspend fun onSeek(
         positionBeforeSeek: Long,
@@ -198,7 +217,14 @@ class ListeningEventRecorder internal constructor(
         val existing = tentativeSpanDao.get() ?: return
         val nowMs = clock.now().toEpochMilliseconds()
         val endPositionMs = maxOf(positionBeforeSeek, existing.startPositionMs)
-        finalizeCurrentSpan(endPositionMs = endPositionMs, endedAt = nowMs)
+        val cleared =
+            finalizeThenCheckCleared(
+                endPositionMs = endPositionMs,
+                endedAt = nowMs,
+                bookId = existing.bookId,
+                caller = "onSeek",
+            )
+        if (!cleared) return
         onPlay(existing.bookId, positionAfterSeek, existing.playbackSpeed)
     }
 
@@ -206,6 +232,12 @@ class ListeningEventRecorder internal constructor(
      * Finalizes the current span for the old book (using [TentativeSpanEntity.currentPositionMs]
      * as the end position), then opens a new span for [newBookId] at [newStartPositionMs].
      * No-op if no span is open.
+     *
+     * If the finalize's enqueue fails, the tentative row survives as the [recoverOrphan] breadcrumb
+     * (see [finalizeCurrentSpan]) — this does NOT open a new span on top of it (that would destroy
+     * the breadcrumb and silently lose the whole original span). The player's next `onPlay` /
+     * `onPeriodicTick` re-establishes recording, and [recoverOrphan] re-promotes the breadcrumb on
+     * the next launch.
      */
     suspend fun onMediaItemTransition(
         newBookId: String,
@@ -213,7 +245,14 @@ class ListeningEventRecorder internal constructor(
     ) {
         val existing = tentativeSpanDao.get() ?: return
         val nowMs = clock.now().toEpochMilliseconds()
-        finalizeCurrentSpan(endPositionMs = existing.currentPositionMs, endedAt = nowMs)
+        val cleared =
+            finalizeThenCheckCleared(
+                endPositionMs = existing.currentPositionMs,
+                endedAt = nowMs,
+                bookId = existing.bookId,
+                caller = "onMediaItemTransition",
+            )
+        if (!cleared) return
         onPlay(newBookId, newStartPositionMs, existing.playbackSpeed)
     }
 
@@ -246,6 +285,34 @@ class ListeningEventRecorder internal constructor(
     }
 
     // ── Private finalization ────────────────────────────────────────────────────
+
+    /**
+     * Finalizes the current span, then reports whether the tentative row actually cleared.
+     *
+     * [finalizeCurrentSpan] deliberately leaves the row in place when its enqueue fails — that
+     * survivor is the ONLY breadcrumb [recoverOrphan] can re-promote from. [onPlay]'s cross-process
+     * branch already honors that breadcrumb; every SAME-process finalize-then-reopen flow
+     * ([onSpeedChange], [onSeek], [onMediaItemTransition]) must honor it too — opening a new span
+     * on top of a survivor would silently destroy the breadcrumb and lose the whole original span,
+     * not just the failed write. Returns `false` (and logs a warning tagged with [caller]) when the
+     * row survived, so the call site can bail without opening a new span.
+     */
+    private suspend fun finalizeThenCheckCleared(
+        endPositionMs: Long,
+        endedAt: Long,
+        bookId: String,
+        caller: String,
+    ): Boolean {
+        finalizeCurrentSpan(endPositionMs = endPositionMs, endedAt = endedAt)
+        if (tentativeSpanDao.get() != null) {
+            logger.warn {
+                "[ListeningEventRecorder] Finalize did not clear the tentative span during $caller " +
+                    "(book=$bookId) — leaving it intact for recovery, new span not opened"
+            }
+            return false
+        }
+        return true
+    }
 
     /**
      * Reads the current [TentativeSpanEntity], applies zero-duration / zero-position drop

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporter.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporter.kt
@@ -124,6 +124,13 @@ class PlaybackProgressReporter(
         record { it.onPause(finalPositionMs) }
     }
 
+    /**
+     * Test-only accessor for the DI-wiring guard tests that resolve this class from the real
+     * platform Koin modules and assert the single-recorder invariant (`null` on Android,
+     * non-null on iOS/Desktop) — see `androidPlaybackModule` / `desktopPlaybackModule`.
+     */
+    internal fun recorderForTest(): ListeningEventRecorder? = recorder
+
     /** Resume position read at prepare time — pure position concern, no recording. */
     suspend fun getResumePosition(bookId: BookId): PlaybackPosition? = progressTracker.getResumePosition(bookId)
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/OrphanRecoveryRaceTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/OrphanRecoveryRaceTest.kt
@@ -232,6 +232,8 @@ private class CountingTentativeSpanDao(
     override suspend fun upsertSingleton(span: TentativeSpanEntity) = delegate.upsertSingleton(span)
 
     override suspend fun delete() = delegate.delete()
+
+    override suspend fun countRows(): Int = delegate.countRows()
 }
 
 /** Minimal [CatchUp] that succeeds immediately without doing any real sync work. */

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/di/DesktopPlaybackModuleRecorderBindingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/di/DesktopPlaybackModuleRecorderBindingTest.kt
@@ -1,0 +1,71 @@
+package com.calypsan.listenup.client.di
+
+import com.calypsan.listenup.api.dto.auth.DeviceInfo
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.device.DeviceInfoProvider
+import com.calypsan.listenup.client.playback.ListeningEventRecorder
+import com.calypsan.listenup.client.playback.PlaybackProgressReporter
+import com.calypsan.listenup.client.playback.ProgressTracker
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.di.KoinTestRule
+import com.calypsan.listenup.client.test.fake.FakeDownloadRepository
+import com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository
+import com.calypsan.listenup.client.test.fake.FakeProgressTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatform
+
+/**
+ * POSITION-05 — pins the single-recorder DI invariant for Desktop by resolving
+ * [PlaybackProgressReporter] from the REAL [desktopPlaybackModule], not a hand-built
+ * fixture.
+ *
+ * Desktop has no Media3 `PlaybackService`, so [PlaybackProgressReporter] is the only
+ * driver of listening-event recording there — [desktopPlaybackModule] MUST bind it with a
+ * non-null recorder, or Desktop listening history would silently stop being recorded. The
+ * asymmetric counterpart to [AndroidPlaybackModuleRecorderBindingTest], which pins the
+ * opposite (`null`) for Android.
+ */
+class DesktopPlaybackModuleRecorderBindingTest :
+    FunSpec({
+        test("desktopPlaybackModule binds PlaybackProgressReporter with a non-null recorder") {
+            val db = createInMemoryTestDatabase()
+            try {
+                val recorder =
+                    ListeningEventRecorder(
+                        listeningEventDao = db.listeningEventDao(),
+                        tentativeSpanDao = db.tentativeSpanDao(),
+                        transactionRunner = RoomTransactionRunner(db),
+                        enqueue = { _, _, _ -> },
+                        currentUserId = { "user-test" },
+                        deviceInfo = DeviceInfoProvider { DeviceInfo(deviceName = "Test Device") },
+                    )
+                val fixtureModule =
+                    module {
+                        single<ProgressTracker> {
+                            FakeProgressTracker(
+                                downloadRepository = FakeDownloadRepository(),
+                                positionRepository = FakePlaybackPositionRepository(),
+                                scope = get(qualifier = named("playbackScope")),
+                            )
+                        }
+                        single(qualifier = named("playbackScope")) { CoroutineScope(SupervisorJob()) }
+                        single { recorder }
+                    }
+                val koinRule = KoinTestRule(listOf(fixtureModule, desktopPlaybackModule))
+                koinRule.setUp()
+                try {
+                    val reporter = KoinPlatform.getKoin().get<PlaybackProgressReporter>()
+                    reporter.recorderForTest().shouldNotBeNull()
+                } finally {
+                    koinRule.tearDown()
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/ListeningEventRecorderFinalizeBreadcrumbTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/ListeningEventRecorderFinalizeBreadcrumbTest.kt
@@ -1,0 +1,192 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.api.dto.auth.DeviceInfo
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.data.sync.PendingOperationSender
+import com.calypsan.listenup.client.data.sync.domains.OpKind
+import com.calypsan.listenup.client.data.sync.domains.OutboxChannels
+import com.calypsan.listenup.client.device.DeviceInfoProvider
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.TimeZone
+
+private const val BOOK_ID = "book-test-1"
+private const val USER_ID = "user-test-1"
+private const val DEVICE_LABEL = "Test Device"
+private const val SPEED = 1.0f
+private const val START_POSITION = 1000L
+
+/**
+ * POSITION-02 — [ListeningEventRecorder]'s same-process finalize-then-reopen flows
+ * ([ListeningEventRecorder.onSpeedChange], [ListeningEventRecorder.onSeek],
+ * [ListeningEventRecorder.onMediaItemTransition]) must preserve the [finalizeCurrentSpan]
+ * breadcrumb the same way [ListeningEventRecorder.onPlay]'s cross-process branch already does:
+ * when the finalize's enqueue fails, the tentative row survives as the ONLY thing
+ * [ListeningEventRecorder.recoverOrphan] can re-promote from — opening a new span on top of it
+ * would silently destroy that breadcrumb and lose the whole original span, not just the failed
+ * write. Split out of [ListeningEventRecorderTest] (which is already near detekt's `LargeClass`
+ * ceiling) the same way that file's own fixture helpers are shared across it.
+ */
+class ListeningEventRecorderFinalizeBreadcrumbTest :
+    FunSpec({
+
+        test("onSpeedChange preserves the breadcrumb when finalize's enqueue fails — no new span opened") {
+            runTest {
+                var now = 1_000L
+                withFixture(nowMillisProvider = { now }, failEnqueue = true) { recorder, db, _ ->
+                    recorder.onPlay(BOOK_ID, START_POSITION, SPEED)
+
+                    now = 31_000L
+                    recorder.onSpeedChange(positionMs = 30_000L, newSpeed = 1.5f)
+
+                    // The ORIGINAL span survives untouched — not replaced by a fresh one at the
+                    // post-speed-change position/speed. Row count (not just get()'s LIMIT-1 read)
+                    // matters here: TentativeSpanEntity's id is a fresh random UUID per onPlay, so
+                    // an unconditional re-open after a failed finalize doesn't cleanly "replace" the
+                    // surviving row — it @Upsert-inserts a SECOND one (a different, worse failure
+                    // mode than the single silently-lost span this fix targets, and one get()'s
+                    // LIMIT 1 would hide).
+                    db.tentativeSpanDao().countRows() shouldBe 1
+                    val span = db.tentativeSpanDao().get().shouldNotBeNull()
+                    span.startPositionMs shouldBe START_POSITION
+                    span.currentPositionMs shouldBe START_POSITION
+                    span.startedAt shouldBe 1_000L
+                    span.playbackSpeed shouldBe SPEED
+
+                    // No listening event was written — the finalize rolled back.
+                    db.listeningEventDao().getByBookForUser(USER_ID, BOOK_ID).size shouldBe 0
+                }
+            }
+        }
+
+        test("onSeek preserves the breadcrumb when finalize's enqueue fails — no new span opened") {
+            runTest {
+                var now = 1_000L
+                withFixture(nowMillisProvider = { now }, failEnqueue = true) { recorder, db, _ ->
+                    recorder.onPlay(BOOK_ID, START_POSITION, SPEED)
+
+                    now = 31_000L
+                    recorder.onSeek(positionBeforeSeek = 30_000L, positionAfterSeek = 90_000L)
+
+                    // The ORIGINAL span survives untouched — not replaced by a fresh one at the
+                    // post-seek position. See the onSpeedChange test above for why countRows matters.
+                    db.tentativeSpanDao().countRows() shouldBe 1
+                    val span = db.tentativeSpanDao().get().shouldNotBeNull()
+                    span.startPositionMs shouldBe START_POSITION
+                    span.currentPositionMs shouldBe START_POSITION
+                    span.startedAt shouldBe 1_000L
+
+                    db.listeningEventDao().getByBookForUser(USER_ID, BOOK_ID).size shouldBe 0
+                }
+            }
+        }
+
+        test("onMediaItemTransition preserves the breadcrumb when finalize's enqueue fails — no new span opened") {
+            runTest {
+                var now = 1_000L
+                withFixture(nowMillisProvider = { now }, failEnqueue = true) { recorder, db, _ ->
+                    recorder.onPlay(BOOK_ID, START_POSITION, SPEED)
+
+                    now = 31_000L
+                    recorder.onMediaItemTransition(newBookId = "book-test-2", newStartPositionMs = 0L)
+
+                    // The ORIGINAL span survives untouched — still for the OLD book, not a fresh
+                    // span for the new one. See the onSpeedChange test above for why countRows matters.
+                    db.tentativeSpanDao().countRows() shouldBe 1
+                    val span = db.tentativeSpanDao().get().shouldNotBeNull()
+                    span.bookId shouldBe BOOK_ID
+                    span.startPositionMs shouldBe START_POSITION
+                    span.currentPositionMs shouldBe START_POSITION
+                    span.startedAt shouldBe 1_000L
+
+                    db.listeningEventDao().getByBookForUser(USER_ID, BOOK_ID).size shouldBe 0
+                    db.listeningEventDao().getByBookForUser(USER_ID, "book-test-2").size shouldBe 0
+                }
+            }
+        }
+
+        test("recoverOrphan re-promotes a breadcrumb a failed onSeek left behind, on a fresh process") {
+            runTest {
+                var now = 1_000L
+                val db = createInMemoryTestDatabase()
+                try {
+                    val failingQueue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = PendingOperationSender { AppResult.Success(Unit) },
+                            nowMillis = { now },
+                        )
+                    val crashedRecorder =
+                        ListeningEventRecorder(
+                            listeningEventDao = db.listeningEventDao(),
+                            tentativeSpanDao = db.tentativeSpanDao(),
+                            transactionRunner = RoomTransactionRunner(db),
+                            enqueue = { _, _, _ -> error("Simulated outbox enqueue failure") },
+                            currentUserId = { USER_ID },
+                            deviceInfo = DeviceInfoProvider { DeviceInfo(deviceName = DEVICE_LABEL) },
+                            processId = "process-crashed",
+                            clock =
+                                object : Clock {
+                                    override fun now(): Instant = Instant.fromEpochMilliseconds(now)
+                                },
+                            timeZone = { TimeZone.currentSystemDefault() },
+                        )
+
+                    crashedRecorder.onPlay(BOOK_ID, START_POSITION, SPEED)
+                    now = 20_000L
+                    crashedRecorder.onPeriodicTick(15_000L)
+                    now = 31_000L
+                    // The seek's finalize fails — the span as of the LAST HEARTBEAT (not the
+                    // seek's own position) survives as the breadcrumb, exactly as the tests above
+                    // pin: onSeek's own finalize attempt never touches the stored row on failure.
+                    crashedRecorder.onSeek(positionBeforeSeek = 30_000L, positionAfterSeek = 90_000L)
+                    db.tentativeSpanDao().get().shouldNotBeNull()
+
+                    // App restarts: a new process, a working outbox.
+                    val captured = mutableListOf<CapturedEnqueue>()
+                    now = 40_000L
+                    val freshRecorder =
+                        ListeningEventRecorder(
+                            listeningEventDao = db.listeningEventDao(),
+                            tentativeSpanDao = db.tentativeSpanDao(),
+                            transactionRunner = RoomTransactionRunner(db),
+                            enqueue = { entityId, payload, ownerUserId ->
+                                captured.add(CapturedEnqueue(entityId, payload, ownerUserId))
+                                failingQueue.enqueue(OutboxChannels.ListeningEvents, entityId, OpKind.Upsert, payload, ownerUserId)
+                            },
+                            currentUserId = { USER_ID },
+                            deviceInfo = DeviceInfoProvider { DeviceInfo(deviceName = DEVICE_LABEL) },
+                            processId = "process-fresh",
+                            clock =
+                                object : Clock {
+                                    override fun now(): Instant = Instant.fromEpochMilliseconds(now)
+                                },
+                            timeZone = { TimeZone.currentSystemDefault() },
+                        )
+
+                    freshRecorder.recoverOrphan()
+
+                    // The breadcrumb is gone, and the ORIGINAL (pre-seek) span was finalized —
+                    // the failed seek never lost the listen, it was just deferred to this recovery.
+                    db.tentativeSpanDao().get().shouldBeNull()
+                    val events = db.listeningEventDao().getByBookForUser(USER_ID, BOOK_ID)
+                    events.size shouldBe 1
+                    events[0].startPositionMs shouldBe START_POSITION
+                    events[0].startedAt shouldBe 1_000L
+                    events[0].endPositionMs shouldBe 15_000L
+                    events[0].endedAt shouldBe 20_000L
+                    captured.size shouldBe 1
+                } finally {
+                    db.close()
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/ListeningEventRecorderTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/ListeningEventRecorderTest.kt
@@ -504,14 +504,14 @@ class ListeningEventRecorderTest :
 // ── Fixture helpers ──────────────────────────────────────────────────────────
 
 /** Captured fields from a single [enqueue] call. */
-private data class CapturedEnqueue(
+internal data class CapturedEnqueue(
     val entityId: String,
     val payload: String,
     val ownerUserId: String,
 )
 
 /** Run [block] with a recorder wired to a fixed [nowMillis] timestamp. */
-private suspend fun withFixture(
+internal suspend fun withFixture(
     nowMillis: Long,
     block: suspend (
         ListeningEventRecorder,
@@ -520,7 +520,7 @@ private suspend fun withFixture(
     ) -> Unit,
 ) = withFixture(nowMillisProvider = { nowMillis }, block = block)
 
-private suspend fun withFixture(
+internal suspend fun withFixture(
     nowMillisProvider: () -> Long,
     failEnqueue: Boolean = false,
     processId: String = "process-fixture-default",


### PR DESCRIPTION
Five findings from the pre-ship position audit. **Based on `9ad7e179f`; `main` has since advanced (#1138 et al.) — needs a rebase before merge, but the changed files (position/listening-event) don't overlap what landed.**

- **POSITION-01 (headline): server clock-skew no longer permanently poisons a position.** `recordPosition`/`recordAllForImport` clamp a future-skewed client `lastPlayedAt` to `now + 5min` before the last-write-wins compare, and treat any stored value beyond that ceiling as corrupt so an honest write **overrides it immediately** (not when wall-clock time catches up). Positions are digest-opt-out, so without this a single bad device clock silently no-op'd every later write forever.
- **POSITION-02**: listening span no longer silently lost when a finalize fails mid seek/speed-change/book-transition — the recovery breadcrumb the cross-process guard already protects is now preserved on the same-process path too.
- **POSITION-03/04**: dropped dead unfiltered listening-event queries and the dead `CrossDeviceSync` parallel conflict path.
- **POSITION-05**: per-platform Koin-graph tests pin the single-recorder wiring (Android `recorder = null`, desktop non-null) so the retired double-count can't silently return.

All TDD (red→green verified, including the poisoned-override test proven to fail against the weaker clamp). Gates green: spotless+detekt, `:server:jvmTest` (11m), `:sharedLogic:jvmTest`, androidHostTest, commonMain metadata.