### PR TITLE
🐛 fix(shared,sharedUI): consolidate sign-out onto LogoutUseCase, owner-scope outbox dispatch

### DIFF
--- a/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
+++ b/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
@@ -22,11 +22,10 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.design.LocalDeviceContext
 import com.calypsan.listenup.client.design.components.LocalSnackbarHostState
 import com.calypsan.listenup.client.device.DeviceContext
-import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.usecase.auth.LogoutUseCase
 import com.calypsan.listenup.client.features.bookdetail.BookDetailScreen
 import com.calypsan.listenup.client.features.bookedit.BookEditScreen
 import com.calypsan.listenup.client.features.admin.AdminScreen
@@ -208,8 +207,7 @@ fun DesktopApp() {
 @Composable
 private fun DesktopAuthenticatedNavigation() {
     val scope = rememberCoroutineScope()
-    val authSession: AuthSession = koinInject()
-    val libraryResetHelper: LibraryResetHelper = koinInject()
+    val logoutUseCase: LogoutUseCase = koinInject()
     val nowPlayingViewModel: NowPlayingViewModel = koinInject()
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -254,8 +252,7 @@ private fun DesktopAuthenticatedNavigation() {
                         onSignOut = {
                             scope.launch {
                                 logger.info { "Signing out..." }
-                                libraryResetHelper.clearLibraryData()
-                                authSession.clearAuthTokens()
+                                logoutUseCase()
                             }
                         },
                         onUserProfileClick = { userId ->

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
@@ -38,6 +38,13 @@ internal interface PendingOperationV2Dao {
      * bump `enqueuedAt` so a second op for an entity that already has one queued is never
      * enqueued at the same instant — but this ordering holds even if that invariant is
      * ever violated.
+     *
+     * [ownerUserId], when non-null, is the structural guard against draining an orphaned op
+     * under the wrong user's session: an op enqueued by a just-signed-out user's in-flight
+     * write (a race the enqueue-time owner stamp alone can't close — see `OfflineEditor.edit`)
+     * simply never matches a different active owner, no matter when it lands in the table.
+     * `null` means unscoped (pre-existing behavior; every production caller passes the active
+     * owner via [PendingOperationQueue]).
      */
     @Query(
         """
@@ -49,16 +56,32 @@ internal interface PendingOperationV2Dao {
               ) AS rn
                 FROM pending_operation
                WHERE failureCount <= :maxAttempts
+                 AND (:ownerUserId IS NULL OR ownerUserId = :ownerUserId)
           )
          WHERE rn = 1
          ORDER BY enqueuedAt ASC, clientOpId ASC
         """,
     )
-    suspend fun nextDispatchable(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): List<PendingOperationV2Entity>
+    suspend fun nextDispatchable(
+        ownerUserId: String? = null,
+        maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS,
+    ): List<PendingOperationV2Entity>
 
-    /** Count of ops still within retry budget — i.e. rows a future drain wave could dispatch. */
-    @Query("SELECT COUNT(*) FROM pending_operation WHERE failureCount <= :maxAttempts")
-    suspend fun countDispatchable(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Int
+    /**
+     * Count of ops still within retry budget — i.e. rows a future drain wave could dispatch.
+     * See [nextDispatchable] for the [ownerUserId] scoping contract.
+     */
+    @Query(
+        """
+        SELECT COUNT(*) FROM pending_operation
+         WHERE failureCount <= :maxAttempts
+           AND (:ownerUserId IS NULL OR ownerUserId = :ownerUserId)
+        """,
+    )
+    suspend fun countDispatchable(
+        ownerUserId: String? = null,
+        maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS,
+    ): Int
 
     /**
      * Latest `enqueuedAt` among all ops (dispatchable or dead-lettered) for (domainName, entityId),
@@ -77,7 +100,8 @@ internal interface PendingOperationV2Dao {
      * local edit is skipped so the optimistic state survives until the edit's own echo lands.
      *
      * Dead letters (`failureCount > maxAttempts`) are EXCLUDED, so a terminally-failed op stops
-     * counting as in-flight — the shield lifts and the entity converges to server truth.
+     * counting as in-flight — the shield lifts and the entity converges to server truth. See
+     * [nextDispatchable] for the [ownerUserId] scoping contract.
      */
     @Query(
         """
@@ -86,22 +110,48 @@ internal interface PendingOperationV2Dao {
              WHERE domainName = :domainName
                AND entityId = :entityId
                AND failureCount <= :maxAttempts
+               AND (:ownerUserId IS NULL OR ownerUserId = :ownerUserId)
         )
         """,
     )
     suspend fun hasQueuedOp(
         domainName: String,
         entityId: String,
+        ownerUserId: String? = null,
         maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS,
     ): Boolean
 
-    /** Live queue depth: ops still eligible for dispatch. Dead letters are counted separately. */
-    @Query("SELECT COUNT(*) FROM pending_operation WHERE failureCount <= :maxAttempts")
-    fun observeQueueDepth(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<Int>
+    /**
+     * Live queue depth: ops still eligible for dispatch. Dead letters are counted separately.
+     * See [nextDispatchable] for the [ownerUserId] scoping contract.
+     */
+    @Query(
+        """
+        SELECT COUNT(*) FROM pending_operation
+         WHERE failureCount <= :maxAttempts
+           AND (:ownerUserId IS NULL OR ownerUserId = :ownerUserId)
+        """,
+    )
+    fun observeQueueDepth(
+        ownerUserId: String? = null,
+        maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS,
+    ): Flow<Int>
 
-    /** Terminal ops that exhausted their retry budget — the dead-letter count. */
-    @Query("SELECT COUNT(*) FROM pending_operation WHERE failureCount > :maxAttempts")
-    fun observeDeadLetterCount(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<Int>
+    /**
+     * Terminal ops that exhausted their retry budget — the dead-letter count.
+     * See [nextDispatchable] for the [ownerUserId] scoping contract.
+     */
+    @Query(
+        """
+        SELECT COUNT(*) FROM pending_operation
+         WHERE failureCount > :maxAttempts
+           AND (:ownerUserId IS NULL OR ownerUserId = :ownerUserId)
+        """,
+    )
+    fun observeDeadLetterCount(
+        ownerUserId: String? = null,
+        maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS,
+    ): Flow<Int>
 
     /**
      * One-shot dead-letter count — the same predicate as [observeDeadLetterCount] read directly.
@@ -114,29 +164,39 @@ internal interface PendingOperationV2Dao {
 
     /**
      * Live snapshots of ops still within retry budget, oldest first. Backs the
-     * sync indicator's visible pending list.
+     * sync indicator's visible pending list. See [nextDispatchable] for the
+     * [ownerUserId] scoping contract.
      */
     @Query(
         """
         SELECT * FROM pending_operation
          WHERE failureCount <= :maxAttempts
+           AND (:ownerUserId IS NULL OR ownerUserId = :ownerUserId)
          ORDER BY enqueuedAt ASC
         """,
     )
-    fun observePending(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<List<PendingOperationV2Entity>>
+    fun observePending(
+        ownerUserId: String? = null,
+        maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS,
+    ): Flow<List<PendingOperationV2Entity>>
 
     /**
      * Live snapshots of terminally failed ops (past [maxAttempts]), oldest first.
-     * Backs the sync indicator's failed-operations list.
+     * Backs the sync indicator's failed-operations list. See [nextDispatchable] for
+     * the [ownerUserId] scoping contract.
      */
     @Query(
         """
         SELECT * FROM pending_operation
          WHERE failureCount > :maxAttempts
+           AND (:ownerUserId IS NULL OR ownerUserId = :ownerUserId)
          ORDER BY enqueuedAt ASC
         """,
     )
-    fun observeFailed(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<List<PendingOperationV2Entity>>
+    fun observeFailed(
+        ownerUserId: String? = null,
+        maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS,
+    ): Flow<List<PendingOperationV2Entity>>
 
     /** Re-arm an op for dispatch: zero its retry budget and clear the stored error. */
     @Query("UPDATE pending_operation SET failureCount = 0, lastError = NULL WHERE clientOpId = :clientOpId")

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -14,11 +14,13 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -177,6 +179,10 @@ private fun classifyFailure(
  *   lost-response) leaves `failureCount` untouched and stays dispatchable so an
  *   outage never silently exhausts the budget; a **non-retryable** failure leaps
  *   past [MAX_RETRYABLE_ATTEMPTS] so it never retries — becoming a **dead letter**.
+ * - [drain] (and every observer above) is scoped to the active owner set by
+ *   [clearForUserChange]: an orphaned op — one a just-signed-out user's in-flight
+ *   write commits AFTER the sweep already ran — can never dispatch under a
+ *   different signed-in user's session, no matter when it lands in the table.
  *
  * Terminal ops are dead letters: excluded from [observeQueueDepth] (the live,
  * dispatchable count), surfaced separately via [observeDeadLetterCount] and
@@ -209,6 +215,17 @@ internal class PendingOperationQueue(
     // increments, which the engine treats as "an op was enqueued since you
     // started listening."
     private val enqueueCounter = MutableStateFlow(0L)
+
+    // The signed-in user [drain] is allowed to dispatch for, set by [clearForUserChange] — the
+    // same call the engine already makes with the current user at start(). Kept as in-memory
+    // state (not re-derived per call) so an orphaned op — one an in-flight `OfflineEditor.edit()`
+    // from the just-signed-out user commits AFTER the sweep already ran (the enqueue-time owner
+    // read races sign-out; see `OfflineEditor.edit`) — can never drain under the new user's
+    // session, regardless of when it lands in the table. `null` means no owner has been
+    // established yet (before the first [clearForUserChange]); dispatch proceeds unscoped, which
+    // matches every pre-existing caller (tests, and any drain that could theoretically race ahead
+    // of the engine's first `start()`).
+    private val currentOwnerFlow = MutableStateFlow<String?>(null)
 
     /**
      * Monotonically increasing counter that ticks each time an op is enqueued.
@@ -325,7 +342,7 @@ internal class PendingOperationQueue(
     suspend fun hasQueuedOpFor(
         domainName: String,
         entityId: String,
-    ): Boolean = dao.hasQueuedOp(domainName, entityId)
+    ): Boolean = dao.hasQueuedOp(domainName, entityId, ownerUserId = currentOwnerFlow.value)
 
     /**
      * Dispatch the earliest-enqueued op per (domain, entityId) group currently
@@ -360,8 +377,9 @@ internal class PendingOperationQueue(
      */
     suspend fun drain(): DrainOutcome =
         drainMutex.withLock {
+            val owner = currentOwnerFlow.value
             dao.gcDeadLetters(cutoffMillis = nowMillis() - DEAD_LETTER_RETENTION_MILLIS)
-            val ops = dao.nextDispatchable()
+            val ops = dao.nextDispatchable(ownerUserId = owner)
             var sent = 0
             var retryableFailures = 0
             var parkedFailures = 0
@@ -464,24 +482,48 @@ internal class PendingOperationQueue(
                 retryableFailures = retryableFailures,
                 parkedFailures = parkedFailures,
                 terminalFailures = terminalFailures,
-                remainingDispatchable = dao.countDispatchable(),
+                remainingDispatchable = dao.countDispatchable(ownerUserId = owner),
                 sentEntities = sentEntities,
             )
         }
 
-    /** Live count of ops still within retry budget. Engine forwards this to `SyncEngineState`. */
-    fun observeQueueDepth(): Flow<Int> = dao.observeQueueDepth()
+    /**
+     * Live count of ops still within retry budget. Engine forwards this to `SyncEngineState`.
+     * `flatMapLatest` over [currentOwnerFlow] so a long-lived collector (the engine's
+     * observer job survives user switches — see `SyncEngine.start`'s KDoc) re-scopes to the
+     * new owner instead of staying pinned to whichever user was active when it first
+     * subscribed.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observeQueueDepth(): Flow<Int> = currentOwnerFlow.flatMapLatest { dao.observeQueueDepth(ownerUserId = it) }
 
-    /** Live count of dead letters (ops past [MAX_RETRYABLE_ATTEMPTS]). Engine forwards to `SyncEngineState`. */
-    fun observeDeadLetterCount(): Flow<Int> = dao.observeDeadLetterCount()
+    /**
+     * Live count of dead letters (ops past [MAX_RETRYABLE_ATTEMPTS]). Engine forwards to
+     * `SyncEngineState`. See [observeQueueDepth] for the owner re-scoping rationale.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observeDeadLetterCount(): Flow<Int> =
+        currentOwnerFlow.flatMapLatest { dao.observeDeadLetterCount(ownerUserId = it) }
 
-    /** Live snapshots of ops still within retry budget, oldest first. */
+    /**
+     * Live snapshots of ops still within retry budget, oldest first. See [observeQueueDepth]
+     * for the owner re-scoping rationale.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun observePendingOperations(): Flow<List<PendingOperation>> =
-        dao.observePending().map { rows -> rows.map { it.toDomain() } }
+        currentOwnerFlow
+            .flatMapLatest { dao.observePending(ownerUserId = it) }
+            .map { rows -> rows.map { it.toDomain() } }
 
-    /** Live snapshots of terminally failed ops (past [MAX_RETRYABLE_ATTEMPTS]), oldest first. */
+    /**
+     * Live snapshots of terminally failed ops (past [MAX_RETRYABLE_ATTEMPTS]), oldest first.
+     * See [observeQueueDepth] for the owner re-scoping rationale.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun observeFailedOperations(): Flow<List<PendingOperation>> =
-        dao.observeFailed().map { rows -> rows.map { it.toDomain() } }
+        currentOwnerFlow
+            .flatMapLatest { dao.observeFailed(ownerUserId = it) }
+            .map { rows -> rows.map { it.toDomain() } }
 
     /**
      * Re-arm a terminally failed op and tick the enqueue signal so the engine
@@ -507,12 +549,14 @@ internal class PendingOperationQueue(
     }
 
     /**
-     * Wipe ops not owned by [currentUserId]. Called by `SyncEngine.start` when
-     * the signed-in user differs from the one whose ops are queued. Same-user
-     * sign-out is a pause, not a clear.
+     * Wipe ops not owned by [currentUserId], then adopt them as [currentOwnerFlow] — the same
+     * call already receives the exact value dispatch should scope to, at the exact point the
+     * engine learns it (`SyncEngine.start`, before catch-up begins). Called when the signed-in
+     * user differs from the one whose ops are queued. Same-user sign-out is a pause, not a clear.
      */
     suspend fun clearForUserChange(currentUserId: String) {
         dao.deleteAllExcept(currentUserId)
+        currentOwnerFlow.value = currentUserId
     }
 
     private fun PendingOperationV2Entity.toDomain() =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/AuthModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/AuthModule.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.client.data.repository.RegistrationStatusStreamImpl
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.InviteRepository
+import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.domain.repository.RegistrationPolicyStream
 import com.calypsan.listenup.client.domain.repository.RegistrationStatusStream
 import com.calypsan.listenup.client.domain.usecase.auth.LoginUseCase
@@ -151,6 +152,7 @@ internal val clientAuthModule: Module
                     userRepository = get(),
                     syncRepository = get(),
                     rpcCacheInvalidator = get(),
+                    libraryResetHelper = get(),
                     playbackStateProvider = getOrNull<PlaybackManager>(),
                 )
             }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/auth/LogoutUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/auth/LogoutUseCase.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.result.onFailure
 import com.calypsan.listenup.client.data.remote.RpcCacheInvalidator
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.playback.PlaybackStateProvider
@@ -13,7 +14,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val logger = KotlinLogging.logger {}
 
 /**
- * Logout flow.
+ * Logout flow — the single sign-out choke point every call site (shell nav, desktop nav,
+ * Settings) routes through, so no path can partially clean up and leave stale state behind.
  *
  * Server-side session revocation is best-effort — if it fails (network
  * down, expired token), local state still clears. Local-only logout is
@@ -29,6 +31,7 @@ open class LogoutUseCase(
     private val userRepository: UserRepository,
     private val syncRepository: SyncRepository,
     private val rpcCacheInvalidator: RpcCacheInvalidator,
+    private val libraryResetHelper: LibraryResetHelper,
     private val playbackStateProvider: PlaybackStateProvider? = null,
 ) {
     open suspend operator fun invoke(): AppResult<Unit> {
@@ -52,16 +55,26 @@ open class LogoutUseCase(
     }
 
     /**
-     * Stop real-time sync first — otherwise the engine keeps reconnecting against
-     * the now-unauthenticated endpoint — then clear local auth/user/playback state.
+     * Stop real-time sync first — otherwise the engine keeps reconnecting against the
+     * now-unauthenticated endpoint (and could apply an in-flight SSE frame or drain an
+     * outbox op after the rest of this sequence has already torn down) — then clear
+     * every other piece of local state.
      */
     private suspend fun clearLocalState() {
+        // 1. Stop the engine first: no drains or SSE applies may run while the rest of
+        // this sequence tears down underneath them.
         syncRepository.disconnect()
-        // Drop every cached principal-bound RPC proxy / HttpClient so a re-login as a
+        // 2. Drop every cached principal-bound RPC proxy / HttpClient so a re-login as a
         // different user in the same process can't reuse the previous session's socket.
         rpcCacheInvalidator.invalidateAll()
         playbackStateProvider?.clearPlayback()
+        // 3. Clear library data, including any still-queued pending operations — a
+        // signed-out user's unsent edits are deliberately discarded, not carried into
+        // the next login (same or different user starts with a clean slate).
+        libraryResetHelper.clearLibraryData(discardPendingOperations = true)
+        // 4. Tokens die after the data they'd otherwise let a stray request re-fetch.
         authSession.clearAuthTokens()
+        // 5. Finally drop the cached user rows themselves.
         userRepository.clearUsers()
     }
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
@@ -73,13 +73,20 @@ private class FakePendingOperationV2Dao : PendingOperationV2Dao {
         inserted.replaceAll { if (it.clientOpId == op.clientOpId) op else it }
     }
 
-    override suspend fun nextDispatchable(maxAttempts: Int): List<PendingOperationV2Entity> = inserted.toList()
+    override suspend fun nextDispatchable(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ): List<PendingOperationV2Entity> = inserted.toList()
 
-    override suspend fun countDispatchable(maxAttempts: Int): Int = inserted.count { it.failureCount <= maxAttempts }
+    override suspend fun countDispatchable(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ): Int = inserted.count { it.failureCount <= maxAttempts }
 
     override suspend fun hasQueuedOp(
         domainName: String,
         entityId: String,
+        ownerUserId: String?,
         maxAttempts: Int,
     ): Boolean =
         inserted.any {
@@ -97,17 +104,29 @@ private class FakePendingOperationV2Dao : PendingOperationV2Dao {
         }
     }
 
-    override fun observePending(maxAttempts: Int): Flow<List<PendingOperationV2Entity>> = flowOf(inserted.toList())
+    override fun observePending(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ): Flow<List<PendingOperationV2Entity>> = flowOf(inserted.toList())
 
-    override fun observeFailed(maxAttempts: Int): Flow<List<PendingOperationV2Entity>> = flowOf(emptyList())
+    override fun observeFailed(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ): Flow<List<PendingOperationV2Entity>> = flowOf(emptyList())
 
     override suspend fun resetFailureCount(clientOpId: String) {
         inserted.replaceAll { if (it.clientOpId == clientOpId) it.copy(failureCount = 0, lastError = null) else it }
     }
 
-    override fun observeQueueDepth(maxAttempts: Int): Flow<Int> = flowOf(inserted.count { it.failureCount <= maxAttempts })
+    override fun observeQueueDepth(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ): Flow<Int> = flowOf(inserted.count { it.failureCount <= maxAttempts })
 
-    override fun observeDeadLetterCount(maxAttempts: Int): Flow<Int> = flowOf(0)
+    override fun observeDeadLetterCount(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ): Flow<Int> = flowOf(0)
 
     override suspend fun countDeadLetters(maxAttempts: Int): Int = 0
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/AuthModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/AuthModuleVerifyTest.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.core.SecureStorage
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.device.DeviceInfoProvider
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
@@ -28,6 +29,8 @@ import org.koin.test.verify.verify
  *  - [PlaybackManager] — owned by the platform playback module
  *    (LogoutUseCase needs it as a `PlaybackStateProvider` to halt playback
  *    on logout).
+ *  - [LibraryResetHelper] — owned by `libraryModule` (LogoutUseCase clears
+ *    library data, including pending operations, on sign-out).
  *  - [DeviceInfoProvider] — owned by the per-platform playback/platform module
  *    (login/register/setup/claim send the device's structured metadata).
  *  - [kotlinx.coroutines.CoroutineScope] — the `appScope` owned by `appCoreModule`;
@@ -49,6 +52,7 @@ class AuthModuleVerifyTest :
                         PlaybackManager::class,
                         DeviceInfoProvider::class,
                         SyncRepository::class,
+                        LibraryResetHelper::class,
                         com.calypsan.listenup.client.data.remote.RpcCacheInvalidator::class,
                         kotlinx.coroutines.CoroutineScope::class,
                     ),

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/auth/LogoutUseCaseTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/auth/LogoutUseCaseTest.kt
@@ -5,11 +5,13 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.remote.RpcCacheInvalidator
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.order
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -21,6 +23,7 @@ private class LogoutFixture {
     val userRepository: UserRepository = mock()
     val syncRepository: SyncRepository = mock()
     val rpcCacheInvalidator: RpcCacheInvalidator = mock()
+    val libraryResetHelper: LibraryResetHelper = mock()
 
     fun build(): LogoutUseCase =
         LogoutUseCase(
@@ -29,6 +32,7 @@ private class LogoutFixture {
             userRepository = userRepository,
             syncRepository = syncRepository,
             rpcCacheInvalidator = rpcCacheInvalidator,
+            libraryResetHelper = libraryResetHelper,
         )
 }
 
@@ -40,6 +44,7 @@ private fun createFixture(): LogoutFixture {
     everySuspend { fixture.authRepository.logout() } returns AppResult.Success(Unit)
     everySuspend { fixture.syncRepository.disconnect() } returns Unit
     everySuspend { fixture.rpcCacheInvalidator.invalidateAll() } returns Unit
+    everySuspend { fixture.libraryResetHelper.clearLibraryData(discardPendingOperations = true) } returns Unit
     return fixture
 }
 
@@ -136,6 +141,47 @@ class LogoutUseCaseTest :
                 useCase.logoutLocally()
 
                 verifySuspend { fixture.syncRepository.disconnect() }
+            }
+        }
+
+        test("logout clears library data including pending operations, discarding unsent edits") {
+            runTest {
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                useCase()
+
+                verifySuspend { fixture.libraryResetHelper.clearLibraryData(discardPendingOperations = true) }
+            }
+        }
+
+        test("logout stops the sync engine before clearing library data") {
+            runTest {
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                useCase()
+
+                // The engine must be fully stopped before the data it could still be touching
+                // (an in-flight SSE apply, an outbox drain) gets wiped out from under it.
+                verifySuspend(order) {
+                    fixture.syncRepository.disconnect()
+                    fixture.libraryResetHelper.clearLibraryData(discardPendingOperations = true)
+                }
+            }
+        }
+
+        test("logout clears library data before clearing auth tokens") {
+            runTest {
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                useCase()
+
+                verifySuspend(order) {
+                    fixture.libraryResetHelper.clearLibraryData(discardPendingOperations = true)
+                    fixture.authSession.clearAuthTokens()
+                }
             }
         }
     })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2DaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2DaoTest.kt
@@ -110,6 +110,32 @@ class PendingOperationV2DaoTest :
             }
         }
 
+        test("nextDispatchable with a non-null ownerUserId excludes ops owned by a different user") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val dao = db.pendingOperationV2Dao()
+                val baseTime = 100L
+                dao.insert(row("mine", "tags", "t1", baseTime, owner = "u1"))
+                dao.insert(row("theirs", "tags", "t2", baseTime, owner = "u2"))
+                val next = dao.nextDispatchable(ownerUserId = "u1")
+                next.map { it.clientOpId } shouldContainExactly listOf("mine")
+                db.close()
+            }
+        }
+
+        test("nextDispatchable with a null ownerUserId is unscoped") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val dao = db.pendingOperationV2Dao()
+                val baseTime = 100L
+                dao.insert(row("mine", "tags", "t1", baseTime, owner = "u1"))
+                dao.insert(row("theirs", "tags", "t2", baseTime, owner = "u2"))
+                val next = dao.nextDispatchable(ownerUserId = null)
+                next.map { it.clientOpId } shouldContainExactlyInAnyOrder listOf("mine", "theirs")
+                db.close()
+            }
+        }
+
         test("deleteAllExcept removes ops not owned by keepUserId") {
             runTest {
                 val db = createInMemoryTestDatabase()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -400,6 +400,83 @@ class PendingOperationQueueTest :
             }
         }
 
+        test("drain does not dispatch an op enqueued for a different owner than the active user") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val sent = mutableListOf<String>()
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender =
+                            PendingOperationSender { op ->
+                                sent += op.clientOpId
+                                AppResult.Success(Unit)
+                            },
+                        nowMillis = { 1_000L },
+                    )
+                // "B" is the active user (e.g. just signed in); the table is empty so the sweep
+                // has nothing to remove.
+                queue.clearForUserChange("B")
+                // Simulate the orphan race: a just-signed-out user "A"'s in-flight
+                // OfflineEditor.edit() commits its enqueue AFTER the sweep already ran.
+                val orphan = queue.enqueue(upsertOnlyChannel, "t1", OpKind.Upsert, "{}", ownerUserId = "A")
+
+                val outcome = queue.drain()
+
+                outcome.sent shouldBe 0
+                sent shouldBe emptyList()
+                db.pendingOperationV2Dao().get(orphan) shouldNotBe null
+                db.close()
+            }
+        }
+
+        test("a subsequent clearForUserChange sweeps an orphaned op the dispatch guard left behind") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                        nowMillis = { 1_000L },
+                    )
+                queue.clearForUserChange("B")
+                val orphan = queue.enqueue(upsertOnlyChannel, "t1", OpKind.Upsert, "{}", ownerUserId = "A")
+                queue.drain() // blocked by the owner guard, not dispatched
+
+                // The next sweep cycle for "B" (e.g. a reconnect) is the real cleanup —
+                // the dispatch guard only prevented the wrong-session drain in between.
+                queue.clearForUserChange("B")
+
+                db.pendingOperationV2Dao().get(orphan) shouldBe null
+                db.close()
+            }
+        }
+
+        test("drain dispatches an op owned by the active user") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val sent = mutableListOf<String>()
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender =
+                            PendingOperationSender { op ->
+                                sent += op.clientOpId
+                                AppResult.Success(Unit)
+                            },
+                        nowMillis = { 1_000L },
+                    )
+                queue.clearForUserChange("A")
+                val opId = queue.enqueue(upsertOnlyChannel, "t1", OpKind.Upsert, "{}", ownerUserId = "A")
+
+                val outcome = queue.drain()
+
+                outcome.sent shouldBe 1
+                sent shouldContainExactly listOf(opId)
+                db.close()
+            }
+        }
+
         test("concurrent drain() calls never dispatch the same op twice") {
             runBlocking {
                 val db = createInMemoryTestDatabase()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -597,18 +597,25 @@ private class CountingDao(
 
     override suspend fun update(op: com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity) = delegate.update(op)
 
-    override suspend fun nextDispatchable(maxAttempts: Int): List<com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity> {
+    override suspend fun nextDispatchable(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ): List<com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity> {
         dispatchCalls.incrementAndGet()
-        return delegate.nextDispatchable(maxAttempts)
+        return delegate.nextDispatchable(ownerUserId, maxAttempts)
     }
 
-    override suspend fun countDispatchable(maxAttempts: Int) = delegate.countDispatchable(maxAttempts)
+    override suspend fun countDispatchable(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ) = delegate.countDispatchable(ownerUserId, maxAttempts)
 
     override suspend fun hasQueuedOp(
         domainName: String,
         entityId: String,
+        ownerUserId: String?,
         maxAttempts: Int,
-    ) = delegate.hasQueuedOp(domainName, entityId, maxAttempts)
+    ) = delegate.hasQueuedOp(domainName, entityId, ownerUserId, maxAttempts)
 
     override suspend fun deleteQueuedOps(
         domainName: String,
@@ -617,15 +624,27 @@ private class CountingDao(
         maxAttempts: Int,
     ) = delegate.deleteQueuedOps(domainName, entityId, opType, maxAttempts)
 
-    override fun observePending(maxAttempts: Int) = delegate.observePending(maxAttempts)
+    override fun observePending(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ) = delegate.observePending(ownerUserId, maxAttempts)
 
-    override fun observeFailed(maxAttempts: Int) = delegate.observeFailed(maxAttempts)
+    override fun observeFailed(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ) = delegate.observeFailed(ownerUserId, maxAttempts)
 
     override suspend fun resetFailureCount(clientOpId: String) = delegate.resetFailureCount(clientOpId)
 
-    override fun observeQueueDepth(maxAttempts: Int) = delegate.observeQueueDepth(maxAttempts)
+    override fun observeQueueDepth(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ) = delegate.observeQueueDepth(ownerUserId, maxAttempts)
 
-    override fun observeDeadLetterCount(maxAttempts: Int) = delegate.observeDeadLetterCount(maxAttempts)
+    override fun observeDeadLetterCount(
+        ownerUserId: String?,
+        maxAttempts: Int,
+    ) = delegate.observeDeadLetterCount(ownerUserId, maxAttempts)
 
     override suspend fun countDeadLetters(maxAttempts: Int) = delegate.countDeadLetters(maxAttempts)
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -59,8 +59,8 @@ import com.calypsan.listenup.client.share.ShareTarget
 import com.calypsan.listenup.client.share.ShareTargetResolver
 import com.calypsan.listenup.client.data.repository.ShortcutAction
 import com.calypsan.listenup.client.data.repository.ShortcutActionManager
-import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.domain.repository.SyncRepository
+import com.calypsan.listenup.client.domain.usecase.auth.LogoutUseCase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import com.calypsan.listenup.client.design.components.FullScreenLoadingIndicator
 import com.calypsan.listenup.client.design.components.ListenUpButton
@@ -544,7 +544,7 @@ private suspend fun handleShortcutAction(
 @Composable
 private fun AuthenticatedNavigation(
     authSession: AuthSession,
-    libraryResetHelper: LibraryResetHelper = koinInject(),
+    logoutUseCase: LogoutUseCase = koinInject(),
     syncRepository: SyncRepository = koinInject(),
     shortcutActionManager: ShortcutActionManager = koinInject(),
     homeRepository: HomeRepository = koinInject(),
@@ -608,13 +608,13 @@ private fun AuthenticatedNavigation(
     // App-wide snackbar state - provided to all screens via CompositionLocal
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // Hoisted sign-out action shared by shell and settings entries.
-    // Clear library data before signing out so the next login (same or different user)
-    // always starts with fresh data.
+    // Hoisted sign-out action shared by shell and settings entries. Delegates to LogoutUseCase —
+    // the single sign-out choke point (engine stop, RPC invalidation, library-data + pending-op
+    // clear, token clear, user clear) — so this nav-level action can't drift from what Settings'
+    // own sign-out does.
     val onSignOut: () -> Unit = {
         scope.launch {
-            libraryResetHelper.clearLibraryData()
-            authSession.clearAuthTokens()
+            logoutUseCase()
         }
     }
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/SettingsEntries.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/SettingsEntries.kt
@@ -57,9 +57,10 @@ internal fun EntryProviderScope<NavKey>.settingsEntries(
                 backStack.removeAt(backStack.lastIndex)
             },
             onSignedOutEverywhere = {
-                // Mirror the Shell sign-out teardown: clear local library
-                // data, then clear auth tokens so auth-state routing returns
-                // the user to login.
+                // Same local teardown as the Shell sign-out action (LogoutUseCase, via
+                // onSignOut) — the server-side revoke-all already happened in
+                // signOutEverywhere(); this just clears local state so auth-state
+                // routing returns the user to login.
                 onSignOut()
             },
         )


### PR DESCRIPTION
Lands the parked audit plan 6 (rebased onto current main):

- `LogoutUseCase` becomes the single sign-out choke point (shell nav, desktop nav, Settings all route through it) and now clears library data + pending operations, in a strict teardown order: disconnect sync → invalidate RPC caches → clear playback → clear library/outbox → clear tokens → clear users
- Closes the cold-start-logout mechanism: the nav/desktop paths previously skipped `disconnect()`/`invalidateAll()`, so an orphaned sync engine's delayed token-refresh failure could wipe a fresh login's tokens
- Outbox dispatch is owner-scoped: `PendingOperationV2Dao` filters by owner and `PendingOperationQueue` drains only the active user's ops, so a stale op can't fire under the wrong user's session

Rebase preserved main's #1144 (`getOrNull<PlaybackManager>`) and #1176 dead-letter heal semantics alongside the new owner scoping. Targeted suite: 65 tests green across LogoutUseCase/PendingOperation* classes.

Note: `:desktopApp:compileKotlin` is red on origin/main independently of this branch (#1183 genre/tag/mood signatures not applied to desktop screens) — fix incoming separately.