### PR TITLE
✨ feat(server): contributor metadata — region-correct search, non-destructive apply, ranked hits

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/MetadataLookupService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/MetadataLookupService.kt
@@ -92,7 +92,8 @@ interface MetadataLookupService {
      * profiles are region-localized (a hit found in `us` can have an empty
      * profile in `fr`), so searching and previewing must hit the same catalog.
      *
-     * Results are deduplicated by ASIN. Cached for 24 hours (search TTL).
+     * Results are deduplicated by ASIN and ranked closest-name-first against
+     * [query]. Cached for 24 hours (search TTL).
      */
     suspend fun searchContributorMetadata(
         query: String,

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/MetadataLookupService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/MetadataLookupService.kt
@@ -84,20 +84,20 @@ interface MetadataLookupService {
     ): AppResult<MetadataChapters?>
 
     /**
-     * Searches Audible for contributors matching [query].
+     * Searches for contributors matching [query] — served by the CONTRIBUTORS
+     * provider chain (Audnexus today; Audible has no contributor-search API).
      *
-     * **Currently stubs to an empty list.** Audible has no official
-     * contributor-search API; the available approach is HTML
-     * scraping of `www.audible.com/search?searchAuthor=`, which requires a
-     * Kotlin-first HTML parser dependency not yet added to `:server`. A proper
-     * implementation will land later — either via HTML scraping or an
-     * alternative metadata source (e.g. MusicBrainz, OpenLibrary).
+     * If [region] is `null`, the server uses its configured default region.
+     * Pass the same region here and to [getContributorMetadata]: Audnexus author
+     * profiles are region-localized (a hit found in `us` can have an empty
+     * profile in `fr`), so searching and previewing must hit the same catalog.
      *
-     * The method signature is included in the contract now so client code can
-     * be written against it; the stub will be transparently replaced by the
-     * real implementation without a contract change.
+     * Results are deduplicated by ASIN. Cached for 24 hours (search TTL).
      */
-    suspend fun searchContributorMetadata(query: String): AppResult<List<MetadataContributorHit>>
+    suspend fun searchContributorMetadata(
+        query: String,
+        region: MetadataLocale? = null,
+    ): AppResult<List<MetadataContributorHit>>
 
     /**
      * Fetches the canonical profile for the Audible contributor identified by

--- a/iosApp/ListenUp/Features/ContributorMetadata/ContributorMetadataObserver.swift
+++ b/iosApp/ListenUp/Features/ContributorMetadata/ContributorMetadataObserver.swift
@@ -102,8 +102,14 @@ final class ContributorMetadataObserver {
     func changeRegion(_ region: MetadataRegionOption) { viewModel.changeRegion(region: region.locale) }
 
     func selectCandidate(_ asin: String) {
-        guard let hit = rawHits[asin] else { return }
-        viewModel.selectCandidate(result: hit)
+        if let hit = rawHits[asin] {
+            viewModel.selectCandidate(result: hit)
+        } else {
+            // No raw hit cached (search results replaced or cleared) — fall back to loading by
+            // ASIN rather than returning silently, which would strand the preview on a spinner
+            // waiting for a fetch that never started.
+            viewModel.loadProfileByAsin(asin: asin)
+        }
     }
 
     func clearSelection() { viewModel.clearSelection() }

--- a/iosApp/ListenUp/Features/ContributorMetadata/ContributorMetadataView.swift
+++ b/iosApp/ListenUp/Features/ContributorMetadata/ContributorMetadataView.swift
@@ -24,9 +24,14 @@ struct ContributorMetadataView: View {
                     ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
-            .navigationDestination(for: String.self) { _ in
+            .navigationDestination(for: String.self) { asin in
                 if let observer {
                     ContributorMetadataPreviewView(observer: observer, onApply: { observer.apply() })
+                        // Kick the profile fetch on arrival. Without this the view model stays in
+                        // its initial state (not loading, no profile, no error) and the preview
+                        // renders its fallthrough spinner forever. Mirrors the Compose route,
+                        // which drives the same fetch from a LaunchedEffect.
+                        .task(id: asin) { observer.selectCandidate(asin) }
                 }
             }
             .navigationTitle(String(localized: "contributor.find_on_audible"))

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplier.kt
@@ -23,13 +23,16 @@ private val log = loggerFor<ContributorMetadataApplier>()
  * [EnrichmentCoordinator] (served by Audnexus's `ContributorSource`), then enriches
  * the existing [ContributorRepository] row in-place:
  *  - `asin` stamp
- *  - `description` (biography)
+ *  - `description` (biography) — only when the profile carries a non-blank one;
+ *    a blank incoming value keeps the existing biography
  *  - `imagePath` — downloads the photo to `contributors/{sha}.jpg` relative to
- *    [imageHome]. The OrphanImageCleanupTask reclaims the orphan file if the DB
- *    write rolls back.
+ *    [imageHome]; a failed download keeps the existing photo. The
+ *    OrphanImageCleanupTask reclaims the orphan file if the DB write rolls back.
  *
- * Returns [MetadataError.NotFound] when the contributor is absent from the DB, or
- * when no catalog has a profile for the ASIN.
+ * Returns [MetadataError.NotFound] when the contributor is absent from the DB,
+ * when no catalog has a profile for the ASIN, or when the profile is an empty
+ * regional shell (no biography AND no photo) — an honest miss, matching what
+ * Audiobookshelf does with the same Audnexus upstream.
  *
  * All writes go through the substrate's `upsert`, so revisions are bumped and
  * SSE change events are published automatically.
@@ -61,13 +64,26 @@ internal class ContributorMetadataApplier(
                     ),
                 )
 
+        // ABS-verified honest-miss guard: a profile with neither biography nor photo is an
+        // empty regional shell (Audnexus returns HTTP 200 with no content for cross-region
+        // fetches) — applying it could only stamp an ASIN while wiping nothing, so refuse.
+        if (profile.description.isNullOrBlank() && profile.imageUrl.isNullOrBlank()) {
+            return AppResult.Failure(
+                MetadataError.NotFound(
+                    debugInfo = "Profile for ASIN $asin has no data in region ${locale.region}.",
+                ),
+            )
+        }
+
         val imagePath = profile.downloadImage(contributorId)
 
+        // Never overwrite an existing field with a blank incoming value (ABS truthy-guard
+        // semantics): a missing bio or a failed photo download keeps what the user already has.
         val updated =
             existing.copy(
                 asin = asin,
-                description = profile.description,
-                imagePath = imagePath,
+                description = profile.description?.takeIf { it.isNotBlank() } ?: existing.description,
+                imagePath = imagePath ?: existing.imagePath,
             )
 
         return contributorRepository.upsert(updated, clientOpId = null).flatMap { AppResult.Success(Unit) }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -150,15 +150,22 @@ internal class MetadataLookupServiceImpl(
      * Contributor auto-match — search + profile fetch — composed across the provider registry through
      * the [coordinator]. The CONTRIBUTORS chain is served by Audnexus's `ContributorSource` (Audible has
      * no contributor-profile endpoint), so the wizard resolves author bios and photos from Audnexus.
+     * The caller's [region] (default US when null) is threaded through so the search hits the same
+     * regional catalog the profile preview will — Audnexus profiles are region-localized.
      * A total catalog miss returns an empty list / null, so the UI cleanly shows "no matches" and manual
      * contributor editing stays the fallback (Never-Stranded).
      */
-    override suspend fun searchContributorMetadata(query: String): AppResult<List<MetadataContributorHit>> =
-        AppResult.Success(
-            coordinator.searchContributors(query, MetadataLocale.DEFAULT).map {
+    override suspend fun searchContributorMetadata(
+        query: String,
+        region: MetadataLocale?,
+    ): AppResult<List<MetadataContributorHit>> {
+        val locale = region ?: MetadataLocale.DEFAULT
+        return AppResult.Success(
+            coordinator.searchContributors(query, locale).map {
                 MetadataContributorHit(asin = it.key, name = it.name)
             },
         )
+    }
 
     override suspend fun getContributorMetadata(
         asin: String,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -25,6 +25,7 @@ import com.calypsan.listenup.server.media.ImageStore
 import com.calypsan.listenup.server.metadata.ComposedBook
 import com.calypsan.listenup.server.metadata.EnrichmentCoordinator
 import com.calypsan.listenup.server.metadata.spi.BookIdentity
+import com.calypsan.listenup.server.metadata.spi.ContributorHitRanker
 import com.calypsan.listenup.server.metadata.spi.ContributorMeta
 import com.calypsan.listenup.api.metadata.MetadataLocale
 import com.calypsan.listenup.server.metadata.spi.MetadataProviderId
@@ -160,11 +161,8 @@ internal class MetadataLookupServiceImpl(
         region: MetadataLocale?,
     ): AppResult<List<MetadataContributorHit>> {
         val locale = region ?: MetadataLocale.DEFAULT
-        return AppResult.Success(
-            coordinator.searchContributors(query, locale).map {
-                MetadataContributorHit(asin = it.key, name = it.name)
-            },
-        )
+        val ranked = ContributorHitRanker.rank(query, coordinator.searchContributors(query, locale))
+        return AppResult.Success(ranked.map { MetadataContributorHit(asin = it.key, name = it.name) })
     }
 
     override suspend fun getContributorMetadata(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudnexusProvider.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudnexusProvider.kt
@@ -133,7 +133,11 @@ internal class AudnexusProvider(
             SEARCH_TTL,
             ListSerializer(AudnexusAuthor.serializer()),
         ) { client.searchAuthors(name, locale.region) }
-            .map { hits -> hits.mapNotNull { it.toContributorHitMetaOrNull() } }
+            // Audnexus indexes an author once per catalogued region/edition, so a common name
+            // returns the same ASIN several times over. One hit per author is the contract our
+            // SPI promises — dedupe by ASIN (not by name: distinct people do share names).
+            // Applied after the cache read, so entries cached before this fix stay valid.
+            .map { hits -> hits.mapNotNull { it.toContributorHitMetaOrNull() }.distinctBy(ContributorHitMeta::key) }
 
     override suspend fun getContributor(
         key: String,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/ContributorHitRanker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/spi/ContributorHitRanker.kt
@@ -1,0 +1,43 @@
+package com.calypsan.listenup.server.metadata.spi
+
+/**
+ * Ranks contributor search hits closest-name-first against the user's query.
+ *
+ * Audnexus's author search is fuzzy — a two-word query can return 25 loosely
+ * related hits. This ranker re-orders them with the same token-set
+ * Sørensen–Dice similarity [MatchScorer] uses for its title/author signals:
+ * order-independent ("King, Stephen" == "Stephen King") and tolerant of
+ * decorations ("Tim Curry - introductions"). The sort is stable, so equally
+ * scored hits keep the catalog's own relevance order.
+ *
+ * ABS solves the same problem by auto-picking the single closest hit
+ * (Levenshtein ≤ 3); we keep the picker UI — two different people can share a
+ * name — so we rank instead of pick. Pure and I/O-free.
+ */
+internal object ContributorHitRanker {
+    /** Returns [hits] sorted best-first by name similarity to [query]; input order on a blank query. */
+    fun rank(
+        query: String,
+        hits: List<ContributorHitMeta>,
+    ): List<ContributorHitMeta> {
+        val queryTokens = query.tokenize()
+        if (queryTokens.isEmpty()) return hits
+        return hits.sortedByDescending { hit -> similarity(queryTokens, hit.name.tokenize()) }
+    }
+
+    /** Sørensen–Dice coefficient over token sets: `2·|A∩B| / (|A|+|B|)`; `0.0` when either side is empty. */
+    private fun similarity(
+        a: Set<String>,
+        b: Set<String>,
+    ): Double {
+        if (a.isEmpty() || b.isEmpty()) return 0.0
+        val intersection = a.count { it in b }
+        return 2.0 * intersection / (a.size + b.size)
+    }
+
+    /** Lower-cases, splits on any non-alphanumeric run, and dedupes into a token set. */
+    private fun String.tokenize(): Set<String> =
+        buildString { this@tokenize.forEach { append(if (it.isLetterOrDigit()) it.lowercaseChar() else ' ') } }
+            .split(' ')
+            .filterTo(mutableSetOf()) { it.isNotEmpty() }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/MetadataRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/MetadataRoutes.kt
@@ -128,7 +128,7 @@ private fun Route.bookCoverRoutes(service: MetadataLookupService) {
 
 private fun Route.contributorMetadataRoutes(service: MetadataLookupService) {
     get<MetadataResources.ContributorSearch> { resource ->
-        when (val result = service.searchContributorMetadata(resource.query)) {
+        when (val result = service.searchContributorMetadata(resource.query, resource.region.toLocaleOrNull())) {
             is AppResult.Success -> call.respond(result.data)
             is AppResult.Failure -> call.respondBareAppError(result.error)
         }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/resources/MetadataResources.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/resources/MetadataResources.kt
@@ -77,18 +77,17 @@ class MetadataResources(
 
     /**
      * REST mirror of [com.calypsan.listenup.api.MetadataLookupService.searchContributorMetadata] —
-     * `GET /api/v1/metadata/contributors/search?query=…` searches for
-     * contributors matching [query].
-     *
-     * **Currently returns an empty list** — the underlying implementation is
-     * stubbed pending an HTML-scraping or alternative-source implementation.
-     * See [com.calypsan.listenup.api.MetadataLookupService.searchContributorMetadata]
-     * for the full deferral rationale.
+     * `GET /api/v1/metadata/contributors/search?query=…&region=us` searches for
+     * contributors matching [query], deduplicated by ASIN. When [region] is
+     * omitted the server uses its default region. Pass the same region to the profile fetch — profiles are
+     * region-localized.
      */
     @Resource("/api/v1/metadata/contributors/search")
     class ContributorSearch(
         /** Contributor name query, e.g. "Brandon Sanderson". */
         val query: String = "",
+        /** Optional region code (e.g. `"us"`, `"de"`). */
+        val region: String? = null,
     )
 
     /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/resources/MetadataResources.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/resources/MetadataResources.kt
@@ -78,8 +78,9 @@ class MetadataResources(
     /**
      * REST mirror of [com.calypsan.listenup.api.MetadataLookupService.searchContributorMetadata] —
      * `GET /api/v1/metadata/contributors/search?query=…&region=us` searches for
-     * contributors matching [query], deduplicated by ASIN. When [region] is
-     * omitted the server uses its default region. Pass the same region to the profile fetch — profiles are
+     * contributors matching [query], deduplicated by ASIN and ranked
+     * closest-name-first. When [region] is omitted the server uses its default
+     * region. Pass the same region to the profile fetch — profiles are
      * region-localized.
      */
     @Resource("/api/v1/metadata/contributors/search")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplierTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplierTest.kt
@@ -1,0 +1,194 @@
+package com.calypsan.listenup.server.api
+
+import com.calypsan.listenup.api.error.MetadataError
+import com.calypsan.listenup.api.metadata.MetadataLocale
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.ContributorSyncPayload
+import com.calypsan.listenup.core.ContributorId
+import com.calypsan.listenup.server.io.hashBytesSha256
+import com.calypsan.listenup.server.metadata.EnrichmentCoordinator
+import com.calypsan.listenup.server.metadata.ImageStorage
+import com.calypsan.listenup.server.metadata.spi.ContributorHitMeta
+import com.calypsan.listenup.server.metadata.spi.ContributorMeta
+import com.calypsan.listenup.server.metadata.spi.ContributorSource
+import com.calypsan.listenup.server.metadata.spi.EnrichmentRoutes
+import com.calypsan.listenup.server.metadata.spi.MetadataProviderId
+import com.calypsan.listenup.server.metadata.spi.MetadataProviderRegistry
+import com.calypsan.listenup.server.services.ContributorRepository
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import java.io.IOException
+import java.nio.file.Files
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path
+
+/**
+ * Non-destructive apply semantics (ABS-verified): a blank profile field never
+ * overwrites the contributor's existing value, a failed photo download keeps
+ * the existing photo, and an all-blank profile is an honest miss.
+ */
+class ContributorMetadataApplierTest :
+    FunSpec({
+
+        val existingPayload =
+            ContributorSyncPayload(
+                id = "c-1",
+                name = "Brandon Sanderson",
+                sortName = "Sanderson, Brandon",
+                revision = 0L,
+                updatedAt = 0L,
+                createdAt = 0L,
+                deletedAt = null,
+                asin = null,
+                description = "Existing bio.",
+                imagePath = "contributors/existing.jpg",
+            )
+
+        fun coordinatorWith(profile: ContributorMeta?): EnrichmentCoordinator =
+            EnrichmentCoordinator(
+                registry = MetadataProviderRegistry(providers = listOf(StaticContributorSource(profile))),
+                routes = EnrichmentRoutes.DEFAULT,
+            )
+
+        fun applier(
+            repo: ContributorRepository,
+            profile: ContributorMeta?,
+            storage: ImageStorage = ImageStorage(HttpClient(MockEngine { respond(ByteArray(8), HttpStatusCode.OK) })),
+        ): ContributorMetadataApplier =
+            ContributorMetadataApplier(
+                contributorRepository = repo,
+                imageStorage = storage,
+                coordinator = coordinatorWith(profile),
+                imageHome = Path(Files.createTempDirectory("applier-test-").toString()),
+            )
+
+        test("a blank-bio profile keeps the existing biography") {
+            withSqlDatabase {
+                val repo = ContributorRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                runTest {
+                    repo.upsert(existingPayload)
+                    val profile =
+                        ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = null, imageUrl = "https://img.example/p.jpg")
+
+                    applier(repo, profile).apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
+                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    val updated = repo.findById("c-1")
+                    updated.shouldNotBeNull()
+                    updated.description shouldBe "Existing bio."
+                    updated.asin shouldBe "B0ASIN"
+                    // Positive path: a successful download IS applied — proves the coalesce
+                    // (`imagePath ?: existing.imagePath`) isn't silently swallowing the new value too.
+                    updated.imagePath shouldBe "contributors/${hashBytesSha256(ByteArray(8))}.jpg"
+                }
+            }
+        }
+
+        test("a whitespace-only bio profile keeps the existing biography") {
+            withSqlDatabase {
+                val repo = ContributorRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                runTest {
+                    repo.upsert(existingPayload)
+                    val profile =
+                        ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = "   ", imageUrl = "https://img.example/p.jpg")
+
+                    applier(repo, profile).apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
+                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    val updated = repo.findById("c-1")
+                    updated.shouldNotBeNull()
+                    // Pins the `isNotBlank()` check specifically — a whitespace-only description is
+                    // non-null, so a regression back to a bare `!= null` check would silently pass
+                    // this value through and wipe the existing biography.
+                    updated.description shouldBe "Existing bio."
+                }
+            }
+        }
+
+        test("a whitespace-only image URL keeps the existing photo") {
+            withSqlDatabase {
+                val repo = ContributorRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                runTest {
+                    repo.upsert(existingPayload)
+                    val profile =
+                        ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = "New bio.", imageUrl = "   ")
+
+                    applier(repo, profile).apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
+                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    val updated = repo.findById("c-1")
+                    updated.shouldNotBeNull()
+                    updated.imagePath shouldBe "contributors/existing.jpg"
+                    updated.description shouldBe "New bio."
+                }
+            }
+        }
+
+        test("a failed photo download keeps the existing image path") {
+            withSqlDatabase {
+                val repo = ContributorRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                runTest {
+                    repo.upsert(existingPayload)
+                    val profile =
+                        ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = "New bio.", imageUrl = "https://img.example/p.jpg")
+                    val failingStorage = ImageStorage(HttpClient(MockEngine { throw IOException("network down") }))
+
+                    applier(repo, profile, storage = failingStorage)
+                        .apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
+                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    val updated = repo.findById("c-1")
+                    updated.shouldNotBeNull()
+                    updated.imagePath shouldBe "contributors/existing.jpg"
+                    updated.description shouldBe "New bio."
+                }
+            }
+        }
+
+        test("an all-blank profile is an honest miss — NotFound, nothing written") {
+            withSqlDatabase {
+                val repo = ContributorRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                runTest {
+                    repo.upsert(existingPayload)
+                    val profile =
+                        ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = null, imageUrl = null)
+
+                    val result = applier(repo, profile).apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
+
+                    result.shouldBeInstanceOf<AppResult.Failure>()
+                    result.error.shouldBeInstanceOf<MetadataError.NotFound>()
+                    val unchanged = repo.findById("c-1")
+                    unchanged.shouldNotBeNull()
+                    unchanged.asin shouldBe null
+                    unchanged.description shouldBe "Existing bio."
+                }
+            }
+        }
+    })
+
+/** A [ContributorSource] returning one canned profile (stands in for Audnexus). */
+private class StaticContributorSource(
+    private val profile: ContributorMeta?,
+) : ContributorSource {
+    override val id: MetadataProviderId = MetadataProviderId.AUDNEXUS
+
+    override suspend fun searchContributors(
+        name: String,
+        locale: MetadataLocale,
+    ): AppResult<List<ContributorHitMeta>> = AppResult.Success(emptyList())
+
+    override suspend fun getContributor(
+        key: String,
+        locale: MetadataLocale,
+        refresh: Boolean,
+    ): AppResult<ContributorMeta?> = AppResult.Success(profile)
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplierTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplierTest.kt
@@ -77,9 +77,15 @@ class ContributorMetadataApplierTest :
                 runTest {
                     repo.upsert(existingPayload)
                     val profile =
-                        ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = null, imageUrl = "https://img.example/p.jpg")
+                        ContributorMeta(
+                            key = "B0ASIN",
+                            name = "Brandon Sanderson",
+                            description = null,
+                            imageUrl = "https://img.example/p.jpg",
+                        )
 
-                    applier(repo, profile).apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
+                    applier(repo, profile)
+                        .apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
                         .shouldBeInstanceOf<AppResult.Success<Unit>>()
 
                     val updated = repo.findById("c-1")
@@ -99,9 +105,15 @@ class ContributorMetadataApplierTest :
                 runTest {
                     repo.upsert(existingPayload)
                     val profile =
-                        ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = "   ", imageUrl = "https://img.example/p.jpg")
+                        ContributorMeta(
+                            key = "B0ASIN",
+                            name = "Brandon Sanderson",
+                            description = "   ",
+                            imageUrl = "https://img.example/p.jpg",
+                        )
 
-                    applier(repo, profile).apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
+                    applier(repo, profile)
+                        .apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
                         .shouldBeInstanceOf<AppResult.Success<Unit>>()
 
                     val updated = repo.findById("c-1")
@@ -122,7 +134,8 @@ class ContributorMetadataApplierTest :
                     val profile =
                         ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = "New bio.", imageUrl = "   ")
 
-                    applier(repo, profile).apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
+                    applier(repo, profile)
+                        .apply(ContributorId("c-1"), "B0ASIN", MetadataLocale("us"))
                         .shouldBeInstanceOf<AppResult.Success<Unit>>()
 
                     val updated = repo.findById("c-1")
@@ -139,7 +152,12 @@ class ContributorMetadataApplierTest :
                 runTest {
                     repo.upsert(existingPayload)
                     val profile =
-                        ContributorMeta(key = "B0ASIN", name = "Brandon Sanderson", description = "New bio.", imageUrl = "https://img.example/p.jpg")
+                        ContributorMeta(
+                            key = "B0ASIN",
+                            name = "Brandon Sanderson",
+                            description = "New bio.",
+                            imageUrl = "https://img.example/p.jpg",
+                        )
                     val failingStorage = ImageStorage(HttpClient(MockEngine { throw IOException("network down") }))
 
                     applier(repo, profile, storage = failingStorage)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
@@ -115,6 +115,33 @@ class MetadataLookupServiceImplTest :
             }
         }
 
+        test("searchContributorMetadata threads the caller's region into the source") {
+            withSqlDatabase {
+                val source =
+                    RegionCapturingContributorSource(
+                        hits = listOf(ContributorHitMeta(key = "B001", name = "Sebastian Fitzek")),
+                    )
+                val service = makeService(audible = StubAudibleApi(), dbs = this, extraProviders = listOf(source))
+
+                runTest {
+                    service.searchContributorMetadata("sebastian fitzek", MetadataLocale("de"))
+                    source.lastSearchRegion shouldBe "de"
+                }
+            }
+        }
+
+        test("searchContributorMetadata defaults to the US region when region is null") {
+            withSqlDatabase {
+                val source = RegionCapturingContributorSource()
+                val service = makeService(audible = StubAudibleApi(), dbs = this, extraProviders = listOf(source))
+
+                runTest {
+                    service.searchContributorMetadata("anyone", null)
+                    source.lastSearchRegion shouldBe "us"
+                }
+            }
+        }
+
         test("getContributorMetadata maps a ContributorMeta profile to the wire profile") {
             withSqlDatabase {
                 val source =
@@ -544,6 +571,28 @@ private class FakeContributorSource(
         locale: MetadataLocale,
         refresh: Boolean,
     ): AppResult<ContributorMeta?> = AppResult.Success(profile)
+}
+
+/** A [ContributorSource] that records the region of the last search, to prove region threading. */
+private class RegionCapturingContributorSource(
+    private val hits: List<ContributorHitMeta> = emptyList(),
+) : ContributorSource {
+    override val id: MetadataProviderId = MetadataProviderId.AUDNEXUS
+    var lastSearchRegion: String? = null
+
+    override suspend fun searchContributors(
+        name: String,
+        locale: MetadataLocale,
+    ): AppResult<List<ContributorHitMeta>> {
+        lastSearchRegion = locale.region
+        return AppResult.Success(hits)
+    }
+
+    override suspend fun getContributor(
+        key: String,
+        locale: MetadataLocale,
+        refresh: Boolean,
+    ): AppResult<ContributorMeta?> = AppResult.Success(null)
 }
 
 private class ComposeStubAudibleApi(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
@@ -142,6 +142,29 @@ class MetadataLookupServiceImplTest :
             }
         }
 
+        test("searchContributorMetadata returns hits ranked closest-name-first") {
+            withSqlDatabase {
+                val source =
+                    FakeContributorSource(
+                        hits =
+                            listOf(
+                                ContributorHitMeta(key = "B1", name = "Timothy Curry Jr."),
+                                ContributorHitMeta(key = "B2", name = "Tim Curry"),
+                            ),
+                    )
+                val service = makeService(audible = StubAudibleApi(), dbs = this, extraProviders = listOf(source))
+
+                runTest {
+                    val result = service.searchContributorMetadata("Tim Curry", null)
+                    result
+                        .shouldBeInstanceOf<AppResult.Success<List<MetadataContributorHit>>>()
+                        .data
+                        .first()
+                        .asin shouldBe "B2"
+                }
+            }
+        }
+
         test("getContributorMetadata maps a ContributorMeta profile to the wire profile") {
             withSqlDatabase {
                 val source =

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/provider/AudnexusProviderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/provider/AudnexusProviderTest.kt
@@ -236,6 +236,37 @@ class AudnexusProviderTest :
             }
         }
 
+        test("searchContributors dedupes repeated ASINs from upstream, keeping first-seen order") {
+            // Audnexus's /authors index returns one record per catalogued region/edition, so a
+            // common name comes back with the same author ASIN several times over. Shipping that
+            // straight to the client crashed a keyed LazyColumn ("Key B0F5XZ1BF2 was already
+            // used") and would have listed the same person repeatedly even without the crash.
+            // Two distinct people who share a name must both survive — dedupe is by ASIN, never
+            // by name.
+            withSqlDatabase {
+                val api =
+                    CountingAudnexusApi(
+                        authors =
+                            listOf(
+                                AudnexusAuthor(asin = "A1", name = "Tim Curry"),
+                                AudnexusAuthor(asin = "A2", name = "Tim Curry"),
+                                AudnexusAuthor(asin = "A1", name = "Tim Curry"),
+                                AudnexusAuthor(asin = "A1", name = "Tim Curry"),
+                                AudnexusAuthor(asin = "A2", name = "Tim Curry"),
+                            ),
+                    )
+                val provider = provider(api, sql)
+                runTest {
+                    val hits =
+                        provider
+                            .searchContributors("tim curry", US)
+                            .shouldBeInstanceOf<AppResult.Success<List<*>>>()
+                            .data
+                    hits.map { (it as ContributorHitMeta).key } shouldBe listOf("A1", "A2")
+                }
+            }
+        }
+
         test("id is AUDNEXUS") {
             withSqlDatabase {
                 provider(CountingAudnexusApi(), sql).id shouldBe MetadataProviderId.AUDNEXUS

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/spi/ContributorHitRankerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/spi/ContributorHitRankerTest.kt
@@ -1,0 +1,51 @@
+package com.calypsan.listenup.server.metadata.spi
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ContributorHitRankerTest :
+    FunSpec({
+
+        test("exact name match ranks above decorated and extended variants") {
+            val hits =
+                listOf(
+                    ContributorHitMeta(key = "B1", name = "Timothy Curry Jr."),
+                    ContributorHitMeta(key = "B2", name = "Tim Curry"),
+                    ContributorHitMeta(key = "B3", name = "Tim Curry - introductions"),
+                )
+
+            val ranked = ContributorHitRanker.rank("Tim Curry", hits)
+
+            ranked.first().key shouldBe "B2"
+        }
+
+        test("token order does not matter — sort-name form matches the natural form") {
+            val hits =
+                listOf(
+                    ContributorHitMeta(key = "B1", name = "Stephen Fry"),
+                    ContributorHitMeta(key = "B2", name = "King, Stephen"),
+                )
+
+            ContributorHitRanker.rank("Stephen King", hits).first().key shouldBe "B2"
+        }
+
+        test("equal scores keep the catalog's original order (stable sort)") {
+            val hits =
+                listOf(
+                    ContributorHitMeta(key = "B1", name = "Tim Curry"),
+                    ContributorHitMeta(key = "B2", name = "Tim Curry"),
+                )
+
+            ContributorHitRanker.rank("Tim Curry", hits).map { it.key } shouldBe listOf("B1", "B2")
+        }
+
+        test("blank query preserves the input order") {
+            val hits =
+                listOf(
+                    ContributorHitMeta(key = "B1", name = "Alpha"),
+                    ContributorHitMeta(key = "B2", name = "Beta"),
+                )
+
+            ContributorHitRanker.rank("   ", hits) shouldBe hits
+        }
+    })


### PR DESCRIPTION
**Stacked on #1181** (`fix/audnexus-duplicate-contributors`) — review/merge that first; this branch contains its two commits.

Phase 1 of the contributor-metadata rebuild. Server and contract only: the client still sends no region, so nothing here is user-visible until Phase 2. It is green and safe to land on its own because the new RPC parameter defaults to `null`.

## Why this feature never worked

The contributor search RPC was a **stub returning `emptyList()`** from 2026-05-23 (`c24ada039`, when the client flow shipped) until 2026-07-14 (`cfa48d377`, #1115). Every search on both platforms returned "No matches found" for ~7 weeks. When the stub became real, the bugs behind it surfaced at once.

## What changes

**Region is threaded through search** — `searchContributorMetadata(query, region = null)`, mirroring `searchBooks`, plus the REST mirror. Previously search hardcoded the default region while the profile fetch used the user's selected one.

This is not cosmetic. Verified against the live Audnexus API: profile *content* is region-localized. Brandon Sanderson `B001IGFHW6` returns a 3023-char English bio in `us`/`uk`, a 356-char German bio in `de`, and an **empty description in `fr`** — all at HTTP 200. Search and preview must agree on one catalog or the preview silently renders nothing.

**Apply is no longer destructive.** `ContributorMetadataApplier` copied `description` and `imagePath` straight onto the existing row; both are null for a blank profile or a failed image download, so applying a match **erased the contributor's existing biography and photo**. Now blank/null coalesces to the existing value, and an all-blank profile is an honest `NotFound` miss rather than something appliable. This matches Audiobookshelf, which guards every write the same way (`if (authorData.description && ...)`).

**Hits are ranked closest-name-first.** Audnexus search is fuzzy — "Brandon Sanderson" returns 25 hits, nine of them the identical row, plus noise like "Andrea Golden" for "Andreas Eschbach". Token-set Sørensen–Dice, stable sort, mirroring `MatchScorer`. We keep a picker rather than ABS's auto-pick because two genuinely different people can share a name (there are two distinct "Tim Curry" ASINs).

## Verification

Every behavioural change has a test **observed failing first**. The applier's RED is the one that matters:

```
a blank-bio profile keeps the existing biography FAILED
    Expected "Existing bio." but actual was null
a failed photo download keeps the existing image path FAILED
    Expected "contributors/existing.jpg" but actual was null
an all-blank profile is an honest miss FAILED
    Success(data=kotlin.Unit) ... but expected AppResult.Failure
```

That is a real biography and photo being erased. Six tests now pin it, including whitespace-only inputs (so a future simplification of `isNotBlank()` to a null check reopens nothing silently) and the positive apply path (so a regression that never applies anything can't pass).

Full CI-parity gate: `BUILD SUCCESSFUL in 27m 45s` — spotless, detekt, Konsist, `:server:jvmTest`, `:contract:jvmTest`, both `androidHostTest` suites.

## Not in this PR

The client half — sealed UI state, region carried across the Android nav boundary, the iOS observer, and deleting the per-field checkboxes (which never crossed the wire; ABS has no such UI either). Those break Compose and iOS at compile time together, so they ship as one atomic follow-up.