### PR TITLE
🔒 fix(server): auth hardening from the 2026-07-16 pre-ship audit

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
@@ -157,6 +157,7 @@ class AdminUserServiceImpl(
         patch: AdminUserPatch,
     ): AppResult<User> {
         requireAdmin()?.let { return it }
+        val caller = principal.current() ?: return AppResult.Failure(AuthError.SessionExpired())
         // Captured inside the txn, acted on after commit: a privilege demotion must sever the
         // demoted user's live sessions so a still-valid access token can't outlive its role (≤15m
         // stale-privilege window otherwise — the access JWT embeds the role claim).
@@ -167,7 +168,7 @@ class AdminUserServiceImpl(
                     activeUser(id)
                         ?: return@suspendTransaction AppResult.Failure(AdminError.UserNotFound())
 
-                val roleChange = roleChangeFor(user, patch.role)
+                val roleChange = roleChangeFor(user, patch.role, caller.role)
                 roleChange?.let { return@suspendTransaction it }
 
                 // Merge only the non-null patch fields, then write the merged row back.
@@ -343,9 +344,14 @@ class AdminUserServiceImpl(
     private fun roleChangeFor(
         user: AuthUser,
         newRole: UserRole?,
+        callerRole: UserRole,
     ): AppResult.Failure? {
         if (newRole == null || newRole.toColumn() == user.role) return null
         if (user.role == UserRoleColumn.ROOT) return AppResult.Failure(AdminError.CannotModifyRoot())
+        // ROOT is a protected tier: only a ROOT caller may promote someone to ROOT.
+        if (newRole == UserRole.ROOT && callerRole != UserRole.ROOT) {
+            return AppResult.Failure(AuthError.PermissionDenied())
+        }
         val demotingAdmin = user.role == UserRoleColumn.ADMIN && newRole == UserRole.MEMBER
         if (demotingAdmin && countActiveAdmins() <= 1) {
             return AppResult.Failure(AdminError.CannotDemoteLastAdmin())

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/InviteServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/InviteServiceImpl.kt
@@ -19,7 +19,10 @@ import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.AuthUser
 import com.calypsan.listenup.server.auth.Email
 import com.calypsan.listenup.server.auth.InviteCodeGenerator
+import com.calypsan.listenup.server.auth.InviteRateBucket
+import com.calypsan.listenup.server.auth.InviteRateLimiter
 import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.auth.RateDecision
 import com.calypsan.listenup.server.auth.SessionIssuer
 import com.calypsan.listenup.server.auth.toColumn
 import com.calypsan.listenup.server.auth.toContract
@@ -79,6 +82,19 @@ class InviteServiceImpl(
      * environments, phased startup). A null value silently skips the roster-projection refresh.
      */
     private val adminUserRosterMaintainer: AdminUserRosterMaintainer? = null,
+    /**
+     * The caller's remote host, captured at the `/api/rpc/public` mount and threaded in via
+     * [withRemoteHost]. Non-null only on the RPC public path, where [inviteRateLimiter] enforces the
+     * per-IP throttle on [claimInvite] / [lookupInvite]; null on REST (throttled by the Ktor
+     * `RateLimit` plugin) and in unit tests.
+     */
+    private val remoteHost: String? = null,
+    /**
+     * The RPC-path per-IP throttle for the anonymous invite surface (SEC-02). Non-null in
+     * production; null in unit tests and on the REST path, where the throttle is a no-op (the Ktor
+     * `RateLimit` plugin covers REST).
+     */
+    private val inviteRateLimiter: InviteRateLimiter? = null,
 ) : InviteService,
     InviteServicePublic {
     /** Returns a copy scoped to the given [provider]. Route handlers call this per-request. */
@@ -93,6 +109,28 @@ class InviteServiceImpl(
             provider,
             defaultGrantIssuer,
             adminUserRosterMaintainer,
+            remoteHost,
+            inviteRateLimiter,
+        )
+
+    /**
+     * Bind the caller's [remoteHost] so the RPC public mount's per-IP throttle
+     * ([inviteRateLimiter]) keys on it. The REST path never calls this — its throttle is the Ktor
+     * `RateLimit` plugin.
+     */
+    fun withRemoteHost(remoteHost: String): InviteServiceImpl =
+        InviteServiceImpl(
+            db,
+            codeGenerator,
+            hasher,
+            sessionIssuer,
+            serverName,
+            clock,
+            principal,
+            defaultGrantIssuer,
+            adminUserRosterMaintainer,
+            remoteHost,
+            inviteRateLimiter,
         )
 
     override suspend fun createInvite(
@@ -174,10 +212,18 @@ class InviteServiceImpl(
         displayName: String?,
         deviceInfo: DeviceInfo?,
     ): AppResult<AuthSession> {
+        // Throttle BEFORE any Argon2 work so a brute-force burst can't turn into a CPU/memory DoS
+        // (SEC-02, mirrors AuthServiceImpl.login).
+        enforceRate(InviteRateBucket.CLAIM)?.let { return AppResult.Failure(it) }
+        val now = clock.now().toEpochMilliseconds()
+        // Cheap existence/expiry/claimed pre-check BEFORE the expensive Argon2 hash — stops a
+        // bogus or dead code from paying for a hash it can never use. claimUserAtomically
+        // re-validates the same conditions inside its own transaction, which stays the single-use
+        // authority for a genuinely racing claim.
+        precheckInviteCode(code, now)?.let { return AppResult.Failure(it) }
         // Argon2 is CPU-bound and slow on purpose — hash before opening the
         // transaction so we don't hold a DB connection during it (mirrors register).
         val passwordHashed = hasher.hash(password)
-        val now = clock.now().toEpochMilliseconds()
         // The validate → insert-user → mark-claimed steps run atomically in one transaction so the
         // single-use guarantee holds (a row can't be both claimed and have no user). Session issuance
         // is hoisted OUT: it opens its own session transaction, and the SQLDelight transaction body is
@@ -199,6 +245,25 @@ class InviteServiceImpl(
         adminUserRosterMaintainer?.refreshBestEffort(user.id)
         return AppResult.Success(sessionIssuer.issue(user, label = null, deviceInfo = deviceInfo))
     }
+
+    /**
+     * Read-only existence/expiry/claimed probe for [code], run BEFORE [claimInvite] pays for an
+     * Argon2 hash. Returns the same typed failures [claimUserAtomically] would raise, or null when
+     * the code looks claimable — [claimUserAtomically] re-checks the identical conditions inside its
+     * own transaction and remains the single-use authority for a genuinely racing claim.
+     */
+    private suspend fun precheckInviteCode(
+        code: String,
+        now: Long,
+    ): InviteError? =
+        suspendTransaction(db) {
+            val invite =
+                db.invitesQueries.selectByCode(code = code).executeAsOneOrNull()
+                    ?: return@suspendTransaction InviteError.NotFound()
+            if (invite.claimed_at != null) return@suspendTransaction InviteError.AlreadyClaimed()
+            if (invite.expires_at < now) return@suspendTransaction InviteError.Expired()
+            null
+        }
 
     /**
      * The transactional core of [claimInvite]: validate the code, insert the new ACTIVE user, and
@@ -270,6 +335,7 @@ class InviteServiceImpl(
         }
 
     override suspend fun lookupInvite(code: String): AppResult<InvitePreview> {
+        enforceRate(InviteRateBucket.LOOKUP)?.let { return AppResult.Failure(it) }
         val now = clock.now().toEpochMilliseconds()
         return suspendTransaction(db) {
             val invite =
@@ -306,6 +372,22 @@ class InviteServiceImpl(
     private fun requireAdmin(): AppResult.Failure? {
         val caller = principal.current() ?: return AppResult.Failure(AuthError.SessionExpired())
         return if (caller.role.isAdmin()) null else AppResult.Failure(AuthError.PermissionDenied())
+    }
+
+    /**
+     * Per-IP throttle probe for [bucket]. Returns an [AuthError.RateLimited] to short-circuit the
+     * caller when over the ceiling, or null to proceed. A no-op (null) unless BOTH the remote host
+     * and the limiter are bound — i.e. only on the RPC public mount (SEC-02). Reuses the shared
+     * [AuthError.RateLimited] shape (same one [com.calypsan.listenup.server.auth.AuthServiceImpl]
+     * raises) rather than a dedicated [InviteError] subtype — one 429 shape for the client to fold.
+     */
+    private suspend fun enforceRate(bucket: InviteRateBucket): AuthError? {
+        val host = remoteHost ?: return null
+        val limiter = inviteRateLimiter ?: return null
+        return when (val decision = limiter.check(bucket, host)) {
+            RateDecision.Allowed -> null
+            is RateDecision.Throttled -> AuthError.RateLimited(retryAfterSeconds = decision.retryAfterSeconds)
+        }
     }
 
     /** Lifecycle status derived from claim then expiry; PENDING when neither applies. */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/InviteServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/InviteServiceImpl.kt
@@ -106,6 +106,10 @@ class InviteServiceImpl(
         if (!Email.isLikelyEmail(email)) return AppResult.Failure(InviteError.InvalidInput())
         if (displayName.isBlank()) return AppResult.Failure(InviteError.InvalidInput())
         if (expiresInDays != null && expiresInDays <= 0) return AppResult.Failure(InviteError.InvalidInput())
+        // ROOT is a protected tier: only a ROOT caller may mint a ROOT-granting invite.
+        if (role == UserRole.ROOT && caller.role != UserRole.ROOT) {
+            return AppResult.Failure(AuthError.PermissionDenied())
+        }
         val now = clock.now()
         val invite =
             Invites(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ProfileServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ProfileServiceImpl.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.error.ProfileError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.Users
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
@@ -27,7 +28,9 @@ private const val AVATAR_TYPE_AUTO = "auto"
  *
  * Password changes verify the current password inside the transaction (against the stored hash)
  * before writing the new hash. The new hash is computed outside the transaction so the
- * CPU-bound Argon2 work does not hold a DB connection.
+ * CPU-bound Argon2 work does not hold a DB connection. A successful password change revokes the
+ * caller's other live sessions — a stolen refresh token must not survive a password change — while
+ * sparing the session that made the request, so the caller isn't logged out of their own action.
  *
  * Route handlers call [copyWith] to bind each request to the authenticated principal; the
  * Koin singleton carries [PrincipalProvider.None] so an un-scoped call is denied rather than
@@ -38,6 +41,7 @@ internal class ProfileServiceImpl(
     private val argon2Limiter: Argon2Limiter,
     private val publicProfileMaintainer: PublicProfileMaintainer,
     private val imageStore: ImageStore,
+    private val sessions: SessionService,
     private val clock: Clock = Clock.System,
     private val principal: PrincipalProvider = PrincipalProvider.None,
 ) : ProfileService {
@@ -54,9 +58,8 @@ internal class ProfileServiceImpl(
     }
 
     override suspend fun updateMyProfile(request: UpdateProfileRequest): AppResult<Profile> {
-        val userId =
-            principal.current()?.userId?.value
-                ?: return AppResult.Failure(AuthError.PermissionDenied())
+        val caller = principal.current() ?: return AppResult.Failure(AuthError.PermissionDenied())
+        val userId = caller.userId.value
         // Hash outside the transaction — Argon2 is CPU-bound and must not hold a DB connection.
         val newHash = request.password?.let { argon2Limiter.hash(it.newPassword) }
         // Read the current row first. The password verify and the write are split across two
@@ -101,6 +104,12 @@ internal class ProfileServiceImpl(
         if (avatarChanged && mergedAvatarType == AVATAR_TYPE_AUTO) {
             imageStore.delete(userId)
         }
+        // A stolen refresh token must not survive a password change (SEC-03). Spare the caller's
+        // own session — they just proved they hold the current password, not an attacker riding a
+        // leaked token — so this request's device isn't logged out by its own action.
+        if (request.password != null) {
+            sessions.revokeAllExcept(UserId(userId), caller.sessionId)
+        }
         // Refresh the projection after the user-row write commits — reads back from DB.
         publicProfileMaintainer.refreshBestEffort(userId)
         return AppResult.Success(
@@ -121,6 +130,7 @@ internal class ProfileServiceImpl(
             argon2Limiter = argon2Limiter,
             publicProfileMaintainer = publicProfileMaintainer,
             imageStore = imageStore,
+            sessions = sessions,
             clock = clock,
             principal = principal,
         )
@@ -148,12 +158,14 @@ fun createProfileService(
     argon2Limiter: Argon2Limiter,
     publicProfileMaintainer: PublicProfileMaintainer,
     imageStore: ImageStore,
+    sessions: SessionService,
 ): ProfileService =
     ProfileServiceImpl(
         sql = sql,
         argon2Limiter = argon2Limiter,
         publicProfileMaintainer = publicProfileMaintainer,
         imageStore = imageStore,
+        sessions = sessions,
     )
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/InviteRateLimiter.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/InviteRateLimiter.kt
@@ -1,0 +1,78 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.calypsan.listenup.server.auth
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.math.ceil
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+
+/**
+ * The throttled invite operations reachable over the RPC public mount, with their per-IP,
+ * per-minute ceilings. The values mirror the REST `RateLimitBuckets.InviteClaim` /
+ * `RateLimitBuckets.InviteLookup` limits so a first-party client gets the same protection whether
+ * it claims or looks up an invite over REST or RPC.
+ */
+enum class InviteRateBucket(
+    val perMinuteLimit: Int,
+) {
+    CLAIM(5),
+    LOOKUP(20),
+}
+
+/**
+ * In-memory, per-IP token-bucket throttle for the RPC invite surface (SEC-02) — the [InviteService]
+ * sibling of [LoginRateLimiter].
+ *
+ * Ktor's `RateLimit` plugin throttles the REST invite routes, but first-party clients reach
+ * [claimInvite]/[lookupInvite] over the RPC public mount too — many messages ride a single
+ * WebSocket, so throttling the upgrade is useless. This limiter runs per-call inside the invite
+ * service instead, keyed by the caller's remote host, so an anonymous claim/lookup burst — and the
+ * Argon2 CPU/memory amplification behind a claim burst — is capped on the RPC path too.
+ *
+ * In-memory keying by host is acceptable for the self-hosted, single-process deployment — the same
+ * rationale as [LoginRateLimiter] and the REST `RateLimiting` plugin.
+ */
+class InviteRateLimiter(
+    private val clock: Clock,
+    private val refillPeriod: Duration = 1.minutes,
+) {
+    private class Bucket(
+        var tokens: Double,
+        var lastRefillMillis: Long,
+    )
+
+    private val mutex = Mutex()
+    private val buckets = mutableMapOf<Pair<InviteRateBucket, String>, Bucket>()
+
+    /**
+     * Consume one token for ([bucket], [host]). Returns [RateDecision.Allowed] when a token was
+     * available, or [RateDecision.Throttled] with the whole seconds until the next token otherwise.
+     */
+    suspend fun check(
+        bucket: InviteRateBucket,
+        host: String,
+    ): RateDecision =
+        mutex.withLock {
+            val capacity = bucket.perMinuteLimit.toDouble()
+            val tokensPerMillis = capacity / refillPeriod.inWholeMilliseconds
+            val now = clock.now().toEpochMilliseconds()
+
+            val entry = buckets.getOrPut(bucket to host) { Bucket(tokens = capacity, lastRefillMillis = now) }
+            val elapsed = (now - entry.lastRefillMillis).coerceAtLeast(0)
+            entry.tokens = (entry.tokens + elapsed * tokensPerMillis).coerceAtMost(capacity)
+            entry.lastRefillMillis = now
+
+            if (entry.tokens >= 1.0) {
+                entry.tokens -= 1.0
+                RateDecision.Allowed
+            } else {
+                val deficit = 1.0 - entry.tokens
+                val retryAfter = ceil(deficit / tokensPerMillis / 1000.0).toInt().coerceAtLeast(1)
+                RateDecision.Throttled(retryAfterSeconds = retryAfter)
+            }
+        }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/SessionService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/SessionService.kt
@@ -193,6 +193,25 @@ class SessionService(
     }
 
     /**
+     * Revoke every other live session for [userId], sparing [exceptSessionId] — the password
+     * change (SEC-03) counterpart to [revokeAll]. A stolen refresh token must not survive a
+     * password change, but the device that just changed the password shouldn't be logged out of
+     * its own action.
+     */
+    suspend fun revokeAllExcept(
+        userId: UserId,
+        exceptSessionId: SessionId,
+    ) {
+        suspendTransaction(db) {
+            db.sessionsQueries.revokeAllForUserExcept(
+                revoked_at = clock.now().toEpochMilliseconds(),
+                user_id = userId.value,
+                except_id = exceptSessionId.value,
+            )
+        }
+    }
+
+    /**
      * True iff [token] matches a session's `previous_hash` — i.e. an attempt
      * to reuse a token that has already been rotated. [rotate] returns null
      * for both "unknown" and "replayed-and-family-revoked"; this lets the

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.AuthServiceImpl
 import com.calypsan.listenup.server.auth.DEFAULT_ARGON2_PARALLELISM
 import com.calypsan.listenup.server.auth.InviteCodeGenerator
+import com.calypsan.listenup.server.auth.InviteRateLimiter
 import com.calypsan.listenup.server.auth.LoginRateLimiter
 import com.calypsan.listenup.server.auth.JwtConfiguration
 import com.calypsan.listenup.server.auth.PasswordHasher
@@ -174,6 +175,10 @@ fun authModule(config: ApplicationConfig): Module {
 
         single { InviteCodeGenerator() }
 
+        // SEC-02: per-IP RPC-path throttle for claimInvite/lookupInvite — the counterpart to the
+        // REST `RateLimit` plugin's InviteClaim/InviteLookup buckets.
+        single { InviteRateLimiter(clock = get()) }
+
         single {
             InviteServiceImpl(
                 db = get<ListenUpDatabase>(),
@@ -184,6 +189,9 @@ fun authModule(config: ApplicationConfig): Module {
                 clock = get(),
                 defaultGrantIssuer = getOrNull(),
                 adminUserRosterMaintainer = getOrNull(),
+                // Per-IP RPC throttle (SEC-02). The per-call remote host is bound at the mount via
+                // withRemoteHost; the singleton carries the limiter but no host (throttle inert).
+                inviteRateLimiter = get(),
             )
         }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ProfileModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ProfileModule.kt
@@ -19,6 +19,7 @@ fun profileModule(avatarsDir: Path): Module =
                 argon2Limiter = get(),
                 publicProfileMaintainer = get(),
                 imageStore = get(),
+                sessions = get(),
                 clock = get(),
             )
         }

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Sessions.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Sessions.sq
@@ -101,6 +101,12 @@ WHERE id = :id AND user_id = :user_id AND revoked_at IS NULL;
 revokeAllForUser:
 UPDATE sessions SET revoked_at = :revoked_at WHERE user_id = :user_id AND revoked_at IS NULL;
 
+-- Revoke every other live session for a user, sparing one (password change — the session that
+-- just changed the password stays live so its owner isn't logged out of their own device).
+revokeAllForUserExcept:
+UPDATE sessions SET revoked_at = :revoked_at
+WHERE user_id = :user_id AND revoked_at IS NULL AND id != :except_id;
+
 -- Active sessions for a user (listSessions): live + unexpired, newest-used first.
 selectActiveForUser:
 SELECT * FROM sessions

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.jvm.kt
@@ -82,8 +82,12 @@ private fun Route.publicRpc(services: RpcServices) {
                 guard(services.authService.withRemoteHost(call.request.origin.remoteHost) as AuthServicePublic)
             }
         }
+        // SEC-02: bind the caller's remote host so the per-IP claim/lookup throttle inside
+        // InviteServiceImpl keys on it — mirrors the AuthServicePublic binding above.
         registerService<InviteServicePublic> {
-            guardedConstruction { guard(services.inviteService as InviteServicePublic) }
+            guardedConstruction {
+                guard(services.inviteService.withRemoteHost(call.request.origin.remoteHost) as InviteServicePublic)
+            }
         }
     }
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
@@ -244,6 +244,65 @@ class AdminUserServiceImplTest :
             }
         }
 
+        test("updateUser by an ADMIN caller promoting a MEMBER to ROOT is denied") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestUser("a1", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m1", UserRoleColumn.MEMBER)
+                runTest {
+                    val svc = makeAdminUserService(db).actAs("a1", UserRole.ADMIN)
+                    svc
+                        .updateUser(UserId("m1"), AdminUserPatch(role = UserRole.ROOT))
+                        .shouldFail<AuthError.PermissionDenied>()
+                }
+            }
+        }
+
+        test("updateUser by an ADMIN caller promoting themselves to ROOT is denied") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestUser("root1", UserRoleColumn.ROOT)
+                sql.seedTestUser("a1", UserRoleColumn.ADMIN)
+                runTest {
+                    val svc = makeAdminUserService(db).actAs("a1", UserRole.ADMIN)
+                    svc
+                        .updateUser(UserId("a1"), AdminUserPatch(role = UserRole.ROOT))
+                        .shouldFail<AuthError.PermissionDenied>()
+                }
+            }
+        }
+
+        test("updateUser by a ROOT caller promoting a MEMBER to ROOT succeeds") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestUser("root1", UserRoleColumn.ROOT)
+                sql.seedTestUser("m1", UserRoleColumn.MEMBER)
+                runTest {
+                    val svc = makeAdminUserService(db).actAs("root1", UserRole.ROOT)
+                    svc
+                        .updateUser(UserId("m1"), AdminUserPatch(role = UserRole.ROOT))
+                        .shouldSucceed()
+                        .role shouldBe UserRole.ROOT
+                }
+            }
+        }
+
+        test("updateUser by an ADMIN caller can still change MEMBER<->ADMIN roles") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestUser("root1", UserRoleColumn.ROOT)
+                sql.seedTestUser("a1", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m1", UserRoleColumn.MEMBER)
+                runTest {
+                    val svc = makeAdminUserService(db).actAs("a1", UserRole.ADMIN)
+                    svc
+                        .updateUser(UserId("m1"), AdminUserPatch(role = UserRole.ADMIN))
+                        .shouldSucceed()
+                        .role shouldBe UserRole.ADMIN
+                }
+            }
+        }
+
         test("updateUser by a non-admin is rejected with PermissionDenied") {
             withSqlDatabase {
                 val db = this

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/InviteServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/InviteServiceImplTest.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.InviteError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.auth.InviteCodeGenerator
+import com.calypsan.listenup.server.auth.InviteRateLimiter
 import com.calypsan.listenup.server.auth.JwtConfiguration
 import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PasswordHasher
@@ -31,6 +32,7 @@ import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.seedTestUser
 import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
@@ -70,14 +72,19 @@ class InviteServiceImplTest :
             return SessionIssuer(sessions, jwt, fixedClock)
         }
 
-        fun makeInviteService(sql: ListenUpDatabase): InviteServiceImpl =
+        fun makeInviteService(
+            sql: ListenUpDatabase,
+            hasher: Argon2Limiter = Argon2Limiter(PasswordHasher()),
+            inviteRateLimiter: InviteRateLimiter? = null,
+        ): InviteServiceImpl =
             InviteServiceImpl(
                 db = sql,
                 codeGenerator = InviteCodeGenerator(),
-                hasher = Argon2Limiter(PasswordHasher()),
+                hasher = hasher,
                 sessionIssuer = sessionIssuerFor(sql),
                 serverName = serverName,
                 clock = fixedClock,
+                inviteRateLimiter = inviteRateLimiter,
             )
 
         fun InviteServiceImpl.actAs(
@@ -389,6 +396,71 @@ class InviteServiceImplTest :
                     val expired = makeInviteService(sql).lookupInvite(invite.code).shouldSucceed()
                     expired.valid shouldBe false
                     expired.invalidReason shouldBe "This invite has expired."
+                }
+            }
+        }
+
+        // ── RPC public-mount rate limiting (SEC-02) ─────────────────────────────
+
+        test("claimInvite rate-limits repeated attempts from one host; a different host is unaffected") {
+            withSqlDatabase {
+                runTest {
+                    val limiter = InviteRateLimiter(clock = fixedClock)
+                    val base = makeInviteService(sql, inviteRateLimiter = limiter)
+                    // CLAIM bucket ceiling is 5/min — the invite code doesn't need to be valid for the
+                    // throttle to count the attempt (mirrors AuthServiceImpl's login throttle, which
+                    // counts before credential validation).
+                    repeat(5) { i ->
+                        base.withRemoteHost("1.1.1.1").claimInvite("bogus-$i", "password123").shouldFail<InviteError.NotFound>()
+                    }
+                    val throttled =
+                        base
+                            .withRemoteHost("1.1.1.1")
+                            .claimInvite("bogus-6", "password123")
+                            .shouldFail<AuthError.RateLimited>()
+                    throttled.retryAfterSeconds shouldBeGreaterThan 0
+                    // A different host has its own bucket and is unaffected.
+                    base
+                        .withRemoteHost("2.2.2.2")
+                        .claimInvite("bogus-x", "password123")
+                        .shouldFail<InviteError.NotFound>()
+                }
+            }
+        }
+
+        test("lookupInvite rate-limits repeated attempts from one host; a different host is unaffected") {
+            withSqlDatabase {
+                runTest {
+                    val limiter = InviteRateLimiter(clock = fixedClock)
+                    val base = makeInviteService(sql, inviteRateLimiter = limiter)
+                    // LOOKUP bucket ceiling is 20/min.
+                    repeat(20) { i ->
+                        base.withRemoteHost("1.1.1.1").lookupInvite("bogus-$i").shouldFail<InviteError.NotFound>()
+                    }
+                    val throttled =
+                        base.withRemoteHost("1.1.1.1").lookupInvite("bogus-21").shouldFail<AuthError.RateLimited>()
+                    throttled.retryAfterSeconds shouldBeGreaterThan 0
+                    base.withRemoteHost("2.2.2.2").lookupInvite("bogus-x").shouldFail<InviteError.NotFound>()
+                }
+            }
+        }
+
+        test("claimInvite on an unknown code fails WITHOUT hashing the password") {
+            withSqlDatabase {
+                runTest {
+                    var hashCalls = 0
+                    val countingHasher =
+                        Argon2Limiter(
+                            permits = 1,
+                            hashFn = {
+                                hashCalls++
+                                "hash"
+                            },
+                            verifyFn = { _, _ -> false },
+                        )
+                    val svc = makeInviteService(sql, hasher = countingHasher)
+                    svc.claimInvite("no-such-code", "password123").shouldFail<InviteError.NotFound>()
+                    hashCalls shouldBe 0
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/InviteServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/InviteServiceImplTest.kt
@@ -152,6 +152,39 @@ class InviteServiceImplTest :
             }
         }
 
+        test("createInvite with role=ROOT by an ADMIN caller is denied") {
+            withSqlDatabase {
+                sql.seedTestUser("a1", UserRoleColumn.ADMIN)
+                runTest {
+                    val svc = makeInviteService(sql).actAs("a1", UserRole.ADMIN)
+                    svc
+                        .createInvite("a@b.c", "A", UserRole.ROOT, null)
+                        .shouldFail<AuthError.PermissionDenied>()
+                }
+            }
+        }
+
+        test("createInvite with role=ROOT by a ROOT caller succeeds") {
+            withSqlDatabase {
+                sql.seedTestUser("root1", UserRoleColumn.ROOT)
+                runTest {
+                    val svc = makeInviteService(sql).actAs("root1", UserRole.ROOT)
+                    svc.createInvite("a@b.c", "A", UserRole.ROOT, null).shouldSucceed().role shouldBe UserRole.ROOT
+                }
+            }
+        }
+
+        test("createInvite by an ADMIN caller can still mint MEMBER and ADMIN invites") {
+            withSqlDatabase {
+                sql.seedTestUser("a1", UserRoleColumn.ADMIN)
+                runTest {
+                    val svc = makeInviteService(sql).actAs("a1", UserRole.ADMIN)
+                    svc.createInvite("m@b.c", "M", UserRole.MEMBER, null).shouldSucceed().role shouldBe UserRole.MEMBER
+                    svc.createInvite("a2@b.c", "A2", UserRole.ADMIN, null).shouldSucceed().role shouldBe UserRole.ADMIN
+                }
+            }
+        }
+
         test("listInvites returns created invites with derived status PENDING") {
             withSqlDatabase {
                 sql.seedTestUser("root1", UserRoleColumn.ROOT)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ProfileServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ProfileServiceImplTest.kt
@@ -11,6 +11,9 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PasswordHasher
 import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.auth.RefreshTokenGenerator
+import com.calypsan.listenup.server.auth.RefreshTokenHasher
+import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.auth.UserPrincipal
 import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.SqlTestDatabases
@@ -27,12 +30,17 @@ import kotlin.time.Instant
 
 class ProfileServiceImplTest :
     FunSpec({
+        val pepper = "x".repeat(32).toByteArray()
+
+        fun SqlTestDatabases.sessionsService(): SessionService = SessionService(sql, RefreshTokenHasher(pepper), RefreshTokenGenerator())
+
         fun SqlTestDatabases.svc(userId: String): ProfileServiceImpl =
             ProfileServiceImpl(
                 sql = sql,
                 argon2Limiter = Argon2Limiter(PasswordHasher()),
                 publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                 imageStore = tempAvatarImageStore(),
+                sessions = sessionsService(),
             ).copyWith(
                 PrincipalProvider {
                     UserPrincipal(UserId(userId), SessionId("s-$userId"), UserRole.MEMBER)
@@ -57,6 +65,7 @@ class ProfileServiceImplTest :
                             argon2Limiter = Argon2Limiter(PasswordHasher()),
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = tempAvatarImageStore(),
+                            sessions = sessionsService(),
                             clock = FixedClock(Instant.fromEpochMilliseconds(fixed)),
                         ).copyWith(
                             PrincipalProvider {
@@ -98,6 +107,7 @@ class ProfileServiceImplTest :
                             argon2Limiter = Argon2Limiter(hasher),
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = tempAvatarImageStore(),
+                            sessions = sessionsService(),
                         ).copyWith(
                             PrincipalProvider {
                                 UserPrincipal(UserId("u1"), SessionId("s"), UserRole.MEMBER)
@@ -128,6 +138,7 @@ class ProfileServiceImplTest :
                             argon2Limiter = Argon2Limiter(hasher),
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = tempAvatarImageStore(),
+                            sessions = sessionsService(),
                         ).copyWith(
                             PrincipalProvider {
                                 UserPrincipal(UserId("u1"), SessionId("s"), UserRole.MEMBER)
@@ -174,6 +185,7 @@ class ProfileServiceImplTest :
                             argon2Limiter = counting,
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = tempAvatarImageStore(),
+                            sessions = sessionsService(),
                         ).copyWith(
                             PrincipalProvider {
                                 UserPrincipal(UserId("u1"), SessionId("s"), UserRole.MEMBER)
@@ -215,6 +227,7 @@ class ProfileServiceImplTest :
                             argon2Limiter = Argon2Limiter(PasswordHasher()),
                             publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
                             imageStore = imageStore,
+                            sessions = sessionsService(),
                             clock = FixedClock(Instant.fromEpochMilliseconds(t2)),
                         ).copyWith(
                             PrincipalProvider { UserPrincipal(UserId("u1"), SessionId("s"), UserRole.MEMBER) },
@@ -228,6 +241,108 @@ class ProfileServiceImplTest :
                     row?.avatar_updated_at shouldBe t2
                     // And the orphaned bytes are gone so GET /avatars/{id} 404s.
                     imageStore.pathFor("u1").shouldBeNull()
+                }
+            }
+        }
+
+        // ── Session revocation on password change (SEC-03) ─────────────────────────
+
+        test("a successful password change revokes the caller's OTHER sessions but spares the current one") {
+            withSqlDatabase {
+                val hasher = PasswordHasher()
+                runTest {
+                    val hash = hasher.hash("correct-pass")
+                    sql.seedTestUser("u1")
+                    sql.usersQueries.updatePasswordHash(password_hash = hash, id = "u1")
+                    val sessions = sessionsService()
+                    // The session issuing THIS request, plus one other live session on a different device.
+                    val current = sessions.createSession(UserId("u1"))
+                    val other = sessions.createSession(UserId("u1"))
+
+                    val svc =
+                        ProfileServiceImpl(
+                            sql = sql,
+                            argon2Limiter = Argon2Limiter(hasher),
+                            publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
+                            imageStore = tempAvatarImageStore(),
+                            sessions = sessions,
+                        ).copyWith(
+                            PrincipalProvider {
+                                UserPrincipal(UserId("u1"), current.sessionId, UserRole.MEMBER)
+                            },
+                        )
+
+                    svc
+                        .updateMyProfile(UpdateProfileRequest(password = PasswordChange("correct-pass", "brand-new-pass")))
+                        .shouldBeInstanceOf<AppResult.Success<Profile>>()
+
+                    sessions.isLive(current.sessionId) shouldBe true
+                    sessions.isLive(other.sessionId) shouldBe false
+                }
+            }
+        }
+
+        test("a display-name-only update does NOT revoke any sessions") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                runTest {
+                    val sessions = sessionsService()
+                    val current = sessions.createSession(UserId("u1"))
+                    val other = sessions.createSession(UserId("u1"))
+
+                    val svc =
+                        ProfileServiceImpl(
+                            sql = sql,
+                            argon2Limiter = Argon2Limiter(PasswordHasher()),
+                            publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
+                            imageStore = tempAvatarImageStore(),
+                            sessions = sessions,
+                        ).copyWith(
+                            PrincipalProvider {
+                                UserPrincipal(UserId("u1"), current.sessionId, UserRole.MEMBER)
+                            },
+                        )
+
+                    svc
+                        .updateMyProfile(UpdateProfileRequest(displayName = "New Name"))
+                        .shouldBeInstanceOf<AppResult.Success<Profile>>()
+
+                    sessions.isLive(current.sessionId) shouldBe true
+                    sessions.isLive(other.sessionId) shouldBe true
+                }
+            }
+        }
+
+        test("a failed password change (wrong current password) does NOT revoke any sessions") {
+            withSqlDatabase {
+                val hasher = PasswordHasher()
+                runTest {
+                    val hash = hasher.hash("correct-pass")
+                    sql.seedTestUser("u1")
+                    sql.usersQueries.updatePasswordHash(password_hash = hash, id = "u1")
+                    val sessions = sessionsService()
+                    val current = sessions.createSession(UserId("u1"))
+                    val other = sessions.createSession(UserId("u1"))
+
+                    val svc =
+                        ProfileServiceImpl(
+                            sql = sql,
+                            argon2Limiter = Argon2Limiter(hasher),
+                            publicProfileMaintainer = sql.noOpPublicProfileMaintainer(),
+                            imageStore = tempAvatarImageStore(),
+                            sessions = sessions,
+                        ).copyWith(
+                            PrincipalProvider {
+                                UserPrincipal(UserId("u1"), current.sessionId, UserRole.MEMBER)
+                            },
+                        )
+
+                    svc
+                        .updateMyProfile(UpdateProfileRequest(password = PasswordChange("wrong-current", "brand-new-pass")))
+                        .shouldBeInstanceOf<AppResult.Failure>()
+
+                    sessions.isLive(current.sessionId) shouldBe true
+                    sessions.isLive(other.sessionId) shouldBe true
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PublicProfileLifecycleTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PublicProfileLifecycleTest.kt
@@ -129,6 +129,7 @@ class PublicProfileLifecycleTest :
                             argon2Limiter = Argon2Limiter(PasswordHasher()),
                             publicProfileMaintainer = maintainer,
                             imageStore = tempAvatarImageStore(),
+                            sessions = SessionService(sql, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = fixedClock),
                         ).copyWith(principalFor("u1"))
 
                     svc

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/auth/SessionServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/auth/SessionServiceTest.kt
@@ -179,6 +179,23 @@ class SessionServiceTest :
                 .revoked_at shouldNotBe null
         }
 
+        test("revokeAllExcept revokes every other session but spares the given one") {
+            val db = freshDb()
+            db.seedTestUser("u-1")
+            val svc =
+                SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = clock)
+
+            val spared = svc.createSession(UserId("u-1"))
+            val other1 = svc.createSession(UserId("u-1"))
+            val other2 = svc.createSession(UserId("u-1"))
+
+            svc.revokeAllExcept(UserId("u-1"), spared.sessionId)
+
+            svc.isLive(spared.sessionId) shouldBe true
+            svc.isLive(other1.sessionId) shouldBe false
+            svc.isLive(other2.sessionId) shouldBe false
+        }
+
         test("rotate returns null for an explicitly-revoked session") {
             val db = freshDb()
             db.seedTestUser("u-1")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/di/ProfileModuleVerifyTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/di/ProfileModuleVerifyTest.kt
@@ -3,6 +3,9 @@ package com.calypsan.listenup.server.di
 import com.calypsan.listenup.api.ProfileService
 import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PasswordHasher
+import com.calypsan.listenup.server.auth.RefreshTokenGenerator
+import com.calypsan.listenup.server.auth.RefreshTokenHasher
+import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.media.ImageStore
 import com.calypsan.listenup.server.testing.noOpPublicProfileMaintainer
@@ -29,6 +32,9 @@ class ProfileModuleVerifyTest :
                                     single { Argon2Limiter(PasswordHasher()) }
                                     single { sql.noOpPublicProfileMaintainer() }
                                     single<Clock> { Clock.System }
+                                    single {
+                                        SessionService(sql, RefreshTokenHasher("x".repeat(32).toByteArray()), RefreshTokenGenerator())
+                                    }
                                 },
                                 profileModule(IoPath(avatarsDir.toString())),
                             )

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.linux.kt
@@ -82,8 +82,12 @@ private fun Route.publicRpc(services: RpcServices) {
                 guard(services.authService.withRemoteHost(call.request.origin.remoteHost) as AuthServicePublic)
             }
         }
+        // SEC-02: bind the caller's remote host so the per-IP claim/lookup throttle inside
+        // InviteServiceImpl keys on it — mirrors the AuthServicePublic binding above.
         registerService<InviteServicePublic> {
-            guardedConstruction { guard(services.inviteService as InviteServicePublic) }
+            guardedConstruction {
+                guard(services.inviteService.withRemoteHost(call.request.origin.remoteHost) as InviteServicePublic)
+            }
         }
     }
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/profile/ProfileE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/profile/ProfileE2ETest.kt
@@ -11,6 +11,9 @@ import com.calypsan.listenup.server.api.createProfileService
 import com.calypsan.listenup.server.api.profileServiceScopedTo
 import com.calypsan.listenup.server.auth.Argon2Limiter
 import com.calypsan.listenup.server.auth.PasswordHasher
+import com.calypsan.listenup.server.auth.RefreshTokenGenerator
+import com.calypsan.listenup.server.auth.RefreshTokenHasher
+import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.services.PublicProfileMaintainer
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.PublicProfileRepository
@@ -118,6 +121,7 @@ class ProfileE2ETest :
                             PublicProfileRepository(serverSqlDb, ChangeBus(), SyncRegistry()),
                         ),
                     imageStore = ImageStore(IoPath(Files.createTempDirectory("e2e-avatars").toString()), AVATAR_MAX_BYTES),
+                    sessions = SessionService(serverSqlDb, RefreshTokenHasher("x".repeat(32).toByteArray()), RefreshTokenGenerator()),
                 )
 
             testApplication {
@@ -175,6 +179,7 @@ class ProfileE2ETest :
                             PublicProfileRepository(serverSqlDb, ChangeBus(), SyncRegistry()),
                         ),
                     imageStore = ImageStore(IoPath(Files.createTempDirectory("e2e-avatars").toString()), AVATAR_MAX_BYTES),
+                    sessions = SessionService(serverSqlDb, RefreshTokenHasher("x".repeat(32).toByteArray()), RefreshTokenGenerator()),
                 )
 
             testApplication {


### PR DESCRIPTION
Three security findings from the pre-ship audit (rebased onto current main; server-only, export-neutral).

- **SEC-01 — block ADMIN→ROOT self-escalation.** `InviteServiceImpl.createInvite` and `AdminUserServiceImpl.roleChangeFor` now reject promotion to `ROOT` unless the caller is already `ROOT` (`AuthError.PermissionDenied`). Previously a non-ROOT ADMIN could mint an irreversible ROOT account via either an invite role or a self-targeted `PATCH /admin/users/{id}` — defeating the ROOT/ADMIN trust-tier design.
- **SEC-02 — rate-limit invite claim/lookup on the public RPC mount.** `InviteServicePublic` was registered without the per-IP throttle its `AuthServicePublic` sibling gets, and `claimInvite` ran Argon2 before validating the code. Added an `InviteRateLimiter` (claim 5/min, lookup 20/min) mirroring `LoginRateLimiter`, bound the remote host on both the JVM and native RPC routes, moved the cheap code-existence precheck ahead of the hash, and returned the existing `AuthError.RateLimited` (no new error type).
- **SEC-03 — revoke other sessions on password change.** `ProfileServiceImpl.updateMyProfile` now revokes the caller's *other* live sessions after a successful password change (sparing the requesting session via `SessionService.revokeAllExcept`), so a stolen 30-day refresh token can't outlive the password change. Mirrors the existing role-demotion revocation. New `Sessions.sq` query, no schema/migration change.

TDD throughout. Gates green: spotless+detekt, `:server:jvmTest` (full suite), commonMain metadata compile.