### PR TITLE
🐛 fix(iosApp): format Release confirm title/button with selected count

### DIFF
--- a/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxView.swift
+++ b/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxView.swift
@@ -69,10 +69,13 @@ struct AdminInboxView: View {
                     }
                 )
                 .alert(
-                    String(localized: "admin.inbox_release_count"),
+                    String(format: String(localized: "admin.inbox_release_count"), ready.selectedCount),
                     isPresented: $showingReleaseConfirm,
                     actions: {
-                        Button(String(localized: "admin.inbox_release_count"), role: .destructive) {
+                        Button(
+                            String(format: String(localized: "admin.inbox_release_count"), ready.selectedCount),
+                            role: .destructive
+                        ) {
                             observer.releaseSelected()
                         }
                         Button(String(localized: "common.cancel"), role: .cancel) {}


### PR DESCRIPTION
The admin-inbox Release confirm alert rendered the raw localization token — `admin.inbox_release_count` is `"Release %1$d"`, and the alert title + destructive button called `String(localized:)` without the `String(format:)` wrapper, so users saw the literal `%1$d` (reported as "%20-like distorted text"). Wraps both call sites with the selected count, matching the three existing correct usages in the same file.