### PR TITLE
✅ test(shared): kill the SyncEngineStateObservers deadLetterCount flake for real

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
@@ -104,6 +104,15 @@ internal interface PendingOperationV2Dao {
     fun observeDeadLetterCount(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<Int>
 
     /**
+     * One-shot dead-letter count — the same predicate as [observeDeadLetterCount] read directly.
+     * A plain suspend `SELECT` sees a committed write immediately, without waiting on Room's
+     * [androidx.room.InvalidationTracker] to notify the reactive Flow; tests use it to confirm a
+     * write landed deterministically, decoupled from invalidation-propagation latency.
+     */
+    @Query("SELECT COUNT(*) FROM pending_operation WHERE failureCount > :maxAttempts")
+    suspend fun countDeadLetters(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Int
+
+    /**
      * Live snapshots of ops still within retry budget, oldest first. Backs the
      * sync indicator's visible pending list.
      */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
@@ -109,6 +109,8 @@ private class FakePendingOperationV2Dao : PendingOperationV2Dao {
 
     override fun observeDeadLetterCount(maxAttempts: Int): Flow<Int> = flowOf(0)
 
+    override suspend fun countDeadLetters(maxAttempts: Int): Int = 0
+
     override suspend fun deleteAllExcept(keepUserId: String) {
         inserted.removeAll { it.ownerUserId != keepUserId }
     }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -627,6 +627,8 @@ private class CountingDao(
 
     override fun observeDeadLetterCount(maxAttempts: Int) = delegate.observeDeadLetterCount(maxAttempts)
 
+    override suspend fun countDeadLetters(maxAttempts: Int) = delegate.countDeadLetters(maxAttempts)
+
     override suspend fun deleteAllExcept(keepUserId: String) = delegate.deleteAllExcept(keepUserId)
 
     override suspend fun deleteAll() = delegate.deleteAll()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStateObserversTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStateObserversTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -21,8 +22,10 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.builtins.serializer
 
-private const val TIMEOUT_SECONDS = 5L
-private const val DEAD_LETTER_OBSERVER_TIMEOUT_SECONDS = 15L
+// Generous budget for reactive assertions that ride Room's InvalidationTracker-backed Flows,
+// whose propagation latency spikes under full-suite CI load.
+private const val OBSERVER_TIMEOUT_SECONDS = 15L
+private const val POLL_INTERVAL_MILLIS = 20L
 
 // "tags" is not a real outbox channel — a minimal local fixture for a hypothetical
 // un-mirrored domain, matching the queue's payload-agnostic contract.
@@ -71,7 +74,7 @@ class SyncEngineStateObserversTest :
                     queue.enqueue(tagsChannel, "t2", OpKind.Upsert, "{}", "u1")
 
                     val expectedDepth = 2
-                    withTimeout(TIMEOUT_SECONDS.seconds) {
+                    withTimeout(OBSERVER_TIMEOUT_SECONDS.seconds) {
                         state.observe().first { it.pendingQueueDepth == expectedDepth }
                     }
                 } finally {
@@ -123,16 +126,22 @@ class SyncEngineStateObserversTest :
                             ),
                         )
 
-                    // Await the DAO's own visibility of the insert BEFORE asserting on the engine's
-                    // observer pipeline — Room's InvalidationTracker propagation latency is a separate
-                    // (and separately load-sensitive) concern from whether SyncEngineState correctly
-                    // forwards observeDeadLetterCount(). Splitting the two means a failure here can only
-                    // mean the engine's forwarding is broken, never that the write hadn't landed yet.
-                    withTimeout(TIMEOUT_SECONDS.seconds) {
-                        db.pendingOperationV2Dao().observeDeadLetterCount().first { it == 1 }
+                    // Confirm the insert landed BEFORE asserting on the engine's observer pipeline,
+                    // using a one-shot suspend read (countDeadLetters) rather than the reactive
+                    // observeDeadLetterCount() Flow. A direct SELECT sees the committed row at once;
+                    // collecting the Flow would instead wait on Room's InvalidationTracker, whose
+                    // propagation latency is load-sensitive and unrelated to whether the write landed —
+                    // the original source of this test's flakiness under full-suite CI load.
+                    withTimeout(OBSERVER_TIMEOUT_SECONDS.seconds) {
+                        while (db.pendingOperationV2Dao().countDeadLetters() != 1) {
+                            delay(POLL_INTERVAL_MILLIS)
+                        }
                     }
 
-                    withTimeout(DEAD_LETTER_OBSERVER_TIMEOUT_SECONDS.seconds) {
+                    // Now the genuinely reactive assertion: SyncEngineState forwards the DAO's
+                    // dead-letter count. This one legitimately rides the InvalidationTracker-backed
+                    // Flow, so it gets the same generous budget.
+                    withTimeout(OBSERVER_TIMEOUT_SECONDS.seconds) {
                         state.observe().first { it.deadLetterCount == 1 }
                     }
                 } finally {


### PR DESCRIPTION
The `SyncEngineStateObserversTest > deadLetterCount` test has been flaking under full-suite CI load for a while (it's failed several audit PRs this session: #1143, #1149, and others). #1140 tried to harden it (raised one timeout to 15s, split the assertion) but it kept flaking — because the root cause wasn't addressed.

**Root cause:** the test's *write-landed* check collected the reactive `observeDeadLetterCount()` Flow with only a 5s budget (`TIMEOUT_SECONDS`). That Flow fires via Room's `InvalidationTracker`, whose notification latency spikes under heavy concurrent CI load — so a write that already committed synchronously could take >5s to surface through the reactive path. Every failure was a `TimeoutCancellationException` at that exact line.

**Fix:** confirm the insert landed with a new one-shot `PendingOperationV2Dao.countDeadLetters()` suspend query (a direct `SELECT COUNT` — sees the committed row immediately, no `InvalidationTracker`), polled to completion. The genuinely-reactive second assertion (does `SyncEngineState` forward the count) still rides the Flow, on the generous shared 15s budget. Also collapsed the sibling `pendingQueueDepth` assertion onto the same generous timeout (identical latent flake).

Verified: target test green locally; lint/detekt/compile green. New query is additive (no other caller), so no production behavior change.

Recommend merging this first — it unblocks the flake class for every in-flight PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)