### PR TITLE
🐛 fix(server): sync-surface hardening from the 2026-07-16 pre-ship audit

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
@@ -178,14 +178,37 @@ class ImportApplier internal constructor(
                 throw e
             } catch (e: AbsBackupReader.AbsReadException) {
                 logger.error(e) { "ABS import apply failed reading the backup for import ${importId.value}" }
+                broadcastLibraryDataChangedBestEffort()
                 onEvent(ImportEvent.Failed(reason = e.message ?: "Failed to read the ABS backup."))
                 AppResult.Failure(ImportError.ApplyFailed(debugInfo = e.message))
             } catch (e: Exception) {
                 logger.error(e) { "ABS import apply failed unexpectedly for import ${importId.value}" }
+                broadcastLibraryDataChangedBestEffort()
                 onEvent(ImportEvent.Failed(reason = e.message ?: "Apply failed unexpectedly."))
                 AppResult.Failure(ImportError.ApplyFailed(debugInfo = e.message))
             }
         }
+
+    /**
+     * Post-failure `LibraryDataChanged` nudge for [apply]'s failure branches. `recordAll` /
+     * `recordSessions` commit in **chunked** transactions, so a failure partway through can leave
+     * already-committed rows sitting above every client cursor with no live signal (the same
+     * FirehoseSuppressed gap the success path's broadcast closes) — unconditional-on-failure is
+     * the safe default here: a spurious nudge on a zero-chunk-committed failure costs one wasted
+     * reconcile pass, whereas skipping it risks stranding real data until a client restart.
+     * Best-effort: a broadcast failure must never mask the original apply failure, so it is caught
+     * and logged rather than propagated. [CancellationException] still needs to win — the coroutine
+     * is being torn down, so nothing further should run.
+     */
+    private suspend fun broadcastLibraryDataChangedBestEffort() {
+        try {
+            changeBus.broadcastControl(SyncControl.LibraryDataChanged)
+        } catch (broadcastError: CancellationException) {
+            throw broadcastError
+        } catch (broadcastError: Exception) {
+            logger.warn(broadcastError) { "post-import-failure LibraryDataChanged broadcast failed" }
+        }
+    }
 
     /**
      * Resolves the effective item→book map: the analyzed matches, with each non-null override

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ActivitySyncRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ActivitySyncRepository.kt
@@ -46,8 +46,6 @@ class ActivitySyncRepository(
     override val ActivitySyncPayload.id: String
         get() = this.id
 
-    override fun ActivitySyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.activitiesQueries].
      * Global (non-userScoped) shape — only the base variants; the *ForUser variants stay unimplemented

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -153,6 +153,21 @@ class BookPersister internal constructor(
                     (e as? PersistAbortedByOom)?.result?.let { PersistCounts(it.persisted, it.failed, removed = 0) }
                         ?: PersistCounts(0, 0, 0)
                 eventBus.emit(ScanEvent.Completed(result.correlationId, libraryId, result.toSummary(partial)))
+                // The rows persisted before the OOM already committed above the client cursor with no
+                // live signal (suppressFirehose skips the per-book publish) — without this nudge they
+                // are stranded until the next app restart, the exact bug #16 class the pairing rule in
+                // FirehoseSuppressed's KDoc exists to prevent. Best-effort: a broadcast failure on top
+                // of an OOM must never mask the original error, so it is caught and logged, never
+                // rethrown in place of `e`.
+                if (suppressFirehose && (partial.persisted > 0 || partial.removed > 0)) {
+                    try {
+                        changeBus.broadcastControl(SyncControl.LibraryDataChanged)
+                    } catch (broadcastError: CancellationException) {
+                        throw broadcastError
+                    } catch (broadcastError: Exception) {
+                        log.warn(broadcastError) { "post-OOM LibraryDataChanged broadcast failed" }
+                    }
+                }
                 throw e
             }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -194,8 +194,6 @@ class BookRepository(
     override val BookSyncPayload.id: BookId
         get() = BookId(this.id)
 
-    override fun BookSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.booksQueries].
      * Mirrors the canonical Tag/Contributor shape.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ContributorRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ContributorRepository.kt
@@ -26,7 +26,7 @@ import kotlin.time.Clock
  *  - [substrate] — the [SyncableSubstrateQueries] adapter over `contributorsQueries`
  *  - [readPayload] / [readPayloads] — root row + alias child rows by id
  *  - [writePayload] — insert-or-update root row, then replace the alias set
- *  - `ContributorSyncPayload.id` / `revisionOf`
+ *  - `ContributorSyncPayload.id`
  *
  * `idAsString(ContributorId) = id.value` is load-bearing — the base's default
  * `toString()` on a value class returns `"ContributorId(value=foo)"`, which would
@@ -51,8 +51,6 @@ class ContributorRepository(
 
     override val ContributorSyncPayload.id: ContributorId
         get() = ContributorId(this.id)
-
-    override fun ContributorSyncPayload.revisionOf(): Long = revision
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.contributorsQueries].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/GenreRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/GenreRepository.kt
@@ -44,8 +44,6 @@ class GenreRepository(
     override val GenreSyncPayload.id: GenreId
         get() = GenreId(this.id)
 
-    override fun GenreSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.genresQueries] —
      * the canonical shape every aggregate copies. Genres are global (cross-user), so the

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/LibraryFolderRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/LibraryFolderRepository.kt
@@ -28,7 +28,7 @@ import kotlin.time.Clock
  *  - [substrate] — the [SyncableSubstrateQueries] adapter over `libraryFoldersQueries`
  *  - [readPayload] / [readPayloads] — root-row reads by id (tombstone-inclusive)
  *  - [writePayload] — insert-or-update inside the open transaction
- *  - `LibraryFolderSyncPayload.id` / `LibraryFolderSyncPayload.revisionOf`
+ *  - `LibraryFolderSyncPayload.id`
  *
  * `idAsString(FolderId) = id.value` is load-bearing — Kotlin's default `toString()`
  * on a value class returns `"FolderId(value=foo)"`, which would corrupt every column
@@ -61,8 +61,6 @@ class LibraryFolderRepository(
     override fun idAsString(id: FolderId): String = id.value
 
     override val LibraryFolderSyncPayload.id: FolderId get() = FolderId(this.id)
-
-    override fun LibraryFolderSyncPayload.revisionOf(): Long = revision
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.libraryFoldersQueries].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/LibraryRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/LibraryRepository.kt
@@ -26,7 +26,7 @@ import kotlin.time.Clock
  *  - [substrate] — the [SyncableSubstrateQueries] adapter over `librariesQueries`
  *  - [readPayload] / [readPayloads] — root-row reads by id (tombstone-inclusive)
  *  - [writePayload] — insert-or-update inside the open transaction
- *  - `LibrarySyncPayload.id` / `LibrarySyncPayload.revisionOf`
+ *  - `LibrarySyncPayload.id`
  *
  * `idAsString(LibraryId) = id.value` is load-bearing — Kotlin's default `toString()`
  * on a value class returns `"LibraryId(value=foo)"`, which would corrupt every column
@@ -54,8 +54,6 @@ class LibraryRepository(
     override fun idAsString(id: LibraryId): String = id.value
 
     override val LibrarySyncPayload.id: LibraryId get() = LibraryId(this.id)
-
-    override fun LibrarySyncPayload.revisionOf(): Long = revision
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.librariesQueries].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ListeningEventRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ListeningEventRepository.kt
@@ -190,8 +190,6 @@ class ListeningEventRepository(
     override val ListeningEventSyncPayload.id: ListeningEventId
         get() = ListeningEventId(this.id)
 
-    override fun ListeningEventSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.listeningEventsQueries].
      * Canonical user-scoped adapter shape (see [ShelfRepository]).

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
@@ -87,8 +87,6 @@ class PlaybackPositionRepository(
     override val PlaybackPositionSyncPayload.id: PlaybackPositionId
         get() = PlaybackPositionId(this.id)
 
-    override fun PlaybackPositionSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.playbackPositionsQueries].
      * Canonical user-scoped adapter shape (see [ShelfRepository]).

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SeriesRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SeriesRepository.kt
@@ -44,8 +44,6 @@ class SeriesRepository(
     override val SeriesSyncPayload.id: SeriesId
         get() = SeriesId(this.id)
 
-    override fun SeriesSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.seriesQueries].
      * Mirrors the canonical [com.calypsan.listenup.server.sync.TagRepository] shape.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsRepository.kt
@@ -56,8 +56,6 @@ class UserStatsRepository(
     override val UserStatsSyncPayload.id: UserStatsId
         get() = UserStatsId(this.id)
 
-    override fun UserStatsSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.userStatsQueries].
      * The canonical user-scoped adapter shape (see [ShelfRepository]): the four global methods

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AdminUserRosterRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AdminUserRosterRepository.kt
@@ -43,8 +43,6 @@ class AdminUserRosterRepository(
     ) {
     override val AdminUserRosterSyncPayload.id: String get() = this.id
 
-    override fun AdminUserRosterSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.adminUserRosterQueries].
      * Global aggregate — only the four unfiltered substrate methods are wired; the `*ForUser`

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
@@ -61,8 +61,6 @@ class BookMoodRepository(
     ) {
     override val BookMoodSyncPayload.id: BookMoodId get() = BookMoodId(bookId, moodId)
 
-    override fun BookMoodSyncPayload.revisionOf(): Long = revision
-
     /** Converts a [BookMoodId] to the stored `"$bookId:$moodId"` string. */
     override fun idAsString(id: BookMoodId): String = id.asString()
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
@@ -61,8 +61,6 @@ class BookTagRepository(
     ) {
     override val BookTagSyncPayload.id: BookTagId get() = BookTagId(bookId, tagId)
 
-    override fun BookTagSyncPayload.revisionOf(): Long = revision
-
     /** Converts a [BookTagId] to the stored `"$bookId:$tagId"` string. */
     override fun idAsString(id: BookTagId): String = id.asString()
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
@@ -71,8 +71,6 @@ class CollectionBookRepository(
     ) {
     override val CollectionBookSyncPayload.id: CollectionBookId get() = CollectionBookId(collectionId, bookId)
 
-    override fun CollectionBookSyncPayload.revisionOf(): Long = revision
-
     /** Converts a [CollectionBookId] to the stored `"$collectionId:$bookId"` string. */
     override fun idAsString(id: CollectionBookId): String = id.asString()
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionGrantRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionGrantRepository.kt
@@ -59,8 +59,6 @@ class CollectionGrantRepository(
     ) {
     override val CollectionShareSyncPayload.id: String get() = this.id
 
-    override fun CollectionShareSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.collectionGrantsQueries].
      * Global aggregate — the `*ForUser` variants stay the base's throwing defaults.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionRepository.kt
@@ -19,7 +19,7 @@ import kotlin.time.Clock
  *  - [substrate] — the [SyncableSubstrateQueries] adapter over `collectionsQueries`
  *  - [readPayload] / [readPayloads] — root-row reads by id (tombstone-inclusive)
  *  - [writePayload] — insert-or-update inside the open transaction
- *  - `CollectionSyncPayload.id` / `CollectionSyncPayload.revisionOf`
+ *  - `CollectionSyncPayload.id`
  *
  * **System collections are sync-invisible to members.** The server-only `collections.type`
  * column (`'NORMAL'` | `'ALL_BOOKS'` | `'INBOX'`) never crosses the wire — [CollectionSyncPayload.isInbox]
@@ -56,8 +56,6 @@ class CollectionRepository(
         clock = clock,
     ) {
     override val CollectionSyncPayload.id: String get() = this.id
-
-    override fun CollectionSyncPayload.revisionOf(): Long = revision
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.collectionsQueries].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/MoodRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/MoodRepository.kt
@@ -22,7 +22,7 @@ import kotlin.time.Clock
  *  - [substrate] — the [SyncableSubstrateQueries] adapter over `moodsQueries`
  *  - [readPayload] / [readPayloads] — root-row reads by id
  *  - [writePayload] — insert-or-update inside the open transaction
- *  - `Mood.id` / `Mood.revisionOf`
+ *  - `Mood.id`
  *
  * Service-layer helpers beyond the base substrate:
  *  - [findById] — fetch one non-deleted mood by id
@@ -38,8 +38,6 @@ class MoodRepository(
     clock: Clock = Clock.System,
 ) : SqlSyncableRepository<Mood, String>(db, bus, registry, SyncDomains.MOODS, clock) {
     override val Mood.id: String get() = this.id
-
-    override fun Mood.revisionOf(): Long = revision
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.moodsQueries].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/PublicProfileRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/PublicProfileRepository.kt
@@ -20,7 +20,7 @@ import kotlin.time.Clock
  *  - [substrate] — the [SyncableSubstrateQueries] adapter over `publicProfilesQueries`
  *  - [readPayload] / [readPayloads] — root-row reads by id
  *  - [writePayload] — insert-or-update inside the open transaction
- *  - `PublicProfileSyncPayload.id` / `revisionOf`
+ *  - `PublicProfileSyncPayload.id`
  *
  * Service-layer helper beyond the base substrate:
  *  - [identities] — batched (id, displayName, avatarType) read for the social presence surfaces.
@@ -40,8 +40,6 @@ class PublicProfileRepository(
         clock = clock,
     ) {
     override val PublicProfileSyncPayload.id: String get() = this.id
-
-    override fun PublicProfileSyncPayload.revisionOf(): Long = revision
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.publicProfilesQueries].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfBookRepository.kt
@@ -72,8 +72,6 @@ class ShelfBookRepository(
 
     override val ShelfBookSyncPayload.id: ShelfBookId get() = ShelfBookId(shelfId, bookId)
 
-    override fun ShelfBookSyncPayload.revisionOf(): Long = revision
-
     /** Converts a [ShelfBookId] to the stored `"$shelfId:$bookId"` string. */
     override fun idAsString(id: ShelfBookId): String = id.asString()
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfRepository.kt
@@ -66,8 +66,6 @@ class ShelfRepository(
 
     override val ShelfSyncPayload.id: ShelfId get() = ShelfId(this.id)
 
-    override fun ShelfSyncPayload.revisionOf(): Long = revision
-
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.shelvesQueries].
      *

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -243,6 +243,17 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
      * Created/Updated discrimination is based on whether the root row exists before
      * the write — existence is determined inside the transaction, so the decision
      * is atomic with the write. Mirrors [SyncableRepository.upsert] exactly.
+     *
+     * **Retries are intentionally re-applied, not deduplicated.** [clientOpId] is stored on the
+     * root row for audit/correlation only — it is never checked against a prior write to short-
+     * circuit this method. A retried outbox operation (the client resending an already-committed
+     * write after a dropped ack) therefore burns a fresh revision and re-publishes a duplicate
+     * [SyncEvent.Updated] here, exactly as if it were a genuinely new write. This is safe by
+     * design: every write is a full-payload overwrite (last-write-wins), so re-applying identical
+     * content converges to the same row — the cost is one burned revision and one duplicate event
+     * per retry, not a correctness gap. The client's own echo-shield (`OutboxInFlightQuery`)
+     * suppresses the local UI flicker a duplicate event would otherwise cause; it is a client-side
+     * concern, not something this method needs to protect against.
      */
     open suspend fun upsert(
         value: T,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -41,7 +41,7 @@ private val log = loggerFor<SqlSyncableRepository<*, *>>()
  *    SQLDelight queries wrapper, adapted to the substrate contract)
  *  - [readPayload] / [readPayloads] — aggregate read (root + children) by id
  *  - [writePayload] — aggregate write inside the open transaction
- *  - the `T.id`, `T.revisionOf()`, and (for value-class ids) [idAsString] projections
+ *  - the `T.id` and, for value-class ids, [idAsString] projections
  *
  * Self-registers with [SyncRegistry] and publishes to [ChangeBus] through the
  * shared [SyncableRepo] interface. Live-tail emits are deferred to the SQLDelight
@@ -203,9 +203,6 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
         contractJson.encodeToString(SyncEvent.serializer(elementSerializer), event as SyncEvent<T>)
 
     protected abstract val T.id: ID
-
-    /** Subclass-provided projection of the DTO's revision. */
-    protected abstract fun T.revisionOf(): Long
 
     /**
      * `true` for a per-user domain whose root table carries a `user_id` column:
@@ -498,9 +495,9 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
      * the result hit the limit.
      *
      * `nextCursor` advances using the queried revision (the last id/rev pair's
-     * revision) rather than `items.last().revisionOf()` — a hard delete between the
-     * id-query and the payload-read could null a row, and the queried revision is
-     * the canonical cursor advance regardless. Mirrors [SyncableRepository.pullSince].
+     * revision) rather than re-deriving it from the hydrated payload — a hard delete
+     * between the id-query and the payload-read could null a row, and the queried
+     * revision is the canonical cursor advance regardless. Mirrors [SyncableRepository.pullSince].
      *
      * For a user-scoped domain ([userScoped] `= true`) the id query routes through
      * [SyncableSubstrateQueries.selectIdsAboveRevisionForUser] with a required non-null

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.koin.ktor.ext.inject
@@ -433,19 +434,10 @@ private suspend fun ServerSSESession.streamFirehose(
                 return
             }
         }
-    val oldestRetained = bus.oldestRetainedRevision()
-
-    // Stale if client cursor is older than the bus's replay-buffer floor:
-    // the bus has already evicted the events the client needs.
-    // "clientCursor < oldestRetained" → stale; "null" → fresh subscriber, stream normally.
-    if (lastEventId != null && oldestRetained != null && lastEventId < oldestRetained) {
-        log.debug {
-            "sync stream cursor stale: userId=$userId lastEventId=$lastEventId " +
-                "oldestRetained=$oldestRetained; sending CursorStale"
-        }
-        sendCursorStale(oldestRetained)
-        return
-    }
+    // Fast-path pre-check: reject an already-stale cursor before spinning up the
+    // heartbeat/control side-jobs. [collectFirehoseEvents] re-runs the same check at actual
+    // subscription attach, closing the race window between this snapshot and that attach.
+    if (sendCursorStaleIfBehind(bus, lastEventId, userId)) return
 
     log.info { "sync stream opened: userId=$userId" }
 
@@ -521,8 +513,19 @@ private suspend fun ServerSSESession.streamFirehose(
  * the firehose's core delivery loop. Extracted from [streamFirehose] so the C2 liveness gate and the
  * keepalive/control side-jobs don't inflate that function's cognitive complexity. Skips events at or
  * below [lastEventId] (already-delivered replay), events for other users, and access-gated content.
+ *
+ * [ChangeBus] is a hot `MutableSharedFlow` (`replay = 256`, `DROP_OLDEST`): a subscriber sees the
+ * replay cache starting from wherever the floor sits at the moment its collector actually attaches
+ * — not at [streamFirehose]'s pre-subscribe staleness snapshot, taken before this `launch` even
+ * starts. Writes landing in that gap can evict past the client's [lastEventId] and the client would
+ * see a silent gap instead of `CursorStale`. `onSubscription` fires exactly when the [ChangeBus]
+ * subscription attaches, so re-running [sendCursorStaleIfBehind] there closes the window: it throws
+ * a plain [CancellationException] on a stale floor, which — thrown from a `launch`ed job's own
+ * coroutine rather than delivered via an external `cancel()` — completes that job as cancelled
+ * without propagating a failure to [streamFirehose]'s `coroutineScope`, exactly like the C2
+ * liveness-revoked path's `streamJob.cancel()`.
  */
-private suspend fun ServerSSESession.collectFirehoseEvents(
+internal suspend fun ServerSSESession.collectFirehoseEvents(
     bus: ChangeBus,
     bookAccessPolicy: () -> BookAccessPolicy,
     userId: String,
@@ -531,6 +534,11 @@ private suspend fun ServerSSESession.collectFirehoseEvents(
 ) {
     bus
         .subscribe()
+        .onSubscription {
+            if (sendCursorStaleIfBehind(bus, lastEventId, userId)) {
+                throw CancellationException("SSE cursor stale at ChangeBus subscription attach")
+            }
+        }
         // Skip events the client already received. With replay=256, a reconnecting
         // client would otherwise see events from the replay cache that it already
         // processed in a previous session.
@@ -803,6 +811,47 @@ private suspend fun ServerSSESession.sendSessionRevoked() {
 /** Emits a [SyncControl.CursorStale] control frame on the firehose. */
 private suspend fun ServerSSESession.sendCursorStale(lastKnownRevision: Long) {
     sendControl(SyncControl.CursorStale(lastKnownRevision = lastKnownRevision))
+}
+
+/**
+ * Pure predicate: is [lastEventId] behind [bus]'s CURRENT replay-buffer floor? Returns the floor
+ * revision (the value a [SyncControl.CursorStale] frame should carry) when stale, `null` when the
+ * cursor is fresh. "clientCursor < oldestRetained" → stale; a `null` [lastEventId] or a `null`
+ * [ChangeBus.oldestRetainedRevision] (empty buffer) is never stale.
+ *
+ * Extracted from [sendCursorStaleIfBehind] so the staleness check itself — the exact race the
+ * attach-time re-check in [collectFirehoseEvents] closes — is unit-testable without an SSE
+ * session: [ChangeBus] is a hot `MutableSharedFlow` (`replay = 256`, `DROP_OLDEST`), so a
+ * subscriber sees the replay cache starting from wherever the floor sits at actual subscription
+ * attach, not at [streamFirehose]'s pre-subscribe snapshot taken before that subscription even
+ * exists. A burst landing in that gap can evict past [lastEventId] with no live signal.
+ */
+internal fun staleCursorFloor(
+    bus: ChangeBus,
+    lastEventId: Long?,
+): Long? {
+    val oldestRetained = bus.oldestRetainedRevision()
+    return if (lastEventId != null && oldestRetained != null && lastEventId < oldestRetained) oldestRetained else null
+}
+
+/**
+ * Checks [lastEventId] against [bus] via [staleCursorFloor] and, if stale, sends
+ * [SyncControl.CursorStale] and returns `true`. Shared by two call sites that must agree on the
+ * same check: [streamFirehose]'s pre-subscribe fast path (rejects an already-stale cursor before
+ * the heartbeat/control side-jobs spin up) and [collectFirehoseEvents]'s attach-time re-check.
+ */
+private suspend fun ServerSSESession.sendCursorStaleIfBehind(
+    bus: ChangeBus,
+    lastEventId: Long?,
+    userId: String,
+): Boolean {
+    val floor = staleCursorFloor(bus, lastEventId) ?: return false
+    log.debug {
+        "sync stream cursor stale: userId=$userId lastEventId=$lastEventId " +
+            "oldestRetained=$floor; sending CursorStale"
+    }
+    sendCursorStale(floor)
+    return true
 }
 
 /** Emits an arbitrary [SyncControl] frame on the firehose's `event: control` line. */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -74,6 +74,15 @@ private const val MAX_TARGETED_IDS = 100
 // a `?bookIds=` request naming any other domain is a 400, not a query against a phantom column.
 private val BOOK_ID_MATCH_DOMAINS = setOf(ACTIVITIES_DOMAIN)
 
+// Domains whose rows carry a `collection_id` column, so a targeted `?collectionIds=` fetch (the
+// collection-membership half of the scoped AccessChanged delta) can match on it — the sibling
+// allowlist to BOOK_ID_MATCH_DOMAINS above. `collection_grants` (wire "collection_shares") also has
+// a `collection_id` column and a wired driver, so it would not SQL-error, but no client caller
+// targets it today and this route's own contract is `collectionIds` → `collection_books` only,
+// so the allowlist stays scoped to that one domain rather than growing to match every column that
+// happens to exist.
+private val COLLECTION_ID_MATCH_DOMAINS = setOf(COLLECTION_BOOKS_DOMAIN)
+
 // Admin-only domain: a row carries an absolute server filesystem path (operator disk
 // topology), which members must never see. Unlike the per-row book/collection gates, this
 // is whole-domain by role — members hold no folder rows at all, so there is nothing for them
@@ -309,6 +318,12 @@ fun Route.syncRoutes(
                 }
 
                 collectionIdsParam != null -> {
+                    if (domainName !in COLLECTION_ID_MATCH_DOMAINS) {
+                        return@get call.respond(
+                            HttpStatusCode.BadRequest,
+                            "collectionIds fetch not supported for domain: $domainName",
+                        )
+                    }
                     parseTargetedIds(collectionIdsParam)?.let { ids ->
                         typedRepo.pullByIds(
                             userId,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
@@ -23,7 +23,7 @@ import kotlin.time.Clock
  *  - [substrate] — the [SyncableSubstrateQueries] adapter over `tagsQueries`
  *  - [readPayload] / [readPayloads] — root-row reads by id
  *  - [writePayload] — insert-or-update inside the open transaction
- *  - `Tag.id` / `Tag.revisionOf`
+ *  - `Tag.id`
  *
  * Service-layer helpers beyond the base substrate:
  *  - [findById] — fetch one non-deleted tag by id
@@ -39,8 +39,6 @@ class TagRepository(
     clock: Clock = Clock.System,
 ) : SqlSyncableRepository<Tag, String>(db, bus, registry, SyncDomains.TAGS, clock) {
     override val Tag.id: String get() = this.id
-
-    override fun Tag.revisionOf(): Long = revision
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.tagsQueries].

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
@@ -213,6 +213,45 @@ class ImportApplierTest :
             }
         }
 
+        test("a mid-burst failure after positions committed still broadcasts LibraryDataChanged") {
+            withSqlDatabase {
+                val dbs = this
+                runTest(UnconfinedTestDispatcher()) {
+                    val staged = stageAnalyzedImport(dbs)
+                    val applier = applierFor(staged)
+                    confirmSimonMapping(staged.paths, staged.importId)
+
+                    val frames = mutableListOf<ControlFrame>()
+                    staged.bus
+                        .subscribeControl()
+                        .onEach { frames += it }
+                        .launchIn(backgroundScope)
+                    repeat(8) { yield() }
+
+                    // Same single-shot mid-burst injection as "an interrupted apply is detectable":
+                    // the fixture's 2 progress rows are well under APPLY_EVENT_INTERVAL (50), so the
+                    // FIRST Applying event is recordAll's tail tick — fired AFTER
+                    // recordAllForImport already committed the position rows. Throwing there
+                    // aborts recordSessions entirely while leaving a real, already-committed chunk
+                    // above every client's cursor — exactly the gap the failure-path broadcast closes.
+                    var thrown = false
+                    val result =
+                        applier.apply(staged.importId) { event ->
+                            if (event is ImportEvent.Applying && !thrown) {
+                                thrown = true
+                                throw IllegalStateException("simulated crash mid-apply")
+                            }
+                        }
+                    repeat(8) { yield() }
+
+                    result.shouldBeInstanceOf<AppResult.Failure>()
+                    // The position row committed before the throw — a genuine partial-progress failure.
+                    staged.repo.getPosition(LU_USER, LU_KINGS).shouldNotBeNull()
+                    frames.map { it.control } shouldContain SyncControl.LibraryDataChanged
+                }
+            }
+        }
+
         test("re-apply is idempotent: sessions don't duplicate and stats are unchanged") {
             withSqlDatabase {
                 val dbs = this

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterLibraryChangedTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterLibraryChangedTest.kt
@@ -11,6 +11,8 @@ import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.instanceOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -158,6 +160,42 @@ class BookPersisterLibraryChangedTest :
                     repeat(8) { yield() }
 
                     frames.map { it.control } shouldNotContain SyncControl.LibraryDataChanged
+                }
+            }
+        }
+
+        test("an OutOfMemoryError with partial persisted progress broadcasts LibraryDataChanged before rethrowing") {
+            withSqlDatabase {
+                runTest(UnconfinedTestDispatcher()) {
+                    val bus = ChangeBus()
+                    // "b" OOMs after "a" already persisted — the partial rows landed above the
+                    // cursor with no live signal (suppressFirehose), so the post-OOM nudge is the
+                    // only thing that reconciles them before a restart.
+                    val persister = persister(FakeBookIngest(oomForRootRelPath = setOf("b")), scope = this, changeBus = bus)
+
+                    val frames = mutableListOf<ControlFrame>()
+                    bus.subscribeControl().onEach { frames += it }.launchIn(backgroundScope)
+                    repeat(8) { yield() }
+
+                    val thrown =
+                        runCatching {
+                            persister.persist(
+                                scanResult(
+                                    books = listOf(analyzedBook("a"), analyzedBook("b")),
+                                    changes =
+                                        listOf(
+                                            ChangeEventDto.Added(analyzedBook("a")),
+                                            ChangeEventDto.Added(analyzedBook("b")),
+                                        ),
+                                    scope = ScanScope.Full,
+                                ),
+                            )
+                        }
+                    repeat(8) { yield() }
+
+                    // The OOM still propagates — the broadcast is best-effort and must never mask it.
+                    thrown.exceptionOrNull() shouldBe instanceOf(OutOfMemoryError::class)
+                    frames.map { it.control }.filter { it == SyncControl.LibraryDataChanged } shouldHaveSize 1
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionIdsAllowlistTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionIdsAllowlistTest.kt
@@ -1,0 +1,132 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.AuthSession
+import com.calypsan.listenup.api.dto.auth.RegisterRequest
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.CollectionSyncPayload
+import com.calypsan.listenup.api.sync.Page
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.module
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.useIsolatedTestConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import java.nio.file.Files
+import org.koin.ktor.ext.inject
+
+/**
+ * Regression guard for the `?collectionIds=` sibling of the `?bookIds=` allowlist bug
+ * (fixed for `?bookIds=` in `721a28cd1`): a domain whose root table has no `collection_id`
+ * column must reject a targeted `?collectionIds=` fetch with 400, never 500.
+ */
+class CollectionIdsAllowlistTest :
+    FunSpec({
+
+        test("a ?collectionIds= fetch on books (driver-wired, no collection_id column) returns 400, not 500") {
+            val libraryRoot = Files.createTempDirectory("listenup-collids-allowlist-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString())
+                    application { module() }
+                    val client = jsonClient()
+
+                    val token = client.mintRootToken()
+
+                    val response =
+                        client.get("/api/v1/sync/books?collectionIds=c1,c2") {
+                            bearerAuth(token)
+                        }
+                    response.status shouldBe HttpStatusCode.BadRequest
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+            }
+        }
+
+        test("a ?collectionIds= fetch on collection_books still returns the matching rows") {
+            val libraryRoot = Files.createTempDirectory("listenup-collids-allowlist-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString())
+                    application { module() }
+                    val client = jsonClient()
+
+                    val token = client.mintRootToken()
+                    seedTestLibraryAndFolder()
+
+                    val sql by application.inject<ListenUpDatabase>()
+                    sql.seedTestBook("b1")
+                    sql.seedTestBook("b2")
+
+                    val collections by application.inject<CollectionRepository>()
+                    val memberships by application.inject<CollectionBookRepository>()
+
+                    collections.upsert(collectionFixture("col-a"))
+                    collections.upsert(collectionFixture("col-b"))
+                    memberships.upsert(membershipFixture("col-a", "b1"))
+                    memberships.upsert(membershipFixture("col-b", "b2"))
+
+                    val response =
+                        client.get("/api/v1/sync/collection_books?collectionIds=col-a") {
+                            bearerAuth(token)
+                        }
+                    response.status shouldBe HttpStatusCode.OK
+                    val page: Page<CollectionBookSyncPayload> = response.body()
+                    page.items.map { it.bookId } shouldContainExactly listOf("b1")
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+            }
+        }
+    })
+
+private fun io.ktor.server.testing.ApplicationTestBuilder.jsonClient(): HttpClient =
+    createClient {
+        install(ContentNegotiation) { json(contractJson) }
+    }
+
+private suspend fun HttpClient.mintRootToken(): String =
+    post("/api/v1/auth/setup") {
+        contentType(ContentType.Application.Json)
+        setBody(RegisterRequest("root@x", "x".repeat(8), "Root"))
+    }.body<AppResult<AuthSession>>()
+        .let { it as AppResult.Success<AuthSession> }
+        .data.accessToken.value
+
+private fun collectionFixture(id: String): CollectionSyncPayload =
+    CollectionSyncPayload(
+        id = id,
+        libraryId = "test-library",
+        ownerId = "root",
+        name = id,
+        isInbox = false,
+        revision = 0L,
+        updatedAt = 0L,
+    )
+
+private fun membershipFixture(
+    collectionId: String,
+    bookId: String,
+): CollectionBookSyncPayload =
+    CollectionBookSyncPayload(
+        collectionId = collectionId,
+        bookId = bookId,
+        createdAt = 0L,
+        revision = 0L,
+    )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SseAttachTimeCursorStaleTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SseAttachTimeCursorStaleTest.kt
@@ -1,0 +1,91 @@
+package com.calypsan.listenup.server.sync
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.db.DatabaseConfig
+import com.calypsan.listenup.server.db.DatabaseFactory
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.plugins.sse.sse
+import io.ktor.server.application.install
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE as ServerSSE
+import io.ktor.server.sse.sse as serverSse
+import io.ktor.server.testing.testApplication
+import java.nio.file.Files
+import kotlinx.coroutines.flow.first
+import org.sqlite.SQLiteConfig
+
+/**
+ * SERVER-SYNC-02: the SSE `Last-Event-ID` staleness check races the [ChangeBus] subscription
+ * attach. [streamFirehose] snapshots [ChangeBus.oldestRetainedRevision] once, before the
+ * `collectFirehoseEvents` coroutine is even launched; a burst landing between that snapshot and
+ * the moment the [ChangeBus] subscription actually attaches can evict past the client's
+ * `lastEventId` with no live signal — a silent gap instead of `CursorStale`.
+ *
+ * The real timing window is not reliably reproducible through `testApplication`'s dispatcher, so
+ * this test drives the exact mechanism deterministically instead: the burst runs BEFORE the route
+ * is even hit, so by construction the replay floor has already moved past `lastEventId` the
+ * moment [collectFirehoseEvents] subscribes — exactly the state a genuine race would leave behind.
+ * `collectFirehoseEvents`'s `onSubscription` re-check is what must catch it.
+ */
+class SseAttachTimeCursorStaleTest :
+    FunSpec({
+
+        test("a floor that already moved past lastEventId at attach time yields CursorStale, not a silent gap") {
+            testApplication {
+                val tmp = Files.createTempFile("listenup-attach-race-test-", ".db").toFile().apply { deleteOnExit() }
+                val path = tmp.absolutePath
+                DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:$path"))
+                val driver =
+                    JdbcSqliteDriver(
+                        "jdbc:sqlite:$path",
+                        SQLiteConfig()
+                            .apply {
+                                enforceForeignKeys(true)
+                                busyTimeout = 5000
+                                setJournalMode(SQLiteConfig.JournalMode.WAL)
+                            }.toProperties(),
+                    )
+                val sqlDb = ListenUpDatabase(driver)
+                val bus = ChangeBus()
+                val repo = TagRepository(db = sqlDb, bus = bus, registry = SyncRegistry())
+
+                // Publish past the 256-deep replay buffer so DROP_OLDEST evicts revision 1 —
+                // BEFORE the test route (and therefore collectFirehoseEvents) is ever hit. The
+                // floor is already stale relative to lastEventId=1 the instant the subscription
+                // attaches; nothing races here, it is pre-arranged.
+                repeat(300) { i -> repo.upsert(Tag("tag-$i", "n$i", "n$i", 0, 0)) }
+
+                application {
+                    install(ServerSSE)
+                    routing {
+                        serverSse("/test/attach-race") {
+                            collectFirehoseEvents(
+                                bus = bus,
+                                bookAccessPolicy = { error("book domain not exercised by this test") },
+                                userId = "u1",
+                                role = UserRole.MEMBER,
+                                lastEventId = 1L,
+                            )
+                        }
+                    }
+                }
+
+                try {
+                    val client = createClient { install(SSE) }
+                    client.sse("/test/attach-race") {
+                        val event = incoming.first()
+                        event.event shouldBe "control"
+                        event.data!! shouldContain """"type":"SyncControl.CursorStale""""
+                    }
+                } finally {
+                    driver.close()
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/StaleCursorFloorTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/StaleCursorFloorTest.kt
@@ -1,0 +1,66 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Unit coverage for [staleCursorFloor] — the pure predicate both [streamFirehose]'s pre-subscribe
+ * fast path and [collectFirehoseEvents]'s attach-time re-check share (SERVER-SYNC-02). Isolating
+ * it from the SSE session lets the staleness math itself be pinned deterministically: the actual
+ * race the attach-time re-check closes (a burst landing between the pre-check snapshot and the
+ * moment the [ChangeBus] subscription attaches) is not reliably reproducible through
+ * `testApplication`'s real dispatcher, so this is the level that check's correctness is proven at.
+ */
+class StaleCursorFloorTest :
+    FunSpec({
+
+        test("returns null when the buffer is empty regardless of lastEventId") {
+            val bus = ChangeBus()
+            staleCursorFloor(bus, lastEventId = 5L).shouldBeNull()
+        }
+
+        test("returns null when lastEventId is null (fresh subscriber)") {
+            withSqlDatabase {
+                val bus = ChangeBus()
+                val repo = TagRepository(db = sql, bus = bus, registry = SyncRegistry())
+                runTest {
+                    repo.upsert(Tag(id = "a", name = "n", slug = "n", revision = 0, updatedAt = 0))
+                    staleCursorFloor(bus, lastEventId = null).shouldBeNull()
+                }
+            }
+        }
+
+        test("returns null when lastEventId is at or above the current floor") {
+            withSqlDatabase {
+                val bus = ChangeBus()
+                val repo = TagRepository(db = sql, bus = bus, registry = SyncRegistry())
+                runTest {
+                    repo.upsert(Tag(id = "a", name = "n", slug = "n", revision = 0, updatedAt = 0))
+                    val floor = bus.oldestRetainedRevision()!!
+                    staleCursorFloor(bus, lastEventId = floor).shouldBeNull()
+                }
+            }
+        }
+
+        test("returns the current floor when lastEventId is behind it") {
+            withSqlDatabase {
+                val bus = ChangeBus()
+                val repo = TagRepository(db = sql, bus = bus, registry = SyncRegistry())
+                runTest {
+                    // Publish past the 256-deep replay buffer so DROP_OLDEST evicts revision 1 — the
+                    // exact overflow the SERVER-SYNC-02 race exploits: a burst landing between a
+                    // staleness snapshot and actual subscription attach can advance this same floor.
+                    repeat(300) { i -> repo.upsert(Tag("tag-$i", "n$i", "n$i", 0, 0)) }
+                    val floor = bus.oldestRetainedRevision()!!
+                    floor shouldBeGreaterThanOrEqual 2L
+
+                    staleCursorFloor(bus, lastEventId = 1L) shouldBe floor
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncRoutesStreamErrorTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncRoutesStreamErrorTest.kt
@@ -224,8 +224,6 @@ private class ThrowingRepository(
     ) {
     override val ThrowingPayload.id: String get() = id
 
-    override fun ThrowingPayload.revisionOf(): Long = revision
-
     /** Materialises the test-only `throwing_streamerror_test` table (revision indexed). */
     fun createSchema() {
         driver.execute(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryIdAsStringTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryIdAsStringTest.kt
@@ -127,8 +127,6 @@ internal class FixtureRepository(
     ) {
     override val FixturePayload.id: FixtureId get() = this.id
 
-    override fun FixturePayload.revisionOf(): Long = revision
-
     override fun idAsString(id: FixtureId): String = id.value
 
     /** Materialises the test-only `fixture_idAsString_test` table (revision indexed). */

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/UserScopedRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/UserScopedRepositoryTest.kt
@@ -136,8 +136,6 @@ internal class UserScopedFixtureRepository(
 
     override val UserScopedPayload.id: String get() = id
 
-    override fun UserScopedPayload.revisionOf(): Long = revision
-
     /** Materialises the test-only `user_scoped_fixture_test` table (revision + user_id indexed). */
     fun createSchema() {
         driver.execute(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Entity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Entity.kt
@@ -6,9 +6,12 @@ import androidx.room.PrimaryKey
 
 /**
  * Local-first pending write awaiting server replay. Each row keys on a
- * client-generated UUID ([clientOpId]) which propagates to the server via the
- * write API and echoes back on the SSE [com.calypsan.listenup.api.sync.SyncEvent]
- * so the engine can match echoes to ops.
+ * client-generated UUID ([clientOpId]) — a local correlation id only: it is never sent to the
+ * server over the RPC write path and never echoes back on an SSE
+ * [com.calypsan.listenup.api.sync.SyncEvent]. The anti-flicker shield that stops an inbound
+ * echo/catch-up snapshot from reverting a still-in-flight local edit keys on entity identity
+ * `(domainName, entityId)` instead — see
+ * [com.calypsan.listenup.client.data.sync.domains.OutboxInFlightQuery].
  *
  * Per-entity FIFO ordering: ops are drained in order of [enqueuedAt] within
  * `(domainName, entityId)` groups; different entities drain in parallel.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperation.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperation.kt
@@ -5,6 +5,12 @@ package com.calypsan.listenup.client.data.sync
  * is opaque JSON shaped by `(domainName, opType)`; the queue does not parse it.
  */
 internal data class PendingOperation(
+    /**
+     * Local correlation id only — never sent to the server over the RPC write path and never
+     * echoes back on an SSE `SyncEvent`. The anti-flicker shield keys on entity identity
+     * `(domainName, entityId)` instead; see
+     * [com.calypsan.listenup.client.data.sync.domains.OutboxInFlightQuery].
+     */
     val clientOpId: String,
     val domainName: String,
     val entityId: String,


### PR DESCRIPTION
Four findings from the pre-ship server-sync audit (rebased onto current main; server-only + two KDoc-only sharedLogic touches, export-neutral).

- **SERVER-SYNC-01**: `?collectionIds=` targeted fetch now has the same domain allowlist its `?bookIds=` sibling got in #1131 — an authenticated `GET /api/v1/sync/books?collectionIds=…` (or activities/collections/…) no longer 500s on the missing `collection_id` column.
- **SERVER-SYNC-03**: `FirehoseSuppressed` bulk writers (`BookPersister` OOM path, `ImportApplier` catch blocks) now broadcast `LibraryDataChanged` on partial-commit failure, so rows already committed above the client cursor don't strand until app restart. Best-effort, never masks the original failure, `CancellationException` rethrown first.
- **SERVER-SYNC-02**: SSE `Last-Event-ID` staleness is re-checked at subscription attach (`onSubscription`), closing the check-then-subscribe race against the `DROP_OLDEST` replay buffer that could silently gap a client instead of sending `CursorStale`.
- **SERVER-SYNC-05 (docs + dead code)**: documented that retried client writes are intentionally re-applied (LWW full-payload; `clientOpId` is audit-only), removed the unused `revisionOf()` abstract member + its 24 trivial overrides, and corrected the stale `clientOpId` "echoes back on SSE" KDoc on the two client outbox files (it doesn't — `OutboxInFlightQuery` is the real echo-shield).

TDD throughout (SSE race proven red→green via an extracted attach-time predicate + a test driving `collectFirehoseEvents` against a pre-advanced bus floor). Gates green: spotless+detekt, `:server:jvmTest`, commonMain metadata compile.

SERVER-SYNC-04 (collection_books tombstone membership leak) deliberately excluded — parked for a product decision.