### PR TITLE
🐛 fix: contributor metadata — dedupe Audnexus ASINs + start the iOS profile fetch

### DIFF
--- a/iosApp/ListenUp/Features/ContributorMetadata/ContributorMetadataObserver.swift
+++ b/iosApp/ListenUp/Features/ContributorMetadata/ContributorMetadataObserver.swift
@@ -102,8 +102,14 @@ final class ContributorMetadataObserver {
     func changeRegion(_ region: MetadataRegionOption) { viewModel.changeRegion(region: region.locale) }
 
     func selectCandidate(_ asin: String) {
-        guard let hit = rawHits[asin] else { return }
-        viewModel.selectCandidate(result: hit)
+        if let hit = rawHits[asin] {
+            viewModel.selectCandidate(result: hit)
+        } else {
+            // No raw hit cached (search results replaced or cleared) — fall back to loading by
+            // ASIN rather than returning silently, which would strand the preview on a spinner
+            // waiting for a fetch that never started.
+            viewModel.loadProfileByAsin(asin: asin)
+        }
     }
 
     func clearSelection() { viewModel.clearSelection() }

--- a/iosApp/ListenUp/Features/ContributorMetadata/ContributorMetadataView.swift
+++ b/iosApp/ListenUp/Features/ContributorMetadata/ContributorMetadataView.swift
@@ -24,9 +24,14 @@ struct ContributorMetadataView: View {
                     ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
-            .navigationDestination(for: String.self) { _ in
+            .navigationDestination(for: String.self) { asin in
                 if let observer {
                     ContributorMetadataPreviewView(observer: observer, onApply: { observer.apply() })
+                        // Kick the profile fetch on arrival. Without this the view model stays in
+                        // its initial state (not loading, no profile, no error) and the preview
+                        // renders its fallthrough spinner forever. Mirrors the Compose route,
+                        // which drives the same fetch from a LaunchedEffect.
+                        .task(id: asin) { observer.selectCandidate(asin) }
                 }
             }
             .navigationTitle(String(localized: "contributor.find_on_audible"))

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudnexusProvider.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudnexusProvider.kt
@@ -133,7 +133,11 @@ internal class AudnexusProvider(
             SEARCH_TTL,
             ListSerializer(AudnexusAuthor.serializer()),
         ) { client.searchAuthors(name, locale.region) }
-            .map { hits -> hits.mapNotNull { it.toContributorHitMetaOrNull() } }
+            // Audnexus indexes an author once per catalogued region/edition, so a common name
+            // returns the same ASIN several times over. One hit per author is the contract our
+            // SPI promises — dedupe by ASIN (not by name: distinct people do share names).
+            // Applied after the cache read, so entries cached before this fix stay valid.
+            .map { hits -> hits.mapNotNull { it.toContributorHitMetaOrNull() }.distinctBy(ContributorHitMeta::key) }
 
     override suspend fun getContributor(
         key: String,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/provider/AudnexusProviderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/provider/AudnexusProviderTest.kt
@@ -236,6 +236,37 @@ class AudnexusProviderTest :
             }
         }
 
+        test("searchContributors dedupes repeated ASINs from upstream, keeping first-seen order") {
+            // Audnexus's /authors index returns one record per catalogued region/edition, so a
+            // common name comes back with the same author ASIN several times over. Shipping that
+            // straight to the client crashed a keyed LazyColumn ("Key B0F5XZ1BF2 was already
+            // used") and would have listed the same person repeatedly even without the crash.
+            // Two distinct people who share a name must both survive — dedupe is by ASIN, never
+            // by name.
+            withSqlDatabase {
+                val api =
+                    CountingAudnexusApi(
+                        authors =
+                            listOf(
+                                AudnexusAuthor(asin = "A1", name = "Tim Curry"),
+                                AudnexusAuthor(asin = "A2", name = "Tim Curry"),
+                                AudnexusAuthor(asin = "A1", name = "Tim Curry"),
+                                AudnexusAuthor(asin = "A1", name = "Tim Curry"),
+                                AudnexusAuthor(asin = "A2", name = "Tim Curry"),
+                            ),
+                    )
+                val provider = provider(api, sql)
+                runTest {
+                    val hits =
+                        provider
+                            .searchContributors("tim curry", US)
+                            .shouldBeInstanceOf<AppResult.Success<List<*>>>()
+                            .data
+                    hits.map { (it as ContributorHitMeta).key } shouldBe listOf("A1", "A2")
+                }
+            }
+        }
+
         test("id is AUDNEXUS") {
             withSqlDatabase {
                 provider(CountingAudnexusApi(), sql).id shouldBe MetadataProviderId.AUDNEXUS


### PR DESCRIPTION
Two independent crash/hang fixes in the contributor match wizard, found during device testing.

**Android crash.** Audnexus' `/authors?name=` returns the same author record many times over (verified live: "Tim Curry" → 25 results, 16 distinct ASINs; "Brandon Sanderson" → 25 hits, 9 identical rows). We passed that straight into a `LazyColumn` keyed on `asin`, so a repeat key threw `IllegalArgumentException: Key "B0F5XZ1BF2" was already used`. Deduped at the SPI boundary where third-party data is normalised, by ASIN rather than name — two distinct people genuinely share a name (there are two different "Tim Curry" ASINs). Applied after the cache read, so entries cached before this change stay valid.

**iOS infinite spinner.** `navigationDestination(for: String.self)` discarded the ASIN, so the profile fetch was never started; the view model stayed in its initial state and the preview rendered its fallthrough `ProgressView` forever. The observer's `selectCandidate` was correct but had no caller. Wired the ASIN through and gave the wrapper a `loadProfileByAsin` fallback so a missing raw hit can't strand the screen again.

## Verification
- `AudnexusProviderTest` — new dedupe test confirmed **RED without the fix, GREEN with it**.
- `spotlessCheck` + `detekt` + `:server:jvmTest` run locally. One unrelated `DemoProfileBootTest` failure (`ConnectException` under full-suite load) passes in isolation.
- iOS changes are **not** locally verified — no swiftlint/xcodebuild on this machine. Relying on the CI iOS lane.

## Not addressed here
This is the surface layer. The underlying feature has deeper problems tracked separately: region is dropped on contributor search, apply can wipe an existing bio/photo with nulls, and the per-field checkboxes never cross the wire.