### PR TITLE
🔒 fix(server,shared,contract): opaque junction sync ids — tombstones stop leaking the natural pair (SERVER-SYNC-04)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/BookMoodSyncPayload.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/BookMoodSyncPayload.kt
@@ -16,10 +16,17 @@ import kotlinx.serialization.Serializable
  * [createdAt] records when the junction row was first created (epoch millis). Unlike
  * [Mood] and [Book], [BookMoodSyncPayload] has no [updatedAt] — the row is either live
  * or soft-deleted; partial updates do not apply.
+ *
+ * [id] is an opaque per-row identity minted at creation (server-side by default;
+ * client-side for offline-first creates). It deliberately encodes nothing about
+ * [bookId] or [moodId] — an ungated tombstone that shipped a composite id would leak
+ * the association to a user who never had access to the row (SERVER-SYNC-04).
  */
 @Serializable
 @SerialName("BookMoodSyncPayload")
 data class BookMoodSyncPayload(
+    /** Opaque per-row sync identity — encodes neither [bookId] nor [moodId]. */
+    @SerialName("id") override val id: String,
     /** The book this mood is linked to. */
     @SerialName("bookId") val bookId: String,
     /** The mood linked to the book. */
@@ -29,7 +36,4 @@ data class BookMoodSyncPayload(
     /** Sync revision counter — bumped on every write (create or soft-delete). */
     @SerialName("revision") override val revision: Long,
     @SerialName("deletedAt") override val deletedAt: Long? = null,
-) : SyncPayload {
-    /** Synthetic sync identity `"$bookId:$moodId"` — matches the server's envelope id. Not serialized. */
-    override val id: String get() = "$bookId:$moodId"
-}
+) : SyncPayload

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/BookTagSyncPayload.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/BookTagSyncPayload.kt
@@ -16,10 +16,17 @@ import kotlinx.serialization.Serializable
  * [createdAt] records when the junction row was first created (epoch millis). Unlike
  * [Tag] and [Book], [BookTagSyncPayload] has no [updatedAt] — the row is either live
  * or soft-deleted; partial updates do not apply.
+ *
+ * [id] is an opaque per-row identity minted at creation (server-side by default;
+ * client-side for offline-first creates). It deliberately encodes nothing about
+ * [bookId] or [tagId] — an ungated tombstone that shipped a composite id would leak
+ * the association to a user who never had access to the row (SERVER-SYNC-04).
  */
 @Serializable
 @SerialName("BookTagSyncPayload")
 data class BookTagSyncPayload(
+    /** Opaque per-row sync identity — encodes neither [bookId] nor [tagId]. */
+    @SerialName("id") override val id: String,
     /** The book this tag is linked to. */
     @SerialName("bookId") val bookId: String,
     /** The tag linked to the book. */
@@ -29,7 +36,4 @@ data class BookTagSyncPayload(
     /** Sync revision counter — bumped on every write (create or soft-delete). */
     @SerialName("revision") override val revision: Long,
     @SerialName("deletedAt") override val deletedAt: Long? = null,
-) : SyncPayload {
-    /** Synthetic sync identity `"$bookId:$tagId"` — matches the server's envelope id. Not serialized. */
-    override val id: String get() = "$bookId:$tagId"
-}
+) : SyncPayload

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/CollectionSyncPayload.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/CollectionSyncPayload.kt
@@ -43,10 +43,18 @@ data class CollectionSyncPayload(
  * collection. [createdAt] records when the junction row was first created.
  * There is no [updatedAt] — the row is either live or soft-deleted; partial
  * updates do not apply.
+ *
+ * [id] is an opaque per-row identity minted at creation (server-side by default;
+ * client-side for offline-first creates). It deliberately encodes nothing about
+ * [collectionId] or [bookId] — an ungated tombstone that shipped a composite id
+ * would leak the association to a user who never had access to the row
+ * (SERVER-SYNC-04).
  */
 @Serializable
 @SerialName("CollectionBookSyncPayload")
 data class CollectionBookSyncPayload(
+    /** Opaque per-row sync identity — encodes neither [collectionId] nor [bookId]. */
+    @SerialName("id") override val id: String,
     /** The collection this book belongs to. */
     @SerialName("collectionId") val collectionId: String,
     /** The book added to the collection. */
@@ -56,10 +64,7 @@ data class CollectionBookSyncPayload(
     /** Sync revision counter — bumped on every write (create or soft-delete). */
     @SerialName("revision") override val revision: Long,
     @SerialName("deletedAt") override val deletedAt: Long? = null,
-) : SyncPayload {
-    /** Synthetic sync identity `"$collectionId:$bookId"` — matches the server's envelope id. Not serialized. */
-    override val id: String get() = "$collectionId:$bookId"
-}
+) : SyncPayload
 
 /**
  * Wire DTO for a collection share record synced between server and client.

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/ShelfSyncPayload.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/ShelfSyncPayload.kt
@@ -38,15 +38,18 @@ data class ShelfSyncPayload(
  *
  * One row per `(shelfId, bookId)` pair. [sortOrder] determines display ordering
  * within the shelf. Soft-deletes are tombstoned via [deletedAt]; a non-null
- * [deletedAt] indicates the book was removed from the shelf. [id] is a synthetic
- * stable identifier (`"$shelfId:$bookId"`) used as the sync-cursor identity.
+ * [deletedAt] indicates the book was removed from the shelf. [id] is an opaque
+ * per-row identity minted at creation (server-side by default; client-side for
+ * offline-first creates); it deliberately encodes nothing about [shelfId] or
+ * [bookId] — an ungated tombstone that shipped a composite id would leak the
+ * association to a user who never had access to the row (SERVER-SYNC-04).
  *
  * `userId` is NOT on the wire — it is scoped server-side via `UserScopedSyncableTable`.
  */
 @Serializable
 @SerialName("ShelfBookSyncPayload")
 data class ShelfBookSyncPayload(
-    /** Synthetic stable id for sync-cursor identity (`"$shelfId:$bookId"`). */
+    /** Opaque per-row sync identity — encodes neither [shelfId] nor [bookId]. */
     @SerialName("id") override val id: String,
     /** The shelf this book belongs to. */
     @SerialName("shelfId") val shelfId: String,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -251,6 +251,7 @@ internal class CollectionServiceImpl(
 
         val payload =
             CollectionBookSyncPayload(
+                id = Uuid.random().toString(),
                 collectionId = id.value,
                 bookId = bookId.value,
                 createdAt = clock.now().toEpochMilliseconds(),
@@ -337,6 +338,7 @@ internal class CollectionServiceImpl(
         for (collectionId in added) {
             collectionBookRepo.upsert(
                 CollectionBookSyncPayload(
+                    id = Uuid.random().toString(),
                     collectionId = collectionId,
                     bookId = bookId.value,
                     createdAt = clock.now().toEpochMilliseconds(),
@@ -579,6 +581,7 @@ internal class CollectionServiceImpl(
 
         val payload =
             CollectionBookSyncPayload(
+                id = Uuid.random().toString(),
                 collectionId = inbox.id.value,
                 bookId = bookId,
                 createdAt = clock.now().toEpochMilliseconds(),
@@ -655,6 +658,7 @@ internal class CollectionServiceImpl(
             for (targetId in resolvedTargets) {
                 collectionBookRepo.upsert(
                     CollectionBookSyncPayload(
+                        id = Uuid.random().toString(),
                         collectionId = targetId,
                         bookId = bookId,
                         createdAt = clock.now().toEpochMilliseconds(),
@@ -770,6 +774,7 @@ internal class CollectionServiceImpl(
                         .also { lookups.noteAllBooksCreated(libraryId, it) }
             collectionBookRepo.upsert(
                 CollectionBookSyncPayload(
+                    id = Uuid.random().toString(),
                     collectionId = id,
                     bookId = bookId,
                     createdAt = clock.now().toEpochMilliseconds(),

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MoodServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MoodServiceImpl.kt
@@ -156,6 +156,7 @@ internal class MoodServiceImpl(
         val now = clock.now().toEpochMilliseconds()
         val junctionPayload =
             BookMoodSyncPayload(
+                id = Uuid.random().toString(),
                 bookId = bookId.value,
                 moodId = mood.id,
                 createdAt = now,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/TagServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/TagServiceImpl.kt
@@ -160,6 +160,7 @@ internal class TagServiceImpl(
         val now = clock.now().toEpochMilliseconds()
         val junctionPayload =
             BookTagSyncPayload(
+                id = Uuid.random().toString(),
                 bookId = bookId.value,
                 tagId = tag.id,
                 createdAt = now,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookMoodWriter.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookMoodWriter.kt
@@ -86,6 +86,7 @@ internal class BookMoodWriter(
         for (moodId in targetMoodIds - currentMoodIds) {
             bookMoodRepository.upsert(
                 BookMoodSyncPayload(
+                    id = Uuid.random().toString(),
                     bookId = bookId.value,
                     moodId = moodId,
                     createdAt = now,
@@ -119,6 +120,7 @@ internal class BookMoodWriter(
         val now = clock.now().toEpochMilliseconds()
         bookMoodRepository.upsert(
             BookMoodSyncPayload(
+                id = Uuid.random().toString(),
                 bookId = bookId.value,
                 moodId = moodId,
                 createdAt = now,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -1595,7 +1595,9 @@ class BookRepository(
         if (db.collectionBooksQueries.existsByCollectionAndBook(systemCollectionId, bookId).executeAsOne()) {
             return
         }
-        val syntheticId = "$systemCollectionId:$bookId"
+        // Opaque per-row id — minted fresh here since the idempotency guard above already
+        // proved no row exists for this pair (SERVER-SYNC-04: never derive it from the pair).
+        val syntheticId = Uuid.random().toString()
         val membershipRev = nextRevision()
         db.collectionBooksQueries.insertMembership(
             id = syntheticId,
@@ -1614,6 +1616,7 @@ class BookRepository(
                 clientOpId = null,
                 payload =
                     CollectionBookSyncPayload(
+                        id = syntheticId,
                         collectionId = systemCollectionId,
                         bookId = bookId,
                         createdAt = now,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookTagWriter.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookTagWriter.kt
@@ -87,6 +87,7 @@ internal class BookTagWriter(
         for (tagId in targetTagIds - currentTagIds) {
             bookTagRepository.upsert(
                 BookTagSyncPayload(
+                    id = Uuid.random().toString(),
                     bookId = bookId.value,
                     tagId = tagId,
                     createdAt = now,
@@ -120,6 +121,7 @@ internal class BookTagWriter(
         val now = clock.now().toEpochMilliseconds()
         bookTagRepository.upsert(
             BookTagSyncPayload(
+                id = Uuid.random().toString(),
                 bookId = bookId.value,
                 tagId = tagId,
                 createdAt = now,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
@@ -148,6 +148,16 @@ class BookMoodRepository(
         return idStrs.mapNotNull { byId[it]?.toPayload() }
     }
 
+    /**
+     * Tombstone projection (SERVER-SYNC-04) — see [SqlSyncableRepository.minimizeTombstone].
+     * The pull path delivers junction tombstones ungated so every client converges, so the
+     * pair itself must not cross the wire: a member who never had access to [bookId] would
+     * otherwise learn the association from the tombstone alone. `id`/`revision`/`deletedAt`/
+     * `createdAt` survive — identity and sync-discipline fields only.
+     */
+    override fun minimizeTombstone(payload: BookMoodSyncPayload): BookMoodSyncPayload =
+        payload.copy(bookId = "", moodId = "")
+
     override fun writePayload(
         value: BookMoodSyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
@@ -10,16 +10,21 @@ import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import kotlin.time.Clock
 
 /**
- * Composite key for `book_moods` junction rows.
+ * Natural-pair identity for `book_moods` junction rows — the server-internal type the
+ * [SqlSyncableRepository] substrate uses to resolve the row's REAL opaque wire id.
  *
- * This is an internal server-side type; the wire representation is
- * [BookMoodSyncPayload], which carries [bookId] and [moodId] as top-level fields.
- * [asString] produces the synthetic `"$bookId:$moodId"` key stored in the
- * `book_moods.id` column and used by the [SqlSyncableRepository] substrate.
+ * The wire representation is [BookMoodSyncPayload], which carries [bookId] and [moodId] as
+ * top-level fields, plus its own opaque `id` (SERVER-SYNC-04: minted at creation, encodes
+ * nothing). [candidateWireId] carries that candidate id through to [idAsString] —
+ * client-minted for an offline-first create, server-minted otherwise — for the case where no
+ * row exists yet for the pair. When a row already exists (live or tombstoned), [idAsString]
+ * discards the candidate and returns the EXISTING row's id instead — "the existing row's id
+ * wins" on a natural-pair conflict.
  */
 data class BookMoodId(
     val bookId: String,
     val moodId: String,
+    val candidateWireId: String = "",
 ) {
     fun asString(): String = "$bookId:$moodId"
 
@@ -37,9 +42,10 @@ data class BookMoodId(
  * SQLDelight syncable repository for the `book_moods` global junction — the
  * composite-key sibling of [MoodRepository] and the twin of [BookTagRepository].
  *
- * Extends [SqlSyncableRepository] with composite-key awareness. The `book_moods.id`
- * column stores the synthetic `"$bookId:$moodId"` key the base uses for revision-cursor
- * queries; the natural composite PK `(book_id, mood_id)` is the write and lookup key.
+ * Extends [SqlSyncableRepository] with composite-key awareness. The `book_moods.id` column
+ * stores an opaque per-row id (SERVER-SYNC-04) the base uses for revision-cursor queries; the
+ * natural composite PK `(book_id, mood_id)` is the write and lookup key. [idAsString] resolves
+ * between the two — see [BookMoodId].
  *
  * In addition to the standard [upsert] / [softDelete], this repository provides
  * bulk cascade variants used by service-layer delete operations:
@@ -59,10 +65,27 @@ class BookMoodRepository(
         key = SyncDomains.BOOK_MOODS,
         clock = clock,
     ) {
-    override val BookMoodSyncPayload.id: BookMoodId get() = BookMoodId(bookId, moodId)
+    override val BookMoodSyncPayload.id: BookMoodId get() = BookMoodId(bookId, moodId, id)
 
-    /** Converts a [BookMoodId] to the stored `"$bookId:$moodId"` string. */
-    override fun idAsString(id: BookMoodId): String = id.asString()
+    /**
+     * Resolves [id] to the REAL stored opaque wire id: an existing row's id if one already
+     * exists for the natural pair (live or tombstoned — "the existing row's id wins" on a
+     * natural-pair conflict), else [BookMoodId.candidateWireId] as-is.
+     *
+     * The candidate is NOT minted here — minting is the call site's job (client-minted for an
+     * offline-first create, server-minted otherwise, e.g. `Uuid.random().toString()` in
+     * `MoodServiceImpl`/`BookMoodWriter`). Minting inside this function would be unsafe:
+     * [upsert] calls [idAsString] once to decide `existed` and again inside [writePayload]'s
+     * insert branch to compute the row's actual `id` — two calls that must resolve identically
+     * within the same transaction. A fresh mint per call would make them diverge, and the
+     * second (real) write would never match the first (assumed) id — see
+     * [SqlSyncableRepository.upsert]'s `readPayload` immediately after `writePayload`.
+     */
+    override fun idAsString(id: BookMoodId): String =
+        db.bookMoodsQueries
+            .selectIdByNaturalPair(id.bookId, id.moodId)
+            .executeAsOneOrNull()
+            ?: id.candidateWireId
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.bookMoodsQueries].
@@ -144,7 +167,10 @@ class BookMoodRepository(
             )
         } else {
             db.bookMoodsQueries.insert(
-                id = BookMoodId(value.bookId, value.moodId).asString(),
+                // Deterministic re-derivation of the SAME resolution upsert() already made for
+                // this write (same natural pair, same candidate, same transaction — no row has
+                // been inserted between the two calls, so the natural-pair lookup still misses).
+                id = idAsString(BookMoodId(value.bookId, value.moodId, value.id)),
                 book_id = value.bookId,
                 mood_id = value.moodId,
                 created_at = now,
@@ -258,6 +284,7 @@ class BookMoodRepository(
                                 clientOpId = null,
                                 payload =
                                     BookMoodSyncPayload(
+                                        id = row.id,
                                         bookId = row.book_id,
                                         moodId = row.mood_id,
                                         createdAt = row.created_at,
@@ -304,6 +331,7 @@ class BookMoodRepository(
     /** Maps a generated [Book_moods] row to the wire [BookMoodSyncPayload] DTO. */
     private fun Book_moods.toPayload(): BookMoodSyncPayload =
         BookMoodSyncPayload(
+            id = id,
             bookId = book_id,
             moodId = mood_id,
             createdAt = created_at,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
@@ -27,15 +27,6 @@ data class BookMoodId(
     val candidateWireId: String = "",
 ) {
     fun asString(): String = "$bookId:$moodId"
-
-    companion object {
-        /** Parses a synthetic id string back into its composite parts. */
-        fun fromString(s: String): BookMoodId {
-            val colon = s.indexOf(':')
-            check(colon > 0) { "Invalid BookMoodId string: $s" }
-            return BookMoodId(s.substring(0, colon), s.substring(colon + 1))
-        }
-    }
 }
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
@@ -27,15 +27,6 @@ data class BookTagId(
     val candidateWireId: String = "",
 ) {
     fun asString(): String = "$bookId:$tagId"
-
-    companion object {
-        /** Parses a synthetic id string back into its composite parts. */
-        fun fromString(s: String): BookTagId {
-            val colon = s.indexOf(':')
-            check(colon > 0) { "Invalid BookTagId string: $s" }
-            return BookTagId(s.substring(0, colon), s.substring(colon + 1))
-        }
-    }
 }
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
@@ -148,6 +148,15 @@ class BookTagRepository(
         return idStrs.mapNotNull { byId[it]?.toPayload() }
     }
 
+    /**
+     * Tombstone projection (SERVER-SYNC-04) — see [SqlSyncableRepository.minimizeTombstone].
+     * The pull path delivers junction tombstones ungated so every client converges, so the
+     * pair itself must not cross the wire: a member who never had access to [bookId] would
+     * otherwise learn the association from the tombstone alone. `id`/`revision`/`deletedAt`/
+     * `createdAt` survive — identity and sync-discipline fields only.
+     */
+    override fun minimizeTombstone(payload: BookTagSyncPayload): BookTagSyncPayload = payload.copy(bookId = "", tagId = "")
+
     override fun writePayload(
         value: BookTagSyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
@@ -146,7 +146,8 @@ class BookTagRepository(
      * otherwise learn the association from the tombstone alone. `id`/`revision`/`deletedAt`/
      * `createdAt` survive — identity and sync-discipline fields only.
      */
-    override fun minimizeTombstone(payload: BookTagSyncPayload): BookTagSyncPayload = payload.copy(bookId = "", tagId = "")
+    override fun minimizeTombstone(payload: BookTagSyncPayload): BookTagSyncPayload =
+        payload.copy(bookId = "", tagId = "")
 
     override fun writePayload(
         value: BookTagSyncPayload,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
@@ -10,16 +10,21 @@ import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import kotlin.time.Clock
 
 /**
- * Composite key for `book_tags` junction rows.
+ * Natural-pair identity for `book_tags` junction rows — the server-internal type the
+ * [SqlSyncableRepository] substrate uses to resolve the row's REAL opaque wire id.
  *
- * This is an internal server-side type; the wire representation is
- * [BookTagSyncPayload], which carries [bookId] and [tagId] as top-level fields.
- * [asString] produces the synthetic `"$bookId:$tagId"` key stored in the
- * `book_tags.id` column and used by the [SqlSyncableRepository] substrate.
+ * The wire representation is [BookTagSyncPayload], which carries [bookId] and [tagId] as
+ * top-level fields, plus its own opaque `id` (SERVER-SYNC-04: minted at creation, encodes
+ * nothing). [candidateWireId] carries that candidate id through to [idAsString] —
+ * client-minted for an offline-first create, server-minted otherwise — for the case where no
+ * row exists yet for the pair. When a row already exists (live or tombstoned), [idAsString]
+ * discards the candidate and returns the EXISTING row's id instead — "the existing row's id
+ * wins" on a natural-pair conflict.
  */
 data class BookTagId(
     val bookId: String,
     val tagId: String,
+    val candidateWireId: String = "",
 ) {
     fun asString(): String = "$bookId:$tagId"
 
@@ -37,9 +42,10 @@ data class BookTagId(
  * SQLDelight syncable repository for the `book_tags` global junction — the
  * composite-key sibling of [TagRepository] in the cutover template.
  *
- * Extends [SqlSyncableRepository] with composite-key awareness. The `book_tags.id`
- * column stores the synthetic `"$bookId:$tagId"` key the base uses for revision-cursor
- * queries; the natural composite PK `(book_id, tag_id)` is the write and lookup key.
+ * Extends [SqlSyncableRepository] with composite-key awareness. The `book_tags.id` column
+ * stores an opaque per-row id (SERVER-SYNC-04) the base uses for revision-cursor queries; the
+ * natural composite PK `(book_id, tag_id)` is the write and lookup key. [idAsString] resolves
+ * between the two — see [BookTagId].
  *
  * In addition to the standard [upsert] / [softDelete], this repository provides
  * bulk cascade variants used by service-layer delete operations:
@@ -59,10 +65,27 @@ class BookTagRepository(
         key = SyncDomains.BOOK_TAGS,
         clock = clock,
     ) {
-    override val BookTagSyncPayload.id: BookTagId get() = BookTagId(bookId, tagId)
+    override val BookTagSyncPayload.id: BookTagId get() = BookTagId(bookId, tagId, id)
 
-    /** Converts a [BookTagId] to the stored `"$bookId:$tagId"` string. */
-    override fun idAsString(id: BookTagId): String = id.asString()
+    /**
+     * Resolves [id] to the REAL stored opaque wire id: an existing row's id if one already
+     * exists for the natural pair (live or tombstoned — "the existing row's id wins" on a
+     * natural-pair conflict), else [BookTagId.candidateWireId] as-is.
+     *
+     * The candidate is NOT minted here — minting is the call site's job (client-minted for an
+     * offline-first create, server-minted otherwise, e.g. `Uuid.random().toString()` in
+     * `TagServiceImpl`/`BookTagWriter`). Minting inside this function would be unsafe: [upsert]
+     * calls [idAsString] once to decide `existed` and again inside [writePayload]'s insert
+     * branch to compute the row's actual `id` — two calls that must resolve identically within
+     * the same transaction. A fresh mint per call would make them diverge, and the second
+     * (real) write would never match the first (assumed) id — see
+     * [SqlSyncableRepository.upsert]'s `readPayload` immediately after `writePayload`.
+     */
+    override fun idAsString(id: BookTagId): String =
+        db.bookTagsQueries
+            .selectIdByNaturalPair(id.bookId, id.tagId)
+            .executeAsOneOrNull()
+            ?: id.candidateWireId
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.bookTagsQueries].
@@ -144,7 +167,10 @@ class BookTagRepository(
             )
         } else {
             db.bookTagsQueries.insert(
-                id = BookTagId(value.bookId, value.tagId).asString(),
+                // Deterministic re-derivation of the SAME resolution upsert() already made for
+                // this write (same natural pair, same candidate, same transaction — no row has
+                // been inserted between the two calls, so the natural-pair lookup still misses).
+                id = idAsString(BookTagId(value.bookId, value.tagId, value.id)),
                 book_id = value.bookId,
                 tag_id = value.tagId,
                 created_at = now,
@@ -280,6 +306,7 @@ class BookTagRepository(
                                 clientOpId = null,
                                 payload =
                                     BookTagSyncPayload(
+                                        id = row.id,
                                         bookId = row.book_id,
                                         tagId = row.tag_id,
                                         createdAt = row.created_at,
@@ -326,6 +353,7 @@ class BookTagRepository(
     /** Maps a generated [Book_tags] row to the wire [BookTagSyncPayload] DTO. */
     private fun Book_tags.toPayload(): BookTagSyncPayload =
         BookTagSyncPayload(
+            id = id,
             bookId = book_id,
             tagId = tag_id,
             createdAt = created_at,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
@@ -11,16 +11,26 @@ import app.cash.sqldelight.db.SqlDriver
 import kotlin.time.Clock
 
 /**
- * Composite key for `collection_books` junction rows.
+ * Natural-pair identity for `collection_books` junction rows — the server-internal type the
+ * [SqlSyncableRepository] substrate uses to resolve the row's REAL opaque wire id.
  *
  * The wire representation is [CollectionBookSyncPayload], which carries [collectionId] and
- * [bookId] as top-level fields. [asString] produces the synthetic `"$collectionId:$bookId"`
- * key stored in the `collection_books.id` column and used by the [SqlSyncableRepository]
- * substrate for revision-cursor identity.
+ * [bookId] as top-level fields, plus its own opaque `id` (SERVER-SYNC-04: minted at creation,
+ * encodes nothing). [candidateWireId] carries that candidate id through to [idAsString] —
+ * client-minted for an offline-first create, server-minted otherwise — for the case where no
+ * row exists yet for the pair. When a row already exists (live or tombstoned), [idAsString]
+ * discards the candidate and returns the EXISTING row's id instead — "the existing row's id
+ * wins" on a natural-pair conflict.
+ *
+ * [asString] still produces the natural-pair string, unrelated to the wire id; it remains in
+ * use where the pair itself (not identity) is the thing being encoded (e.g. cross-checks in
+ * tests, [SyncRoutes]'s access-hiding lookup which reads `collectionId` off a payload/DB row,
+ * never off the opaque wire id).
  */
 data class CollectionBookId(
     val collectionId: String,
     val bookId: String,
+    val candidateWireId: String = "",
 ) {
     fun asString(): String = "$collectionId:$bookId"
 
@@ -38,9 +48,9 @@ data class CollectionBookId(
  * SQLDelight syncable repository for the `collection_books` global junction — the composite-key
  * sibling of [CollectionRepository].
  *
- * The `collection_books.id` column stores the synthetic `"$collectionId:$bookId"` key the base
- * uses for revision-cursor queries; the natural composite PK `(collection_id, book_id)` is the
- * write and lookup key.
+ * The `collection_books.id` column stores an opaque per-row id (SERVER-SYNC-04) the base uses
+ * for revision-cursor queries; the natural composite PK `(collection_id, book_id)` is the write
+ * and lookup key. [idAsString] resolves between the two — see [CollectionBookId].
  *
  * **Access-filtered sync.** A member's membership catch-up/digest must exclude membership rows
  * for collections they cannot reach (including the system collections), so the firehose arrives
@@ -69,10 +79,27 @@ class CollectionBookRepository(
         key = SyncDomains.COLLECTION_BOOKS,
         clock = clock,
     ) {
-    override val CollectionBookSyncPayload.id: CollectionBookId get() = CollectionBookId(collectionId, bookId)
+    override val CollectionBookSyncPayload.id: CollectionBookId get() = CollectionBookId(collectionId, bookId, id)
 
-    /** Converts a [CollectionBookId] to the stored `"$collectionId:$bookId"` string. */
-    override fun idAsString(id: CollectionBookId): String = id.asString()
+    /**
+     * Resolves [id] to the REAL stored opaque wire id: an existing row's id if one already
+     * exists for the natural pair (live or tombstoned — "the existing row's id wins" on a
+     * natural-pair conflict), else [CollectionBookId.candidateWireId] as-is.
+     *
+     * The candidate is NOT minted here — minting is the call site's job (client-minted for an
+     * offline-first create, server-minted otherwise, e.g. `Uuid.random().toString()` in
+     * `CollectionServiceImpl`). Minting inside this function would be unsafe: [upsert] calls
+     * [idAsString] once to decide `existed` and again inside [writePayload]'s insert branch to
+     * compute the row's actual `id` — two calls that must resolve identically within the same
+     * transaction. A fresh mint per call would make them diverge, and the second (real) write
+     * would never match the first (assumed) id — see [SqlSyncableRepository.upsert]'s
+     * `readPayload` immediately after `writePayload`.
+     */
+    override fun idAsString(id: CollectionBookId): String =
+        db.collectionBooksQueries
+            .selectIdByNaturalPair(id.collectionId, id.bookId)
+            .executeAsOneOrNull()
+            ?: id.candidateWireId
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.collectionBooksQueries].
@@ -149,7 +176,10 @@ class CollectionBookRepository(
             )
         } else {
             db.collectionBooksQueries.insert(
-                id = CollectionBookId(value.collectionId, value.bookId).asString(),
+                // Deterministic re-derivation of the SAME resolution upsert() already made for
+                // this write (same natural pair, same candidate, same transaction — no row has
+                // been inserted between the two calls, so the natural-pair lookup still misses).
+                id = idAsString(CollectionBookId(value.collectionId, value.bookId, value.id)),
                 collection_id = value.collectionId,
                 book_id = value.bookId,
                 created_at = now,
@@ -300,6 +330,7 @@ class CollectionBookRepository(
                                 clientOpId = null,
                                 payload =
                                     CollectionBookSyncPayload(
+                                        id = row.id,
                                         collectionId = row.collection_id,
                                         bookId = row.book_id,
                                         createdAt = row.created_at,
@@ -319,6 +350,7 @@ class CollectionBookRepository(
     /** Maps a generated [Collection_books] row to the wire [CollectionBookSyncPayload] DTO. */
     private fun Collection_books.toSyncPayload(): CollectionBookSyncPayload =
         CollectionBookSyncPayload(
+            id = id,
             collectionId = collection_id,
             bookId = book_id,
             createdAt = created_at,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
@@ -33,15 +33,6 @@ data class CollectionBookId(
     val candidateWireId: String = "",
 ) {
     fun asString(): String = "$collectionId:$bookId"
-
-    companion object {
-        /** Parses a synthetic id string back into its composite parts. */
-        fun fromString(s: String): CollectionBookId {
-            val colon = s.indexOf(':')
-            check(colon > 0) { "Invalid CollectionBookId string: $s" }
-            return CollectionBookId(s.substring(0, colon), s.substring(colon + 1))
-        }
-    }
 }
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
@@ -157,6 +157,16 @@ class CollectionBookRepository(
         return idStrs.mapNotNull { byId[it]?.toSyncPayload() }
     }
 
+    /**
+     * Tombstone projection (SERVER-SYNC-04) — see [SqlSyncableRepository.minimizeTombstone].
+     * The pull path delivers junction tombstones ungated so every client converges, so the
+     * pair itself must not cross the wire: a member who never had access to [collectionId]
+     * would otherwise learn the association from the tombstone alone. `id`/`revision`/
+     * `deletedAt`/`createdAt` survive — identity and sync-discipline fields only.
+     */
+    override fun minimizeTombstone(payload: CollectionBookSyncPayload): CollectionBookSyncPayload =
+        payload.copy(collectionId = "", bookId = "")
+
     override fun writePayload(
         value: CollectionBookSyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfBookRepository.kt
@@ -7,18 +7,24 @@ import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.Shelf_books
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import kotlin.time.Clock
+import kotlin.uuid.Uuid
 
 /**
- * Composite key for `shelf_books` junction rows.
+ * Natural-pair identity for `shelf_books` junction rows — the server-internal type the
+ * [SqlSyncableRepository] substrate uses to resolve the row's REAL opaque wire id.
  *
- * The wire representation is [ShelfBookSyncPayload], which carries [shelfId] and
- * [bookId] as top-level fields. [asString] produces the synthetic
- * `"$shelfId:$bookId"` key stored in the `shelf_books.id` column and used by the
- * [SqlSyncableRepository] substrate for revision-cursor identity.
+ * The wire representation is [ShelfBookSyncPayload], which carries [shelfId] and [bookId] as
+ * top-level fields, plus its own opaque `id` (SERVER-SYNC-04: minted at creation, encodes
+ * nothing). [candidateWireId] carries that candidate id through to [idAsString] —
+ * client-minted for an offline-first create, server-minted otherwise — for the case where no
+ * row exists yet for the pair. When a row already exists (live or tombstoned), [idAsString]
+ * discards the candidate and returns the EXISTING row's id instead — "the existing row's id
+ * wins" on a natural-pair conflict.
  */
 data class ShelfBookId(
     val shelfId: String,
     val bookId: String,
+    val candidateWireId: String = "",
 ) {
     fun asString(): String = "$shelfId:$bookId"
 
@@ -39,9 +45,10 @@ data class ShelfBookId(
  * `userScoped = true` — junction rows carry the owning `user_id` (the shelf owner)
  * and sync only to that user. Pull/digest route through the substrate's `*ForUser`
  * variants ([SyncableSubstrateQueries.selectIdsAboveRevisionForUser] /
- * [SyncableSubstrateQueries.selectIdRevAtMostForUser]). The `shelf_books.id` column
- * stores the synthetic `"$shelfId:$bookId"` key the base uses for revision-cursor
- * queries; the natural composite PK `(shelf_id, book_id)` is the write and lookup key.
+ * [SyncableSubstrateQueries.selectIdRevAtMostForUser]). The `shelf_books.id` column stores an
+ * opaque per-row id (SERVER-SYNC-04) the base uses for revision-cursor queries; the natural
+ * composite PK `(shelf_id, book_id)` is the write and lookup key. [idAsString] resolves between
+ * the two — see [ShelfBookId].
  *
  * `sort_order` is the denormalized display position within the shelf, preserved
  * verbatim across the conversion (Int on the wire, INTEGER in SQLite, mapped at the
@@ -70,10 +77,27 @@ class ShelfBookRepository(
     ) {
     override val userScoped: Boolean = true
 
-    override val ShelfBookSyncPayload.id: ShelfBookId get() = ShelfBookId(shelfId, bookId)
+    override val ShelfBookSyncPayload.id: ShelfBookId get() = ShelfBookId(shelfId, bookId, id)
 
-    /** Converts a [ShelfBookId] to the stored `"$shelfId:$bookId"` string. */
-    override fun idAsString(id: ShelfBookId): String = id.asString()
+    /**
+     * Resolves [id] to the REAL stored opaque wire id: an existing row's id if one already
+     * exists for the natural pair (live or tombstoned — "the existing row's id wins" on a
+     * natural-pair conflict), else [ShelfBookId.candidateWireId] as-is.
+     *
+     * The candidate is NOT minted here — minting is the call site's job (client-minted for an
+     * offline-first create, server-minted otherwise, e.g. [addBook]'s `Uuid.random().toString()`).
+     * Minting inside this function would be unsafe: [upsert] calls [idAsString] once to decide
+     * `existed` and again inside [writePayload]'s insert branch to compute the row's actual
+     * `id` — two calls that must resolve identically within the same transaction. A fresh mint
+     * per call would make them diverge, and the second (real) write would never match the first
+     * (assumed) id — see [SqlSyncableRepository.upsert]'s `readPayload` immediately after
+     * `writePayload`.
+     */
+    override fun idAsString(id: ShelfBookId): String =
+        db.shelfBooksQueries
+            .selectIdByNaturalPair(id.shelfId, id.bookId)
+            .executeAsOneOrNull()
+            ?: id.candidateWireId
 
     /**
      * [SyncableSubstrateQueries] adapter over the generated [ListenUpDatabase.shelfBooksQueries].
@@ -174,7 +198,10 @@ class ShelfBookRepository(
             )
         } else {
             db.shelfBooksQueries.insert(
-                id = ShelfBookId(value.shelfId, value.bookId).asString(),
+                // Deterministic re-derivation of the SAME resolution upsert() already made for
+                // this write (same natural pair, same candidate, same transaction — no row has
+                // been inserted between the two calls, so the natural-pair lookup still misses).
+                id = idAsString(ShelfBookId(value.shelfId, value.bookId, value.id)),
                 user_id = requireNotNull(userId) { "ShelfBookRepository.writePayload requires a userId" },
                 shelf_id = value.shelfId,
                 book_id = value.bookId,
@@ -222,7 +249,7 @@ class ShelfBookRepository(
         val nextSortOrder = nextSortOrderFor(shelfId)
         return upsert(
             ShelfBookSyncPayload(
-                id = ShelfBookId(shelfId, bookId).asString(),
+                id = Uuid.random().toString(),
                 shelfId = shelfId,
                 bookId = bookId,
                 sortOrder = nextSortOrder,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfBookRepository.kt
@@ -27,15 +27,6 @@ data class ShelfBookId(
     val candidateWireId: String = "",
 ) {
     fun asString(): String = "$shelfId:$bookId"
-
-    companion object {
-        /** Parses a synthetic id string back into its composite parts. */
-        fun fromString(s: String): ShelfBookId {
-            val colon = s.indexOf(':')
-            check(colon > 0) { "Invalid ShelfBookId string: $s" }
-            return ShelfBookId(s.substring(0, colon), s.substring(colon + 1))
-        }
-    }
 }
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ShelfBookRepository.kt
@@ -178,6 +178,17 @@ class ShelfBookRepository(
         return idStrs.mapNotNull { byId[it]?.toSyncPayload() }
     }
 
+    /**
+     * Tombstone projection (SERVER-SYNC-04) — see [SqlSyncableRepository.minimizeTombstone].
+     * The pull path delivers junction tombstones ungated so every client converges, so the
+     * pair itself must not cross the wire: a member who never had access to [shelfId] would
+     * otherwise learn the association from the tombstone alone. `id`/`revision`/`deletedAt`/
+     * `createdAt`/`sortOrder` survive — identity, sync-discipline, and non-sensitive display
+     * ordering only.
+     */
+    override fun minimizeTombstone(payload: ShelfBookSyncPayload): ShelfBookSyncPayload =
+        payload.copy(shelfId = "", bookId = "")
+
     override fun writePayload(
         value: ShelfBookSyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.sync.ActivitySyncPayload
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
 import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
 import com.calypsan.listenup.api.sync.DomainDigest
 import com.calypsan.listenup.api.sync.DomainList
@@ -738,8 +739,9 @@ private fun isAdminRosterEventHidden(
  * Visibility matches each domain's catch-up fragment exactly so the live tail and REST
  * replay never disagree:
  *  - `collections` — the event id *is* the collection id; gated by [BookAccessPolicy.canAccessCollection].
- *  - `collection_books` — the event id is the synthetic `"$collectionId:$bookId"` key
- *    ([CollectionBookId.fromString]); gated by the parsed collection's access.
+ *  - `collection_books` — the event id is an opaque per-row value (SERVER-SYNC-04: it encodes
+ *    nothing), so the collection id comes from the [CollectionBookSyncPayload] carried by the
+ *    Created/Updated event, never parsed off the id; gated by that collection's access.
  *  - `collection_shares` — the event id is the grant row id, so the collection id and named
  *    user come from the [CollectionShareSyncPayload]; visible iff the grant names the viewer
  *    or the viewer owns the collection (the `visibleCollectionGrantIdsSql` rule).
@@ -765,12 +767,24 @@ private suspend fun isCollectionEventHidden(
 
     val collectionId =
         if (domain == COLLECTION_BOOKS_DOMAIN) {
-            CollectionBookId.fromString(busEvent.event.id).collectionId
+            collectionBookPayloadOf(busEvent.event)?.collectionId ?: return false
         } else {
             busEvent.event.id
         }
     return !bookAccessPolicy().canAccessCollection(userId, role, collectionId)
 }
+
+/**
+ * Extracts the [CollectionBookSyncPayload] carried by a Created/Updated `collection_books`
+ * event, or null for a Deleted event (which carries no payload — callers never reach this for
+ * Deleted, since [isCollectionEventHidden] returns early on tombstones). Mirrors [sharePayloadOf].
+ */
+private fun collectionBookPayloadOf(event: SyncEvent<*>): CollectionBookSyncPayload? =
+    when (event) {
+        is SyncEvent.Created<*> -> event.payload as CollectionBookSyncPayload
+        is SyncEvent.Updated<*> -> event.payload as CollectionBookSyncPayload
+        is SyncEvent.Deleted -> null
+    }
 
 /**
  * The [CollectionShareSyncPayload] carried by a content [event] on the `collection_shares`

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -767,11 +767,13 @@ private suspend fun isCollectionEventHidden(
 
     val collectionId =
         if (domain == COLLECTION_BOOKS_DOMAIN) {
-            collectionBookPayloadOf(busEvent.event)?.collectionId ?: return false
+            collectionBookPayloadOf(busEvent.event)?.collectionId
         } else {
             busEvent.event.id
         }
-    return !bookAccessPolicy().canAccessCollection(userId, role, collectionId)
+    // A missing collection_books payload should never happen for Created/Updated (only Deleted
+    // carries none, and that already returned above) — hide defensively rather than bypass.
+    return collectionId == null || !bookAccessPolicy().canAccessCollection(userId, role, collectionId)
 }
 
 /**

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
@@ -38,6 +38,13 @@ SELECT id, revision FROM book_moods WHERE deleted_at IS NULL AND revision <= :cu
 
 -- Domain queries.
 
+-- Resolves the REAL stored opaque id for an existing (live OR tombstoned) row for a natural
+-- pair, or null if no row exists yet. SqlSyncableRepository.upsert/softDelete key off this so
+-- an idempotent re-add or a revive reuses the SAME opaque id instead of minting a new one — the
+-- server-side half of "the existing row's id wins" (SERVER-SYNC-04).
+selectIdByNaturalPair:
+SELECT id FROM book_moods WHERE book_id = :book_id AND mood_id = :mood_id;
+
 -- Tombstone-inclusive read by synthetic id. Used by the base's pullSince/readPayloads,
 -- which must hydrate soft-deleted rows so clients receive tombstones.
 selectById:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookTags.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookTags.sq
@@ -38,6 +38,13 @@ SELECT id, revision FROM book_tags WHERE deleted_at IS NULL AND revision <= :cur
 
 -- Domain queries.
 
+-- Resolves the REAL stored opaque id for an existing (live OR tombstoned) row for a natural
+-- pair, or null if no row exists yet. SqlSyncableRepository.upsert/softDelete key off this so
+-- an idempotent re-add or a revive reuses the SAME opaque id instead of minting a new one — the
+-- server-side half of "the existing row's id wins" (SERVER-SYNC-04).
+selectIdByNaturalPair:
+SELECT id FROM book_tags WHERE book_id = :book_id AND tag_id = :tag_id;
+
 -- Tombstone-inclusive read by synthetic id. Used by the base's pullSince/readPayloads,
 -- which must hydrate soft-deleted rows so clients receive tombstones.
 selectById:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/CollectionBooks.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/CollectionBooks.sq
@@ -31,6 +31,13 @@ CREATE INDEX idx_collection_books_revision ON collection_books(revision);
 existsByCollectionAndBook:
 SELECT EXISTS(SELECT 1 FROM collection_books WHERE collection_id = :collection_id AND book_id = :book_id);
 
+-- Resolves the REAL stored opaque id for an existing (live OR tombstoned) row for a natural
+-- pair, or null if no row exists yet. SqlSyncableRepository.upsert/softDelete key off this so
+-- an idempotent re-add or a revive reuses the SAME opaque id instead of minting a new one — the
+-- server-side half of "the existing row's id wins" (SERVER-SYNC-04).
+selectIdByNaturalPair:
+SELECT id FROM collection_books WHERE collection_id = :collection_id AND book_id = :book_id;
+
 -- Inbox membership insert. The synthetic `id` is the canonical "$collectionId:$bookId" key
 -- (see CollectionBookId.asString); used by BookRepository's atomic quarantine write path.
 insertMembership:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ShelfBooks.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ShelfBooks.sq
@@ -61,6 +61,13 @@ WHERE user_id = :userId AND deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 
+-- Resolves the REAL stored opaque id for an existing (live OR tombstoned) row for a natural
+-- pair, or null if no row exists yet. SqlSyncableRepository.upsert/softDelete key off this so
+-- an idempotent re-add or a revive reuses the SAME opaque id instead of minting a new one — the
+-- server-side half of "the existing row's id wins" (SERVER-SYNC-04).
+selectIdByNaturalPair:
+SELECT id FROM shelf_books WHERE shelf_id = :shelf_id AND book_id = :book_id;
+
 -- Tombstone-inclusive read by synthetic id. Used by the base's pullSince/readPayloads,
 -- which must hydrate soft-deleted rows so clients receive tombstones.
 selectById:

--- a/server/src/jvmMain/resources/db/migration/V54__opaque_junction_sync_ids.sql
+++ b/server/src/jvmMain/resources/db/migration/V54__opaque_junction_sync_ids.sql
@@ -1,0 +1,11 @@
+-- V54__opaque_junction_sync_ids.sql — SERVER-SYNC-04: junction wire ids become opaque.
+-- The id column of every junction table previously encoded the natural pair
+-- ("$collectionId:$bookId"), so ungated tombstones leaked the association to every
+-- authenticated user. Rewrite ids to random values; digests change, clients full-resync.
+-- All four tables already have an `id TEXT NOT NULL` column with a UNIQUE INDEX (verified
+-- against CollectionBooks.sq / BookTags.sq / BookMoods.sq / ShelfBooks.sq) — this migration
+-- is data-only, no ADD COLUMN, no golden-schema regeneration required.
+UPDATE collection_books SET id = lower(hex(randomblob(16)));
+UPDATE book_tags SET id = lower(hex(randomblob(16)));
+UPDATE book_moods SET id = lower(hex(randomblob(16)));
+UPDATE shelf_books SET id = lower(hex(randomblob(16)));

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookAccessPolicyTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookAccessPolicyTest.kt
@@ -362,6 +362,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookAccessPolicyTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookAccessPolicyTest.kt
@@ -362,7 +362,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplGetBookAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplGetBookAccessTest.kt
@@ -221,6 +221,7 @@ private fun getBookMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplGetBookAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplGetBookAccessTest.kt
@@ -221,7 +221,7 @@ private fun getBookMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSearchAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSearchAccessTest.kt
@@ -173,7 +173,7 @@ private fun searchMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSearchAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSearchAccessTest.kt
@@ -173,6 +173,7 @@ private fun searchMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorServiceImplAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorServiceImplAccessTest.kt
@@ -181,6 +181,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorServiceImplAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorServiceImplAccessTest.kt
@@ -181,7 +181,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/GenreServiceImplBrowseAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/GenreServiceImplBrowseAccessTest.kt
@@ -188,6 +188,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/GenreServiceImplBrowseAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/GenreServiceImplBrowseAccessTest.kt
@@ -188,7 +188,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImplTest.kt
@@ -849,6 +849,7 @@ private fun playbackMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImplTest.kt
@@ -849,7 +849,7 @@ private fun playbackMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeamLeakE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeamLeakE2ETest.kt
@@ -468,7 +468,7 @@ private suspend fun io.ktor.server.testing.ApplicationTestBuilder.makeBookPublic
                 as AppResult.Success
         ).data
     collectionBookRepo
-        .upsert(CollectionBookSyncPayload(collectionId = allBooks.id.value, bookId = bookId, createdAt = 0L, revision = 0L))
+        .upsert(CollectionBookSyncPayload(id = "${allBooks.id.value}:${bookId}", collectionId = allBooks.id.value, bookId = bookId, createdAt = 0L, revision = 0L))
         .requireSuccess()
 }
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeamLeakE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeamLeakE2ETest.kt
@@ -468,8 +468,15 @@ private suspend fun io.ktor.server.testing.ApplicationTestBuilder.makeBookPublic
                 as AppResult.Success
         ).data
     collectionBookRepo
-        .upsert(CollectionBookSyncPayload(id = "${allBooks.id.value}:${bookId}", collectionId = allBooks.id.value, bookId = bookId, createdAt = 0L, revision = 0L))
-        .requireSuccess()
+        .upsert(
+            CollectionBookSyncPayload(
+                id = "${allBooks.id.value}:$bookId",
+                collectionId = allBooks.id.value,
+                bookId = bookId,
+                createdAt = 0L,
+                revision = 0L,
+            ),
+        ).requireSuccess()
 }
 
 /** Creates a private collection owned by the *acting* caller and adds [bookId]; returns its id. */

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SearchServiceAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SearchServiceAccessTest.kt
@@ -208,6 +208,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SearchServiceAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SearchServiceAccessTest.kt
@@ -208,7 +208,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeriesServiceImplAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeriesServiceImplAccessTest.kt
@@ -172,7 +172,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeriesServiceImplAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeriesServiceImplAccessTest.kt
@@ -172,6 +172,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfAccessTest.kt
@@ -386,7 +386,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfAccessTest.kt
@@ -386,6 +386,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfServiceTest.kt
@@ -315,7 +315,13 @@ class ShelfServiceTest :
                         ),
                     )
                     collectionBookRepo.upsert(
-                        CollectionBookSyncPayload(id = "priv:hidden", collectionId = "priv", bookId = "hidden", createdAt = 0L, revision = 0L),
+                        CollectionBookSyncPayload(
+                            id = "priv:hidden",
+                            collectionId = "priv",
+                            bookId = "hidden",
+                            createdAt = 0L,
+                            revision = 0L,
+                        ),
                     )
 
                     val service = makeService(sql, driver).actAs("u1")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfServiceTest.kt
@@ -247,10 +247,10 @@ class ShelfServiceTest :
                         ),
                     )
                     collectionBookRepo.upsert(
-                        CollectionBookSyncPayload(collectionId = "u1-col", bookId = "b1", createdAt = 0L, revision = 0L),
+                        CollectionBookSyncPayload(id = "u1-col:b1", collectionId = "u1-col", bookId = "b1", createdAt = 0L, revision = 0L),
                     )
                     collectionBookRepo.upsert(
-                        CollectionBookSyncPayload(collectionId = "u1-col", bookId = "b2", createdAt = 0L, revision = 0L),
+                        CollectionBookSyncPayload(id = "u1-col:b2", collectionId = "u1-col", bookId = "b2", createdAt = 0L, revision = 0L),
                     )
 
                     val service = makeService(sql, driver).actAs("u1")
@@ -315,7 +315,7 @@ class ShelfServiceTest :
                         ),
                     )
                     collectionBookRepo.upsert(
-                        CollectionBookSyncPayload(collectionId = "priv", bookId = "hidden", createdAt = 0L, revision = 0L),
+                        CollectionBookSyncPayload(id = "priv:hidden", collectionId = "priv", bookId = "hidden", createdAt = 0L, revision = 0L),
                     )
 
                     val service = makeService(sql, driver).actAs("u1")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfServiceUserShelvesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfServiceUserShelvesTest.kt
@@ -132,6 +132,7 @@ class ShelfServiceUserShelvesTest :
                 )
                 collectionBookRepo.upsert(
                     CollectionBookSyncPayload(
+                        id = "${collectionId}:${bookId}",
                         collectionId = collectionId,
                         bookId = bookId,
                         createdAt = 0L,
@@ -191,6 +192,7 @@ class ShelfServiceUserShelvesTest :
                 )
                 collectionBookRepo.upsert(
                     CollectionBookSyncPayload(
+                        id = "${collectionId}:${bookId}",
                         collectionId = collectionId,
                         bookId = bookId,
                         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfServiceUserShelvesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ShelfServiceUserShelvesTest.kt
@@ -132,7 +132,7 @@ class ShelfServiceUserShelvesTest :
                 )
                 collectionBookRepo.upsert(
                     CollectionBookSyncPayload(
-                        id = "${collectionId}:${bookId}",
+                        id = "$collectionId:$bookId",
                         collectionId = collectionId,
                         bookId = bookId,
                         createdAt = 0L,
@@ -192,7 +192,7 @@ class ShelfServiceUserShelvesTest :
                 )
                 collectionBookRepo.upsert(
                     CollectionBookSyncPayload(
-                        id = "${collectionId}:${bookId}",
+                        id = "$collectionId:$bookId",
                         collectionId = collectionId,
                         bookId = bookId,
                         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SocialAclE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SocialAclE2ETest.kt
@@ -149,6 +149,7 @@ class SocialAclE2ETest :
             )
             collectionBooks.upsert(
                 CollectionBookSyncPayload(
+                    id = "${collectionId}:${bookId}",
                     collectionId = collectionId,
                     bookId = bookId,
                     createdAt = 0L,
@@ -203,6 +204,7 @@ class SocialAclE2ETest :
                         ).data.id.value
                     collectionBooks.upsert(
                         CollectionBookSyncPayload(
+                            id = "${allBooksId}:public-book",
                             collectionId = allBooksId,
                             bookId = "public-book",
                             createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SocialAclE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SocialAclE2ETest.kt
@@ -149,7 +149,7 @@ class SocialAclE2ETest :
             )
             collectionBooks.upsert(
                 CollectionBookSyncPayload(
-                    id = "${collectionId}:${bookId}",
+                    id = "$collectionId:$bookId",
                     collectionId = collectionId,
                     bookId = bookId,
                     createdAt = 0L,
@@ -204,7 +204,7 @@ class SocialAclE2ETest :
                         ).data.id.value
                     collectionBooks.upsert(
                         CollectionBookSyncPayload(
-                            id = "${allBooksId}:public-book",
+                            id = "$allBooksId:public-book",
                             collectionId = allBooksId,
                             bookId = "public-book",
                             createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SocialServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SocialServiceTest.kt
@@ -229,6 +229,7 @@ class SocialServiceTest :
             )
             collectionBookRepo.upsert(
                 CollectionBookSyncPayload(
+                    id = "${collectionId}:${bookId}",
                     collectionId = collectionId,
                     bookId = bookId,
                     createdAt = 0L,
@@ -290,6 +291,7 @@ class SocialServiceTest :
             )
             collectionBookRepo.upsert(
                 CollectionBookSyncPayload(
+                    id = "${allBooksId}:${bookId}",
                     collectionId = allBooksId,
                     bookId = bookId,
                     createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SocialServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SocialServiceTest.kt
@@ -229,7 +229,7 @@ class SocialServiceTest :
             )
             collectionBookRepo.upsert(
                 CollectionBookSyncPayload(
-                    id = "${collectionId}:${bookId}",
+                    id = "$collectionId:$bookId",
                     collectionId = collectionId,
                     bookId = bookId,
                     createdAt = 0L,
@@ -291,7 +291,7 @@ class SocialServiceTest :
             )
             collectionBookRepo.upsert(
                 CollectionBookSyncPayload(
-                    id = "${allBooksId}:${bookId}",
+                    id = "$allBooksId:$bookId",
                     collectionId = allBooksId,
                     bookId = bookId,
                     createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/AudioRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/AudioRoutesTest.kt
@@ -405,7 +405,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/AudioRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/AudioRoutesTest.kt
@@ -405,6 +405,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookCoverRouteTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookCoverRouteTest.kt
@@ -515,7 +515,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookCoverRouteTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookCoverRouteTest.kt
@@ -515,6 +515,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookRoutesTest.kt
@@ -332,6 +332,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookRoutesTest.kt
@@ -332,7 +332,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/ContributorRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/ContributorRoutesTest.kt
@@ -260,7 +260,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/ContributorRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/ContributorRoutesTest.kt
@@ -260,6 +260,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutesTest.kt
@@ -205,7 +205,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutesTest.kt
@@ -205,6 +205,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/GenreRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/GenreRoutesTest.kt
@@ -207,6 +207,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/GenreRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/GenreRoutesTest.kt
@@ -207,7 +207,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/PlaybackProgressRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/PlaybackProgressRoutesTest.kt
@@ -417,7 +417,7 @@ private fun progressMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/PlaybackProgressRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/PlaybackProgressRoutesTest.kt
@@ -417,6 +417,7 @@ private fun progressMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/SeriesRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/SeriesRoutesTest.kt
@@ -248,7 +248,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/SeriesRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/SeriesRoutesTest.kt
@@ -248,6 +248,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/TagRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/TagRoutesTest.kt
@@ -482,6 +482,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/TagRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/TagRoutesTest.kt
@@ -482,7 +482,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookCascadeRegistryParityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookCascadeRegistryParityTest.kt
@@ -105,8 +105,12 @@ class BookCascadeRegistryParityTest :
                     // CASCADE_TOMBSTONED set — checked below).
                     tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
                     moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
-                    bookTagRepo.upsert(BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload(id = "book1:m1", bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L))
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                    )
+                    bookMoodRepo.upsert(
+                        BookMoodSyncPayload(id = "book1:m1", bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
+                    )
                     collectionBookRepo.upsert(
                         CollectionBookSyncPayload(id = "c1:book1", collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
                     )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookCascadeRegistryParityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookCascadeRegistryParityTest.kt
@@ -105,10 +105,10 @@ class BookCascadeRegistryParityTest :
                     // CASCADE_TOMBSTONED set — checked below).
                     tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
                     moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
-                    bookTagRepo.upsert(BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload(bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload(id = "book1:m1", bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L))
                     collectionBookRepo.upsert(
-                        CollectionBookSyncPayload(collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
+                        CollectionBookSyncPayload(id = "c1:book1", collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
                     )
 
                     // live-row count for "book1" per CASCADE_TOMBSTONED table.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookMoodWriterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookMoodWriterTest.kt
@@ -108,6 +108,7 @@ class BookMoodWriterTest :
                     moodRepository.upsert(cozy) as AppResult.Success
                     bookMoodRepository.upsert(
                         BookMoodSyncPayload(
+                            id = "book-1:${cozy.id}",
                             bookId = "book-1",
                             moodId = cozy.id,
                             createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
@@ -110,7 +110,7 @@ class BookRemovalOrphanPurgeTest :
                     val (bookRepo, tagRepo, bookTagRepo) = buildRepo(sql, driver)
                     tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
                     )
 
                     bookRepo.softDelete(BookId("book1"), clientOpId = null)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryScanRevivalCascadeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryScanRevivalCascadeTest.kt
@@ -148,10 +148,12 @@ private class RevivalHarness(
     suspend fun attachJunctions(bookId: BookId) {
         val id = bookId.value
         tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
-        bookTagRepo.upsert(BookTagSyncPayload(id = "${id}:t1", bookId = id, tagId = "t1", createdAt = 1000L, revision = 0L))
+        bookTagRepo.upsert(BookTagSyncPayload(id = "$id:t1", bookId = id, tagId = "t1", createdAt = 1000L, revision = 0L))
         moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
-        bookMoodRepo.upsert(BookMoodSyncPayload(id = "${id}:m1", bookId = id, moodId = "m1", createdAt = 1000L, revision = 0L))
-        collectionBookRepo.upsert(CollectionBookSyncPayload(id = "c1:${id}", collectionId = "c1", bookId = id, createdAt = 1000L, revision = 0L))
+        bookMoodRepo.upsert(BookMoodSyncPayload(id = "$id:m1", bookId = id, moodId = "m1", createdAt = 1000L, revision = 0L))
+        collectionBookRepo.upsert(
+            CollectionBookSyncPayload(id = "c1:$id", collectionId = "c1", bookId = id, createdAt = 1000L, revision = 0L),
+        )
         check(bookTagRepo.findAllForBook(id).size == 1)
         check(bookMoodRepo.findAllForBook(id).size == 1)
         check(collectionBookRepo.findBookIdsForCollection("c1") == listOf(id))

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryScanRevivalCascadeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryScanRevivalCascadeTest.kt
@@ -148,10 +148,10 @@ private class RevivalHarness(
     suspend fun attachJunctions(bookId: BookId) {
         val id = bookId.value
         tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
-        bookTagRepo.upsert(BookTagSyncPayload(bookId = id, tagId = "t1", createdAt = 1000L, revision = 0L))
+        bookTagRepo.upsert(BookTagSyncPayload(id = "${id}:t1", bookId = id, tagId = "t1", createdAt = 1000L, revision = 0L))
         moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
-        bookMoodRepo.upsert(BookMoodSyncPayload(bookId = id, moodId = "m1", createdAt = 1000L, revision = 0L))
-        collectionBookRepo.upsert(CollectionBookSyncPayload(collectionId = "c1", bookId = id, createdAt = 1000L, revision = 0L))
+        bookMoodRepo.upsert(BookMoodSyncPayload(id = "${id}:m1", bookId = id, moodId = "m1", createdAt = 1000L, revision = 0L))
+        collectionBookRepo.upsert(CollectionBookSyncPayload(id = "c1:${id}", collectionId = "c1", bookId = id, createdAt = 1000L, revision = 0L))
         check(bookTagRepo.findAllForBook(id).size == 1)
         check(bookMoodRepo.findAllForBook(id).size == 1)
         check(collectionBookRepo.findBookIdsForCollection("c1") == listOf(id))

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositorySoftDeleteCascadeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositorySoftDeleteCascadeTest.kt
@@ -55,7 +55,7 @@ class BookRepositorySoftDeleteCascadeTest :
                     // Seed a tag and attach it to book1.
                     tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
                     )
 
                     // Verify junction exists before delete.
@@ -114,10 +114,10 @@ class BookRepositorySoftDeleteCascadeTest :
                     // Attach a mood and a collection membership to book1.
                     moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
                     bookMoodRepo.upsert(
-                        BookMoodSyncPayload(bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
+                        BookMoodSyncPayload(id = "book1:m1", bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
                     )
                     collectionBookRepo.upsert(
-                        CollectionBookSyncPayload(collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
+                        CollectionBookSyncPayload(id = "c1:book1", collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
                     )
 
                     check(collectionBookRepo.findBookIdsForCollection("c1") == listOf("book1"))
@@ -172,10 +172,10 @@ class BookRepositorySoftDeleteCascadeTest :
 
                     moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
                     bookMoodRepo.upsert(
-                        BookMoodSyncPayload(bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
+                        BookMoodSyncPayload(id = "book1:m1", bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
                     )
                     collectionBookRepo.upsert(
-                        CollectionBookSyncPayload(collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
+                        CollectionBookSyncPayload(id = "c1:book1", collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
                     )
 
                     // Remove (tombstones book + its junctions), then re-add (revive) with floor 0.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookSoftDeleteCascadeResumeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookSoftDeleteCascadeResumeTest.kt
@@ -119,10 +119,18 @@ class BookSoftDeleteCascadeResumeTest :
             )
             tagRepo.upsert(Tag(id = tagId, name = tagId, slug = tagId, revision = 0, updatedAt = 0))
             moodRepo.upsert(Mood(id = moodId, name = moodId, slug = moodId, revision = 0, updatedAt = 0))
-            bookTagRepo.upsert(BookTagSyncPayload(id = "${bookId}:${tagId}", bookId = bookId, tagId = tagId, createdAt = 1000L, revision = 0L))
-            bookMoodRepo.upsert(BookMoodSyncPayload(id = "${bookId}:${moodId}", bookId = bookId, moodId = moodId, createdAt = 1000L, revision = 0L))
+            bookTagRepo.upsert(BookTagSyncPayload(id = "$bookId:$tagId", bookId = bookId, tagId = tagId, createdAt = 1000L, revision = 0L))
+            bookMoodRepo.upsert(
+                BookMoodSyncPayload(id = "$bookId:$moodId", bookId = bookId, moodId = moodId, createdAt = 1000L, revision = 0L),
+            )
             collectionBookRepo.upsert(
-                CollectionBookSyncPayload(id = "${collectionId}:${bookId}", collectionId = collectionId, bookId = bookId, createdAt = 1000L, revision = 0L),
+                CollectionBookSyncPayload(
+                    id = "$collectionId:$bookId",
+                    collectionId = collectionId,
+                    bookId = bookId,
+                    createdAt = 1000L,
+                    revision = 0L,
+                ),
             )
         }
 
@@ -385,8 +393,12 @@ class BookSoftDeleteCascadeResumeTest :
                     val graph = CascadeGraph(sql, driver)
                     // t1 linked to book1 AND book2 (both live).
                     graph.tagRepo.upsert(Tag(id = "t1", name = "t1", slug = "t1", revision = 0, updatedAt = 0))
-                    graph.bookTagRepo.upsert(BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L))
-                    graph.bookTagRepo.upsert(BookTagSyncPayload(id = "book2:t1", bookId = "book2", tagId = "t1", createdAt = 1000L, revision = 0L))
+                    graph.bookTagRepo.upsert(
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                    )
+                    graph.bookTagRepo.upsert(
+                        BookTagSyncPayload(id = "book2:t1", bookId = "book2", tagId = "t1", createdAt = 1000L, revision = 0L),
+                    )
                     // The user detached t1 from book1 earlier: book1's junction is tombstoned BEFORE the removal.
                     graph.bookTagRepo.softDeleteAllForBook("book1")
                     graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookSoftDeleteCascadeResumeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookSoftDeleteCascadeResumeTest.kt
@@ -119,10 +119,10 @@ class BookSoftDeleteCascadeResumeTest :
             )
             tagRepo.upsert(Tag(id = tagId, name = tagId, slug = tagId, revision = 0, updatedAt = 0))
             moodRepo.upsert(Mood(id = moodId, name = moodId, slug = moodId, revision = 0, updatedAt = 0))
-            bookTagRepo.upsert(BookTagSyncPayload(bookId = bookId, tagId = tagId, createdAt = 1000L, revision = 0L))
-            bookMoodRepo.upsert(BookMoodSyncPayload(bookId = bookId, moodId = moodId, createdAt = 1000L, revision = 0L))
+            bookTagRepo.upsert(BookTagSyncPayload(id = "${bookId}:${tagId}", bookId = bookId, tagId = tagId, createdAt = 1000L, revision = 0L))
+            bookMoodRepo.upsert(BookMoodSyncPayload(id = "${bookId}:${moodId}", bookId = bookId, moodId = moodId, createdAt = 1000L, revision = 0L))
             collectionBookRepo.upsert(
-                CollectionBookSyncPayload(collectionId = collectionId, bookId = bookId, createdAt = 1000L, revision = 0L),
+                CollectionBookSyncPayload(id = "${collectionId}:${bookId}", collectionId = collectionId, bookId = bookId, createdAt = 1000L, revision = 0L),
             )
         }
 
@@ -385,8 +385,8 @@ class BookSoftDeleteCascadeResumeTest :
                     val graph = CascadeGraph(sql, driver)
                     // t1 linked to book1 AND book2 (both live).
                     graph.tagRepo.upsert(Tag(id = "t1", name = "t1", slug = "t1", revision = 0, updatedAt = 0))
-                    graph.bookTagRepo.upsert(BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L))
-                    graph.bookTagRepo.upsert(BookTagSyncPayload(bookId = "book2", tagId = "t1", createdAt = 1000L, revision = 0L))
+                    graph.bookTagRepo.upsert(BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L))
+                    graph.bookTagRepo.upsert(BookTagSyncPayload(id = "book2:t1", bookId = "book2", tagId = "t1", createdAt = 1000L, revision = 0L))
                     // The user detached t1 from book1 earlier: book1's junction is tombstoned BEFORE the removal.
                     graph.bookTagRepo.softDeleteAllForBook("book1")
                     graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookTagWriterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookTagWriterTest.kt
@@ -108,6 +108,7 @@ class BookTagWriterTest :
                     tagRepository.upsert(favorite) as AppResult.Success
                     bookTagRepository.upsert(
                         BookTagSyncPayload(
+                            id = "book-1:${favorite.id}",
                             bookId = "book-1",
                             tagId = favorite.id,
                             createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityCatchUpAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityCatchUpAccessTest.kt
@@ -178,7 +178,7 @@ private fun aclMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityCatchUpAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityCatchUpAccessTest.kt
@@ -178,6 +178,7 @@ private fun aclMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityFirehoseAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityFirehoseAccessTest.kt
@@ -155,7 +155,7 @@ class ActivityFirehoseAccessTest :
                         ).data.id.value
                     collectionBooks.upsert(
                         CollectionBookSyncPayload(
-                            id = "${allBooksId}:public-book",
+                            id = "$allBooksId:public-book",
                             collectionId = allBooksId,
                             bookId = "public-book",
                             createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityFirehoseAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ActivityFirehoseAccessTest.kt
@@ -135,6 +135,7 @@ class ActivityFirehoseAccessTest :
                     )
                     collectionBooks.upsert(
                         CollectionBookSyncPayload(
+                            id = "alice-private:private-book",
                             collectionId = "alice-private",
                             bookId = "private-book",
                             createdAt = 0L,
@@ -154,6 +155,7 @@ class ActivityFirehoseAccessTest :
                         ).data.id.value
                     collectionBooks.upsert(
                         CollectionBookSyncPayload(
+                            id = "${allBooksId}:public-book",
                             collectionId = allBooksId,
                             bookId = "public-book",
                             createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookCatchUpAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookCatchUpAccessTest.kt
@@ -187,6 +187,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookCatchUpAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookCatchUpAccessTest.kt
@@ -187,7 +187,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookMoodRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookMoodRepositoryTest.kt
@@ -59,7 +59,7 @@ class BookMoodRepositoryTest :
 
                     val result =
                         bookMoodRepo.upsert(
-                            BookMoodSyncPayload(bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
+                            BookMoodSyncPayload(id = "book1:m1", bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
                         )
 
                     result.shouldBeInstanceOf<AppResult.Success<BookMoodSyncPayload>>()
@@ -87,7 +87,7 @@ class BookMoodRepositoryTest :
 
                 runTest {
                     moodRepo.upsert(Mood(id = "m1", name = "Cozy", slug = "cozy", revision = 0, updatedAt = 0))
-                    val payload = BookMoodSyncPayload(bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L)
+                    val payload = BookMoodSyncPayload(id = "book1:m1", bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L)
                     bookMoodRepo.upsert(payload)
                     bookMoodRepo.softDelete("book1", "m1")
 
@@ -114,9 +114,9 @@ class BookMoodRepositoryTest :
                     moodRepo.upsert(Mood("m2", "Cozy", "cozy", 0, 0))
                     moodRepo.upsert(Mood("m3", "Hopeful", "hopeful", 0, 0))
 
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m2", 2000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m3", 3000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m2", "book1", "m2", 2000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m3", "book1", "m3", 3000L, 0L))
                     bookMoodRepo.softDelete("book1", "m3")
 
                     val rows = bookMoodRepo.findAllForBook("book1")
@@ -141,9 +141,9 @@ class BookMoodRepositoryTest :
                 runTest {
                     moodRepo.upsert(Mood("m1", "Tense", "tense", 0, 0))
 
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book2", "m1", 2000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book3", "m1", 3000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book2:m1", "book2", "m1", 2000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book3:m1", "book3", "m1", 3000L, 0L))
                     bookMoodRepo.softDelete("book3", "m1")
 
                     val rows = bookMoodRepo.findAllForMood("m1")
@@ -202,7 +202,7 @@ class BookMoodRepositoryTest :
 
                 runTest {
                     moodRepo.upsert(Mood("m1", "Tense", "tense", 0, 0))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
 
                     val sub = async { bus.subscribe().drop(2).first() }
                     advanceUntilIdle()
@@ -251,9 +251,9 @@ class BookMoodRepositoryTest :
                 runTest {
                     moodRepo.upsert(Mood("m1", "Tense", "tense", 0, 0))
                     moodRepo.upsert(Mood("m2", "Cozy", "cozy", 0, 0))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m2", 2000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book2", "m1", 3000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m2", "book1", "m2", 2000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book2:m1", "book2", "m1", 3000L, 0L))
 
                     val count = bookMoodRepo.softDeleteAllForBook("book1")
                     count shouldBe 2
@@ -277,8 +277,8 @@ class BookMoodRepositoryTest :
                 runTest {
                     moodRepo.upsert(Mood("m1", "Tense", "tense", 0, 0))
                     moodRepo.upsert(Mood("m2", "Cozy", "cozy", 0, 0))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m2", 2000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m2", "book1", "m2", 2000L, 0L))
 
                     // Subscribe before the action; drop the 4 setup events
                     // (2 mood Created + 2 junction Created).
@@ -308,8 +308,8 @@ class BookMoodRepositoryTest :
 
                 runTest {
                     moodRepo.upsert(Mood("m1", "Tense", "tense", 0, 0))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book2", "m1", 2000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book2:m1", "book2", "m1", 2000L, 0L))
 
                     val count = bookMoodRepo.softDeleteAllForMood("m1")
                     count shouldBe 2
@@ -334,9 +334,9 @@ class BookMoodRepositoryTest :
 
                 runTest {
                     moodRepo.upsert(Mood("m1", "Cozy", "cozy", 0, 0))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book2", "m1", 2000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book3", "m1", 3000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book2:m1", "book2", "m1", 2000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book3:m1", "book3", "m1", 3000L, 0L))
                     bookMoodRepo.softDelete("book3", "m1")
 
                     val bookIds = bookMoodRepo.findBookIdsForMood("m1")
@@ -359,8 +359,8 @@ class BookMoodRepositoryTest :
                 runTest {
                     moodRepo.upsert(Mood("m1", "Tense", "tense", 0, 0))
                     moodRepo.upsert(Mood("m2", "Cozy", "cozy", 0, 0))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m2", 2000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m2", "book1", "m2", 2000L, 0L))
 
                     val page = bookMoodRepo.pullSince(userId = null, cursor = 0L, limit = 100)
                     page.items shouldHaveSize 2
@@ -382,7 +382,7 @@ class BookMoodRepositoryTest :
 
                 runTest {
                     moodRepo.upsert(Mood("m1", "Tense", "tense", 0, 0))
-                    bookMoodRepo.upsert(BookMoodSyncPayload("book1", "m1", 1000L, 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload("book1:m1", "book1", "m1", 1000L, 0L))
                     bookMoodRepo.softDelete("book1", "m1")
 
                     val page = bookMoodRepo.pullSince(userId = null, cursor = 0L, limit = 100)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerBulkTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerBulkTest.kt
@@ -384,7 +384,13 @@ class BookSearchReindexerBulkTest :
                         val tagId = "tag$index"
                         tagRepo.upsert(Tag(id = tagId, name = "TagFor$bookId", slug = "tag-for-$bookId", revision = 0, updatedAt = 0))
                         bookTagRepo.upsert(
-                            BookTagSyncPayload(id = "${bookId}:${tagId}", bookId = bookId, tagId = tagId, createdAt = 1000L + index, revision = 0L),
+                            BookTagSyncPayload(
+                                id = "$bookId:$tagId",
+                                bookId = bookId,
+                                tagId = tagId,
+                                createdAt = 1000L + index,
+                                revision = 0L,
+                            ),
                         )
                     }
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerBulkTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerBulkTest.kt
@@ -137,22 +137,22 @@ class BookSearchReindexerBulkTest :
                     tagRepo.upsert(Tag(id = "u3", name = "Unique3", slug = "unique3", revision = 0, updatedAt = 0))
 
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "shared", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:shared", bookId = "book1", tagId = "shared", createdAt = 1000L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "u1", createdAt = 1001L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:u1", bookId = "book1", tagId = "u1", createdAt = 1001L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book2", tagId = "shared", createdAt = 1002L, revision = 0L),
+                        BookTagSyncPayload(id = "book2:shared", bookId = "book2", tagId = "shared", createdAt = 1002L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book2", tagId = "u2", createdAt = 1003L, revision = 0L),
+                        BookTagSyncPayload(id = "book2:u2", bookId = "book2", tagId = "u2", createdAt = 1003L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book3", tagId = "shared", createdAt = 1004L, revision = 0L),
+                        BookTagSyncPayload(id = "book3:shared", bookId = "book3", tagId = "shared", createdAt = 1004L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book3", tagId = "u3", createdAt = 1005L, revision = 0L),
+                        BookTagSyncPayload(id = "book3:u3", bookId = "book3", tagId = "u3", createdAt = 1005L, revision = 0L),
                     )
 
                     reindexer.reindexAllBooksForTag("shared")
@@ -195,13 +195,13 @@ class BookSearchReindexerBulkTest :
 
                     tagRepo.upsert(Tag(id = "shared", name = "Shared", slug = "shared", revision = 0, updatedAt = 0))
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "shared", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:shared", bookId = "book1", tagId = "shared", createdAt = 1000L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book2", tagId = "shared", createdAt = 1001L, revision = 0L),
+                        BookTagSyncPayload(id = "book2:shared", bookId = "book2", tagId = "shared", createdAt = 1001L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book3", tagId = "shared", createdAt = 1002L, revision = 0L),
+                        BookTagSyncPayload(id = "book3:shared", bookId = "book3", tagId = "shared", createdAt = 1002L, revision = 0L),
                     )
 
                     // Should complete without throwing despite book3 having no map row.
@@ -234,20 +234,20 @@ class BookSearchReindexerBulkTest :
 
                     // book1: tombstoned junction to a live tag.
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "dead1", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:dead1", bookId = "book1", tagId = "dead1", createdAt = 1000L, revision = 0L),
                     )
                     bookTagRepo.softDelete(bookId = "book1", tagId = "dead1")
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "shared", createdAt = 1001L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:shared", bookId = "book1", tagId = "shared", createdAt = 1001L, revision = 0L),
                     )
 
                     // book2: live junction to a tombstoned tag.
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book2", tagId = "dead2", createdAt = 1002L, revision = 0L),
+                        BookTagSyncPayload(id = "book2:dead2", bookId = "book2", tagId = "dead2", createdAt = 1002L, revision = 0L),
                     )
                     tagRepo.softDelete("dead2")
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book2", tagId = "shared", createdAt = 1003L, revision = 0L),
+                        BookTagSyncPayload(id = "book2:shared", bookId = "book2", tagId = "shared", createdAt = 1003L, revision = 0L),
                     )
 
                     reindexer.reindexAllBooksForTag("shared")
@@ -384,7 +384,7 @@ class BookSearchReindexerBulkTest :
                         val tagId = "tag$index"
                         tagRepo.upsert(Tag(id = tagId, name = "TagFor$bookId", slug = "tag-for-$bookId", revision = 0, updatedAt = 0))
                         bookTagRepo.upsert(
-                            BookTagSyncPayload(bookId = bookId, tagId = tagId, createdAt = 1000L + index, revision = 0L),
+                            BookTagSyncPayload(id = "${bookId}:${tagId}", bookId = bookId, tagId = tagId, createdAt = 1000L + index, revision = 0L),
                         )
                     }
 
@@ -417,10 +417,10 @@ class BookSearchReindexerBulkTest :
                     tagRepo.upsert(Tag(id = "t1", name = "AlphaTag", slug = "alpha-tag", revision = 0, updatedAt = 0))
                     tagRepo.upsert(Tag(id = "t2", name = "BetaTag", slug = "beta-tag", revision = 0, updatedAt = 0))
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book2", tagId = "t2", createdAt = 1001L, revision = 0L),
+                        BookTagSyncPayload(id = "book2:t2", bookId = "book2", tagId = "t2", createdAt = 1001L, revision = 0L),
                     )
 
                     reindexer.reindexBooks(listOf("book1", "book2"))

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerTest.kt
@@ -133,10 +133,10 @@ class BookSearchReindexerTest :
                     tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
                     tagRepo.upsert(Tag(id = "t2", name = "Fantasy", slug = "fantasy", revision = 0, updatedAt = 0))
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "t2", createdAt = 1001L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:t2", bookId = "book1", tagId = "t2", createdAt = 1001L, revision = 0L),
                     )
 
                     reindexer.reindexBook("book1")
@@ -186,7 +186,7 @@ class BookSearchReindexerTest :
 
                     tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
                     )
                     // Soft-delete the junction.
                     bookTagRepo.softDelete(bookId = "book1", tagId = "t1")
@@ -214,7 +214,7 @@ class BookSearchReindexerTest :
 
                     tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
                     )
                     // Soft-delete the tag itself (junction is still live).
                     tagRepo.softDelete("t1")
@@ -244,10 +244,10 @@ class BookSearchReindexerTest :
 
                     tagRepo.upsert(Tag(id = "t1", name = "SciFi", slug = "scifi", revision = 0, updatedAt = 0))
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                        BookTagSyncPayload(id = "book1:t1", bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
                     )
                     bookTagRepo.upsert(
-                        BookTagSyncPayload(bookId = "book2", tagId = "t1", createdAt = 1001L, revision = 0L),
+                        BookTagSyncPayload(id = "book2:t1", bookId = "book2", tagId = "t1", createdAt = 1001L, revision = 0L),
                     )
 
                     reindexer.reindexAllBooksForTag("t1")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookTagRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookTagRepositoryTest.kt
@@ -58,7 +58,7 @@ class BookTagRepositoryTest :
 
                     val result =
                         bookTagRepo.upsert(
-                            BookTagSyncPayload(bookId = "book1", tagId = "tag1", createdAt = 1000L, revision = 0L),
+                            BookTagSyncPayload(id = "book1:tag1", bookId = "book1", tagId = "tag1", createdAt = 1000L, revision = 0L),
                         )
 
                     result.shouldBeInstanceOf<AppResult.Success<BookTagSyncPayload>>()
@@ -86,7 +86,7 @@ class BookTagRepositoryTest :
 
                 runTest {
                     tagRepo.upsert(Tag(id = "tag1", name = "Fantasy", slug = "fantasy", revision = 0, updatedAt = 0))
-                    val payload = BookTagSyncPayload(bookId = "book1", tagId = "tag1", createdAt = 1000L, revision = 0L)
+                    val payload = BookTagSyncPayload(id = "book1:tag1", bookId = "book1", tagId = "tag1", createdAt = 1000L, revision = 0L)
                     bookTagRepo.upsert(payload)
                     bookTagRepo.softDelete("book1", "tag1")
 
@@ -113,9 +113,9 @@ class BookTagRepositoryTest :
                     tagRepo.upsert(Tag("t2", "Fantasy", "fantasy", 0, 0))
                     tagRepo.upsert(Tag("t3", "Mystery", "mystery", 0, 0))
 
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t2", 2000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t3", 3000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t2", "book1", "t2", 2000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t3", "book1", "t3", 3000L, 0L))
                     bookTagRepo.softDelete("book1", "t3")
 
                     val rows = bookTagRepo.findAllForBook("book1")
@@ -139,9 +139,9 @@ class BookTagRepositoryTest :
                 runTest {
                     tagRepo.upsert(Tag("t1", "Sci-Fi", "sci-fi", 0, 0))
 
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book2", "t1", 2000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book3", "t1", 3000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book2:t1", "book2", "t1", 2000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book3:t1", "book3", "t1", 3000L, 0L))
                     bookTagRepo.softDelete("book3", "t1")
 
                     val rows = bookTagRepo.findAllForTag("t1")
@@ -163,8 +163,8 @@ class BookTagRepositoryTest :
 
                 runTest {
                     tagRepo.upsert(Tag("t1", "Sci-Fi", "sci-fi", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book2", "t1", 2000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book2:t1", "book2", "t1", 2000L, 0L))
 
                     val rows = bookTagRepo.findAllForBook("book1")
                     rows shouldHaveSize 1
@@ -186,7 +186,7 @@ class BookTagRepositoryTest :
 
                 runTest {
                     tagRepo.upsert(Tag("t1", "Sci-Fi", "sci-fi", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
 
                     val sub = async { bus.subscribe().drop(2).first() }
                     advanceUntilIdle()
@@ -233,9 +233,9 @@ class BookTagRepositoryTest :
                 runTest {
                     tagRepo.upsert(Tag("t1", "Sci-Fi", "sci-fi", 0, 0))
                     tagRepo.upsert(Tag("t2", "Fantasy", "fantasy", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t2", 2000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book2", "t1", 3000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t2", "book1", "t2", 2000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book2:t1", "book2", "t1", 3000L, 0L))
 
                     val count = bookTagRepo.softDeleteAllForBook("book1")
                     count shouldBe 2
@@ -259,8 +259,8 @@ class BookTagRepositoryTest :
                 runTest {
                     tagRepo.upsert(Tag("t1", "Sci-Fi", "sci-fi", 0, 0))
                     tagRepo.upsert(Tag("t2", "Fantasy", "fantasy", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t2", 2000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t2", "book1", "t2", 2000L, 0L))
 
                     // Subscribe before the action; drop the 4 setup events
                     // (2 tag Created + 2 junction Created)
@@ -291,8 +291,8 @@ class BookTagRepositoryTest :
 
                 runTest {
                     tagRepo.upsert(Tag("t1", "Sci-Fi", "sci-fi", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book2", "t1", 2000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book2:t1", "book2", "t1", 2000L, 0L))
 
                     val count = bookTagRepo.softDeleteAllForTag("t1")
                     count shouldBe 2
@@ -317,9 +317,9 @@ class BookTagRepositoryTest :
 
                 runTest {
                     tagRepo.upsert(Tag("t1", "Fantasy", "fantasy", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book2", "t1", 2000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book3", "t1", 3000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book2:t1", "book2", "t1", 2000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book3:t1", "book3", "t1", 3000L, 0L))
                     bookTagRepo.softDelete("book3", "t1")
 
                     val bookIds = bookTagRepo.findBookIdsForTag("t1")
@@ -345,8 +345,8 @@ class BookTagRepositoryTest :
                 runTest {
                     tagRepo.upsert(Tag("manual", "Manual", "manual", 0, 0))
                     tagRepo.upsert(Tag("folder", "Folder", "folder", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "manual", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "folder", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:manual", "book1", "manual", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:folder", "book1", "folder", 1000L, 0L))
 
                     // The user removes the "manual" tag BEFORE the folder is removed — an older tombstone.
                     clock.set(Instant.fromEpochMilliseconds(5_000L))
@@ -381,8 +381,8 @@ class BookTagRepositoryTest :
                 runTest {
                     tagRepo.upsert(Tag("t1", "Sci-Fi", "sci-fi", 0, 0))
                     tagRepo.upsert(Tag("t2", "Fantasy", "fantasy", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t2", 2000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t2", "book1", "t2", 2000L, 0L))
 
                     val page = bookTagRepo.pullSince(userId = null, cursor = 0L, limit = 100)
                     page.items shouldHaveSize 2
@@ -405,7 +405,7 @@ class BookTagRepositoryTest :
 
                 runTest {
                     tagRepo.upsert(Tag("t1", "Sci-Fi", "sci-fi", 0, 0))
-                    bookTagRepo.upsert(BookTagSyncPayload("book1", "t1", 1000L, 0L))
+                    bookTagRepo.upsert(BookTagSyncPayload("book1:t1", "book1", "t1", 1000L, 0L))
                     bookTagRepo.softDelete("book1", "t1")
 
                     val page = bookTagRepo.pullSince(userId = null, cursor = 0L, limit = 100)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BooksDigestRouteAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BooksDigestRouteAccessTest.kt
@@ -184,6 +184,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BooksDigestRouteAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BooksDigestRouteAccessTest.kt
@@ -184,7 +184,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionBooksFirehoseAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionBooksFirehoseAccessTest.kt
@@ -1,0 +1,193 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.activity.ActivityType
+import com.calypsan.listenup.api.dto.auth.AuthSession
+import com.calypsan.listenup.api.dto.auth.LoginRequest
+import com.calypsan.listenup.api.dto.auth.RegisterRequest
+import com.calypsan.listenup.api.dto.auth.RegisterResult
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.CollectionSyncPayload
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.module
+import com.calypsan.listenup.server.services.ActivityRecorder
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.useIsolatedTestConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import io.ktor.sse.ServerSentEvent
+import java.nio.file.Files
+import kotlin.time.Duration.Companion.minutes
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
+import org.koin.ktor.ext.inject
+
+/**
+ * Firehose ACL proof for the `collection_books` domain, post-SERVER-SYNC-04: [isCollectionEventHidden]
+ * must gate a live Created/Updated event by the payload's `collectionId`, never by parsing the
+ * event's wire `id` — which is now an opaque per-row value (SERVER-SYNC-04), not the
+ * `"$collectionId:$bookId"` composite the old `CollectionBookId.fromString` parse assumed.
+ *
+ * Before the fix, a Created event for an opaque-id junction row would either crash
+ * `isCollectionEventHidden` (the parsed "id" has no `:`) or, worse, silently misroute access —
+ * either way the gate could not be trusted. Mirrors [ActivityFirehoseAccessTest]'s shape: both
+ * viewers subscribe to the firehose FIRST (live-tail semantics), then the owner adds a book to a
+ * private collection; a trailing sentinel bounds each collector.
+ */
+class CollectionBooksFirehoseAccessTest :
+    FunSpec({
+
+        val sentinelMarker = "SENTINEL-cb-firehose"
+
+        suspend fun HttpClient.setupRoot(): Pair<String, String> {
+            val session =
+                post("/api/v1/auth/setup") {
+                    contentType(ContentType.Application.Json)
+                    setBody(RegisterRequest("owner@cb-firehose.example", "x".repeat(8), "Owner"))
+                }.body<AppResult<AuthSession>>()
+                    .shouldBeInstanceOf<AppResult.Success<AuthSession>>()
+                    .data
+            return session.user.id.value to session.accessToken.value
+        }
+
+        suspend fun HttpClient.registerMemberToken(): String {
+            post("/api/v1/auth/register") {
+                contentType(ContentType.Application.Json)
+                setBody(RegisterRequest("member@cb-firehose.example", "y".repeat(8), "Member"))
+            }.body<AppResult<RegisterResult>>()
+                .shouldBeInstanceOf<AppResult.Success<RegisterResult>>()
+            val session =
+                post("/api/v1/auth/login") {
+                    contentType(ContentType.Application.Json)
+                    setBody(LoginRequest("member@cb-firehose.example", "y".repeat(8)))
+                }.body<AppResult<AuthSession>>()
+                    .shouldBeInstanceOf<AppResult.Success<AuthSession>>()
+                    .data
+            return session.accessToken.value
+        }
+
+        test(
+            "firehose withholds a private collection_books Created event (opaque id) from a non-member, delivers to the owner",
+        ).config(timeout = 2.minutes) {
+            val libraryRoot = Files.createTempDirectory("listenup-cb-firehose-acl-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString())
+                    application { module() }
+
+                    val restClient = createClient { install(ContentNegotiation) { json(contractJson) } }
+                    val (ownerId, ownerToken) = restClient.setupRoot()
+                    val memberToken = restClient.registerMemberToken()
+
+                    seedTestLibraryAndFolder()
+                    val sql by application.inject<ListenUpDatabase>()
+                    sql.seedTestBook("private-book")
+
+                    val collections by application.inject<CollectionRepository>()
+                    val collectionBooks by application.inject<CollectionBookRepository>()
+                    collections.upsert(
+                        CollectionSyncPayload(
+                            id = "owner-private",
+                            libraryId = "test-library",
+                            ownerId = ownerId,
+                            name = "owner-private",
+                            isInbox = false,
+                            revision = 0L,
+                            updatedAt = 0L,
+                        ),
+                    )
+
+                    val recorder by application.inject<ActivityRecorder>()
+
+                    val memberEvents = mutableListOf<ServerSentEvent>()
+                    val ownerEvents = mutableListOf<ServerSentEvent>()
+
+                    val sseClient =
+                        createClient {
+                            install(ContentNegotiation) { json(contractJson) }
+                            install(SSE)
+                        }
+
+                    // Both viewers subscribe FIRST (live-tail semantics), then the owner adds the book —
+                    // a fresh, server-minted opaque id (SERVER-SYNC-04), never a "$collectionId:$bookId"
+                    // composite — exercising the exact shape isCollectionEventHidden must now handle.
+                    // The sentinel is a non-book activity (ungated, per ActivityFirehoseAccessTest) —
+                    // it bounds both collectors without depending on a collection the member could see.
+                    sseClient.sse(urlString = "/api/v1/sync/events", request = { bearerAuth(memberToken) }) {
+                        val memberIncoming = incoming
+                        coroutineScope {
+                            val memberDone =
+                                async {
+                                    memberIncoming
+                                        .filter { it.event == "collection_books" || it.event == "activities" }
+                                        .onEach { memberEvents += it }
+                                        .first { it.data?.contains(sentinelMarker) == true }
+                                }
+
+                            sseClient.sse(urlString = "/api/v1/sync/events", request = { bearerAuth(ownerToken) }) {
+                                val ownerIncoming = incoming
+                                coroutineScope {
+                                    val ownerDone =
+                                        async {
+                                            ownerIncoming
+                                                .filter { it.event == "collection_books" || it.event == "activities" }
+                                                .onEach { ownerEvents += it }
+                                                .first { it.data?.contains(sentinelMarker) == true }
+                                        }
+
+                                    collectionBooks.upsert(
+                                        CollectionBookSyncPayload(
+                                            id = Uuid.random().toString(),
+                                            collectionId = "owner-private",
+                                            bookId = "private-book",
+                                            createdAt = 0L,
+                                            revision = 0L,
+                                        ),
+                                    )
+                                    recorder.record(
+                                        ownerId,
+                                        ActivityType.SHELF_CREATED,
+                                        shelfId = "sentinel",
+                                        shelfName = sentinelMarker,
+                                    )
+
+                                    ownerDone.await()
+                                }
+                            }
+
+                            memberDone.await()
+                        }
+                    }
+
+                    // Member: never sees the private junction row, but does see the public sentinel rename.
+                    memberEvents.none { it.data!!.contains("private-book") } shouldBe true
+                    memberEvents.any { it.data!!.contains(sentinelMarker) } shouldBe true
+
+                    // Owner: sees both — the private junction Created event and the sentinel.
+                    ownerEvents.any { it.data!!.contains("private-book") } shouldBe true
+                    ownerEvents.any { it.data!!.contains(sentinelMarker) } shouldBe true
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionIdsAllowlistTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionIdsAllowlistTest.kt
@@ -125,6 +125,7 @@ private fun membershipFixture(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionIdsAllowlistTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionIdsAllowlistTest.kt
@@ -125,7 +125,7 @@ private fun membershipFixture(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionRepositoryTest.kt
@@ -337,6 +337,7 @@ class CollectionRepositoryTest :
                     )
                     junctionRepo.upsert(
                         CollectionBookSyncPayload(
+                            id = "col1:book1",
                             collectionId = "col1",
                             bookId = "book1",
                             createdAt = 1000L,
@@ -386,6 +387,7 @@ class CollectionRepositoryTest :
                     )
                     junctionRepo.upsert(
                         CollectionBookSyncPayload(
+                            id = "col1:book1",
                             collectionId = "col1",
                             bookId = "book1",
                             createdAt = 1000L,
@@ -434,10 +436,10 @@ class CollectionRepositoryTest :
                         ),
                     )
                     junctionRepo.upsert(
-                        CollectionBookSyncPayload("col1", "book1", 1000L, 0L),
+                        CollectionBookSyncPayload("col1:book1", "col1", "book1", 1000L, 0L),
                     )
                     junctionRepo.upsert(
-                        CollectionBookSyncPayload("col1", "book2", 2000L, 0L),
+                        CollectionBookSyncPayload("col1:book2", "col1", "book2", 2000L, 0L),
                     )
 
                     junctionRepo.countLiveForCollection("col1") shouldBe 2L
@@ -482,8 +484,8 @@ class CollectionRepositoryTest :
                             updatedAt = 0L,
                         ),
                     )
-                    junctionRepo.upsert(CollectionBookSyncPayload("col1", "book1", 1000L, 0L))
-                    junctionRepo.upsert(CollectionBookSyncPayload("col1", "book2", 2000L, 0L))
+                    junctionRepo.upsert(CollectionBookSyncPayload("col1:book1", "col1", "book1", 1000L, 0L))
+                    junctionRepo.upsert(CollectionBookSyncPayload("col1:book2", "col1", "book2", 2000L, 0L))
 
                     val count = junctionRepo.softDeleteAllForCollection("col1")
                     count shouldBe 2

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionRowVisibilityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionRowVisibilityTest.kt
@@ -282,7 +282,7 @@ private fun membershipFixture(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionRowVisibilityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/CollectionRowVisibilityTest.kt
@@ -282,6 +282,7 @@ private fun membershipFixture(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/LibraryFolderSyncAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/LibraryFolderSyncAccessTest.kt
@@ -197,7 +197,7 @@ private suspend fun ApplicationTestBuilder.makeBookPublic(bookId: String) {
         collectionService.getOrCreateSystemCollection(libraryId, SystemCollectionType.ALL_BOOKS) as AppResult.Success
     require(
         collectionBookRepo.upsert(
-            CollectionBookSyncPayload(collectionId = allBooks.data.id.value, bookId = bookId, createdAt = 0L, revision = 0L),
+            CollectionBookSyncPayload(id = "${allBooks.data.id.value}:${bookId}", collectionId = allBooks.data.id.value, bookId = bookId, createdAt = 0L, revision = 0L),
         ) is AppResult.Success,
     ) { "failed to add $bookId to ALL_BOOKS" }
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/LibraryFolderSyncAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/LibraryFolderSyncAccessTest.kt
@@ -197,7 +197,13 @@ private suspend fun ApplicationTestBuilder.makeBookPublic(bookId: String) {
         collectionService.getOrCreateSystemCollection(libraryId, SystemCollectionType.ALL_BOOKS) as AppResult.Success
     require(
         collectionBookRepo.upsert(
-            CollectionBookSyncPayload(id = "${allBooks.data.id.value}:${bookId}", collectionId = allBooks.data.id.value, bookId = bookId, createdAt = 0L, revision = 0L),
+            CollectionBookSyncPayload(
+                id = "${allBooks.data.id.value}:$bookId",
+                collectionId = allBooks.data.id.value,
+                bookId = bookId,
+                createdAt = 0L,
+                revision = 0L,
+            ),
         ) is AppResult.Success,
     ) { "failed to add $bookId to ALL_BOOKS" }
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/OpaqueJunctionIdTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/OpaqueJunctionIdTest.kt
@@ -1,0 +1,182 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.BookMoodSyncPayload
+import com.calypsan.listenup.api.sync.BookTagSyncPayload
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.CollectionSyncPayload
+import com.calypsan.listenup.api.sync.Mood
+import com.calypsan.listenup.api.sync.ShelfBookSyncPayload
+import com.calypsan.listenup.api.sync.ShelfSyncPayload
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.coroutines.test.runTest
+import kotlin.uuid.Uuid
+
+/**
+ * Regression proof for SERVER-SYNC-04: a server-minted junction row's `id` column must be an
+ * opaque value that encodes neither half of the natural pair — the fix that stops an ungated
+ * tombstone from leaking the association it protects. One test per junction domain
+ * (`collection_books`, `book_tags`, `book_moods`, `shelf_books`).
+ *
+ * Each test mints the id at the call site (`Uuid.random().toString()`) exactly as the real
+ * server-originated call sites do (`CollectionServiceImpl`, `TagServiceImpl`, `MoodServiceImpl`,
+ * `ShelfBookRepository.addBook`, scan-time writers) — the repository's `upsert` never mints on
+ * the caller's behalf (see `idAsString`'s KDoc for why) — and asserts the persisted row's `id`
+ * is non-blank, contains neither natural-key value, and contains no `:` (the tell-tale of the
+ * old composite scheme).
+ */
+class OpaqueJunctionIdTest :
+    FunSpec({
+
+        test("a server-minted collection_books row gets an id that encodes neither collectionId nor bookId") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book-1")
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val collectionRepo = CollectionRepository(db = sql, bus = bus, registry = registry, driver = driver)
+                val collectionBookRepo = CollectionBookRepository(db = sql, bus = bus, registry = registry, driver = driver)
+
+                runTest {
+                    collectionRepo.upsert(
+                        CollectionSyncPayload(
+                            id = "col-1",
+                            libraryId = "test-library",
+                            ownerId = "owner",
+                            name = "Collection",
+                            revision = 0L,
+                            updatedAt = 0L,
+                        ),
+                    )
+                    collectionBookRepo.upsert(
+                        CollectionBookSyncPayload(
+                            id = Uuid.random().toString(),
+                            collectionId = "col-1",
+                            bookId = "book-1",
+                            createdAt = 0L,
+                            revision = 0L,
+                        ),
+                    )
+
+                    val row = sql.collectionBooksQueries.selectLiveByCollectionAndBook("col-1", "book-1").executeAsOne()
+                    row.id shouldNotContain "col-1"
+                    row.id shouldNotContain "book-1"
+                    row.id shouldNotContain ":"
+                    row.id.isBlank() shouldBe false
+                }
+            }
+        }
+
+        test("a server-minted book_tags row gets an id that encodes neither bookId nor tagId") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book-1")
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+
+                runTest {
+                    tagRepo.upsert(Tag(id = "tag-1", name = "Sci-Fi", slug = "sci-fi", revision = 0L, updatedAt = 0L))
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(
+                            id = Uuid.random().toString(),
+                            bookId = "book-1",
+                            tagId = "tag-1",
+                            createdAt = 0L,
+                            revision = 0L,
+                        ),
+                    )
+
+                    val row = sql.bookTagsQueries.selectByBookId("book-1").executeAsOne()
+                    row.id shouldNotContain "book-1"
+                    row.id shouldNotContain "tag-1"
+                    row.id shouldNotContain ":"
+                    row.id.isBlank() shouldBe false
+                }
+            }
+        }
+
+        test("a server-minted book_moods row gets an id that encodes neither bookId nor moodId") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book-1")
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val moodRepo = MoodRepository(db = sql, bus = bus, registry = registry)
+                val bookMoodRepo = BookMoodRepository(db = sql, bus = bus, registry = registry)
+
+                runTest {
+                    moodRepo.upsert(Mood(id = "mood-1", name = "Feel-Good", slug = "feel-good", revision = 0L, updatedAt = 0L))
+                    bookMoodRepo.upsert(
+                        BookMoodSyncPayload(
+                            id = Uuid.random().toString(),
+                            bookId = "book-1",
+                            moodId = "mood-1",
+                            createdAt = 0L,
+                            revision = 0L,
+                        ),
+                    )
+
+                    val row = sql.bookMoodsQueries.selectByBookId("book-1").executeAsOne()
+                    row.id shouldNotContain "book-1"
+                    row.id shouldNotContain "mood-1"
+                    row.id shouldNotContain ":"
+                    row.id.isBlank() shouldBe false
+                }
+            }
+        }
+
+        test("a server-minted shelf_books row gets an id that encodes neither shelfId nor bookId") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("owner")
+                sql.seedTestBook("book-1")
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val shelfRepo = ShelfRepository(db = sql, bus = bus, registry = registry)
+                val shelfBookRepo = ShelfBookRepository(db = sql, bus = bus, registry = registry)
+
+                runTest {
+                    shelfRepo.upsert(
+                        ShelfSyncPayload(
+                            id = "shelf-1",
+                            name = "To Read",
+                            description = "",
+                            isPrivate = false,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            createdAt = 0L,
+                        ),
+                        userId = "owner",
+                    )
+                    shelfBookRepo.upsert(
+                        ShelfBookSyncPayload(
+                            id = Uuid.random().toString(),
+                            shelfId = "shelf-1",
+                            bookId = "book-1",
+                            sortOrder = 0,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            createdAt = 0L,
+                        ),
+                        userId = "owner",
+                    )
+
+                    val row = sql.shelfBooksQueries.selectByShelf("shelf-1").executeAsOne()
+                    row.id shouldNotContain "shelf-1"
+                    row.id shouldNotContain "book-1"
+                    row.id shouldNotContain ":"
+                    row.id.isBlank() shouldBe false
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/PullByIdsAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/PullByIdsAccessTest.kt
@@ -260,7 +260,7 @@ private fun pbiMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/PullByIdsAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/PullByIdsAccessTest.kt
@@ -260,6 +260,7 @@ private fun pbiMembership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ShelfRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/ShelfRepositoryTest.kt
@@ -145,9 +145,11 @@ class ShelfRepositoryTest :
                     shelfRepo.upsert(shelfPayload("shelfA"), userId = "userA")
                     junctionRepo.addBook("shelfA", "book1", "userA")
 
+                    // The junction's wire id is opaque (SERVER-SYNC-04) — select by shelf,
+                    // not by a hardcoded "shelfId:bookId" string.
                     val storedUserId =
                         sql.shelfBooksQueries
-                            .selectById("shelfA:book1")
+                            .selectByShelf("shelfA")
                             .executeAsOne()
                             .user_id
                     storedUserId shouldBe "userA"

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SystemCollectionSyncExclusionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SystemCollectionSyncExclusionTest.kt
@@ -256,7 +256,7 @@ private fun membershipFixture(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = "$collectionId:$bookId",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SystemCollectionSyncExclusionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SystemCollectionSyncExclusionTest.kt
@@ -256,6 +256,7 @@ private fun membershipFixture(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/TombstonePayloadMinimizationTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/TombstonePayloadMinimizationTest.kt
@@ -24,11 +24,20 @@ import com.calypsan.listenup.server.testing.seedTestBook
 import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
 import com.calypsan.listenup.server.testing.seedTestUser
 import com.calypsan.listenup.server.testing.withSqlDatabase
+import com.calypsan.listenup.api.sync.BookMoodSyncPayload
+import com.calypsan.listenup.api.sync.BookTagSyncPayload
+import com.calypsan.listenup.api.sync.Mood
+import com.calypsan.listenup.api.sync.ShelfBookSyncPayload
+import com.calypsan.listenup.api.sync.ShelfSyncPayload
+import com.calypsan.listenup.api.sync.Tag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.test.runTest
+import kotlin.uuid.Uuid
 
 /**
  * Reproduction + regression proof for plan 087: a tombstone delivered on the access-filtered pull
@@ -323,7 +332,7 @@ class TombstonePayloadMinimizationTest :
             }
         }
 
-        test("collection_books tombstone keeps its junction identity (no minimization for this domain)") {
+        test("collection_books tombstone ships only the opaque id — the pair is blanked") {
             withSqlDatabase {
                 sql.seedTestLibraryAndFolder()
                 sql.seedTestUser("member")
@@ -337,14 +346,118 @@ class TombstonePayloadMinimizationTest :
                     val extra = f.policy.accessibleCollectionBookIdsSql("member", UserRole.MEMBER)
                     val page = f.collectionBookRepo.pullSince("member", cursor = 0L, limit = 100, extraWhere = extra)
 
-                    val tomb =
-                        page.items
-                            .firstOrNull { it.collectionId == "private-col" && it.bookId == "some-book" }
-                            .shouldNotBeNull()
-                    // The client applies the junction tombstone by (collectionId, bookId) — identity must survive.
-                    tomb.deletedAt shouldNotBe null
-                    tomb.collectionId shouldBe "private-col"
-                    tomb.bookId shouldBe "some-book"
+                    val tomb = page.items.firstOrNull { it.deletedAt != null }.shouldNotBeNull()
+                    tomb.deletedAt.shouldNotBeNull()
+                    tomb.id.shouldNotBeEmpty()
+                    tomb.id shouldNotContain ":"
+                    tomb.collectionId shouldBe ""
+                    tomb.bookId shouldBe ""
+                }
+            }
+        }
+
+        test("book_tags tombstone ships only the opaque id — the pair is blanked") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("some-book")
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                runTest {
+                    tagRepo.upsert(Tag(id = "some-tag", name = "Sci-Fi", slug = "sci-fi", revision = 0L, updatedAt = 0L))
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(
+                            id = Uuid.random().toString(),
+                            bookId = "some-book",
+                            tagId = "some-tag",
+                            createdAt = 0L,
+                            revision = 0L,
+                        ),
+                    )
+                    bookTagRepo.softDelete("some-book", "some-tag")
+
+                    // book_tags is an ungated global domain — pullSince takes no access filter.
+                    val page = bookTagRepo.pullSince(userId = null, cursor = 0L, limit = 100, extraWhere = null)
+
+                    val tomb = page.items.firstOrNull { it.deletedAt != null }.shouldNotBeNull()
+                    tomb.deletedAt.shouldNotBeNull()
+                    tomb.id.shouldNotBeEmpty()
+                    tomb.id shouldNotContain ":"
+                    tomb.bookId shouldBe ""
+                    tomb.tagId shouldBe ""
+                }
+            }
+        }
+
+        test("book_moods tombstone ships only the opaque id — the pair is blanked") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("some-book")
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val moodRepo = MoodRepository(db = sql, bus = bus, registry = registry)
+                val bookMoodRepo = BookMoodRepository(db = sql, bus = bus, registry = registry)
+                runTest {
+                    moodRepo.upsert(Mood(id = "some-mood", name = "Feel-Good", slug = "feel-good", revision = 0L, updatedAt = 0L))
+                    bookMoodRepo.upsert(
+                        BookMoodSyncPayload(
+                            id = Uuid.random().toString(),
+                            bookId = "some-book",
+                            moodId = "some-mood",
+                            createdAt = 0L,
+                            revision = 0L,
+                        ),
+                    )
+                    bookMoodRepo.softDelete("some-book", "some-mood")
+
+                    // book_moods is an ungated global domain — pullSince takes no access filter.
+                    val page = bookMoodRepo.pullSince(userId = null, cursor = 0L, limit = 100, extraWhere = null)
+
+                    val tomb = page.items.firstOrNull { it.deletedAt != null }.shouldNotBeNull()
+                    tomb.deletedAt.shouldNotBeNull()
+                    tomb.id.shouldNotBeEmpty()
+                    tomb.id shouldNotContain ":"
+                    tomb.bookId shouldBe ""
+                    tomb.moodId shouldBe ""
+                }
+            }
+        }
+
+        test("shelf_books tombstone ships only the opaque id — the pair is blanked") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("owner")
+                sql.seedTestBook("some-book")
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val shelfRepo = ShelfRepository(db = sql, bus = bus, registry = registry)
+                val shelfBookRepo = ShelfBookRepository(db = sql, bus = bus, registry = registry)
+                runTest {
+                    shelfRepo.upsert(
+                        ShelfSyncPayload(
+                            id = "some-shelf",
+                            name = "To Read",
+                            description = "",
+                            isPrivate = false,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            createdAt = 0L,
+                        ),
+                        userId = "owner",
+                    )
+                    shelfBookRepo.addBook("some-shelf", "some-book", "owner")
+                    shelfBookRepo.removeBook("some-shelf", "some-book", "owner")
+
+                    // shelf_books is userScoped — pullSince routes through the *ForUser substrate.
+                    val page = shelfBookRepo.pullSince(userId = "owner", cursor = 0L, limit = 100, extraWhere = null)
+
+                    val tomb = page.items.firstOrNull { it.deletedAt != null }.shouldNotBeNull()
+                    tomb.deletedAt.shouldNotBeNull()
+                    tomb.id.shouldNotBeEmpty()
+                    tomb.id shouldNotContain ":"
+                    tomb.shelfId shouldBe ""
+                    tomb.bookId shouldBe ""
                 }
             }
         }
@@ -379,7 +492,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
-        id = "${collectionId}:${bookId}",
+        id = Uuid.random().toString(),
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/TombstonePayloadMinimizationTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/TombstonePayloadMinimizationTest.kt
@@ -379,6 +379,7 @@ private fun membership(
     bookId: String,
 ): CollectionBookSyncPayload =
     CollectionBookSyncPayload(
+        id = "${collectionId}:${bookId}",
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,

--- a/sharedLogic/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/2.json
+++ b/sharedLogic/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/2.json
@@ -1,0 +1,2815 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "3763a221723426afe01262312540104f",
+    "entities": [
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `firstName` TEXT, `lastName` TEXT, `isRoot` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `tagline` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isRoot",
+            "columnName": "isRoot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `metadataPrecedence` TEXT NOT NULL, `accessMode` TEXT NOT NULL, `createdByUserId` TEXT, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `initialScanCompletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataPrecedence",
+            "columnName": "metadataPrecedence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessMode",
+            "columnName": "accessMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdByUserId",
+            "columnName": "createdByUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "initialScanCompletedAt",
+            "columnName": "initialScanCompletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `rootPath` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`libraryId`) REFERENCES `libraries`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootPath",
+            "columnName": "rootPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_folders_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_folders_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "libraries",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "libraryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `folderId` TEXT NOT NULL, `title` TEXT NOT NULL, `sortTitle` TEXT, `subtitle` TEXT, `coverHash` TEXT, `coverDownloadedAt` INTEGER, `totalDuration` INTEGER NOT NULL, `description` TEXT, `publishYear` INTEGER, `publisher` TEXT, `language` TEXT, `isbn` TEXT, `asin` TEXT, `abridged` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `hasScanWarning` INTEGER NOT NULL, `fieldProvenance` TEXT NOT NULL DEFAULT '{}', `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortTitle",
+            "columnName": "sortTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverHash",
+            "columnName": "coverHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverDownloadedAt",
+            "columnName": "coverDownloadedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalDuration",
+            "columnName": "totalDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishYear",
+            "columnName": "publishYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abridged",
+            "columnName": "abridged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasScanWarning",
+            "columnName": "hasScanWarning",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldProvenance",
+            "columnName": "fieldProvenance",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'{}'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_books_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookId` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `startTime` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `description` TEXT, `asin` TEXT, `coverPath` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `asin` TEXT, `description` TEXT, `imagePath` TEXT, `website` TEXT, `birthDate` TEXT, `deathDate` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "imagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "website",
+            "columnName": "website",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "birthDate",
+            "columnName": "birthDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deathDate",
+            "columnName": "deathDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "book_contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `contributorId` TEXT NOT NULL, `role` TEXT NOT NULL, `creditedAs` TEXT, PRIMARY KEY(`bookId`, `contributorId`, `role`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditedAs",
+            "columnName": "creditedAs",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "contributorId",
+            "role"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_contributors_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_contributors_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contributor_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contributorId` TEXT NOT NULL, `alias` TEXT NOT NULL, PRIMARY KEY(`contributorId`, `alias`), FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contributorId",
+            "alias"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contributor_aliases_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contributor_aliases_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `seriesId` TEXT NOT NULL, `sequence` TEXT, PRIMARY KEY(`bookId`, `seriesId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "seriesId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_series_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_series_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `hasCustomSpeed` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `syncedAt` INTEGER, `lastPlayedAt` INTEGER, `isFinished` INTEGER NOT NULL, `finishedAt` INTEGER, `startedAt` INTEGER, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomSpeed",
+            "columnName": "hasCustomSpeed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFinished",
+            "columnName": "isFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`audioFileId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `filename` TEXT NOT NULL, `fileIndex` INTEGER NOT NULL, `state` TEXT NOT NULL, `localPath` TEXT, `totalBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `queuedAt` INTEGER NOT NULL, `startedAt` INTEGER, `completedAt` INTEGER, `errorMessage` TEXT, `retryCount` INTEGER NOT NULL, PRIMARY KEY(`audioFileId`))",
+        "fields": [
+          {
+            "fieldPath": "audioFileId",
+            "columnName": "audioFileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileIndex",
+            "columnName": "fileIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "audioFileId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `name` TEXT NOT NULL, `isInbox` INTEGER NOT NULL, `isSystem` INTEGER NOT NULL DEFAULT 0, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInbox",
+            "columnName": "isInbox",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "isSystem",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collections_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_collections_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collection_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `syncId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`collectionId`, `bookId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "syncId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_collection_books_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_books_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          },
+          {
+            "name": "index_collection_books_syncId",
+            "unique": true,
+            "columnNames": [
+              "syncId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_collection_books_syncId` ON `${TABLE_NAME}` (`syncId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collection_shares",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `collectionId` TEXT NOT NULL, `sharedWithUserId` TEXT NOT NULL, `sharedByUserId` TEXT NOT NULL, `permission` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedWithUserId",
+            "columnName": "sharedWithUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedByUserId",
+            "columnName": "sharedByUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "permission",
+            "columnName": "permission",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_shares_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_shares_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          },
+          {
+            "name": "index_collection_shares_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_shares_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelves",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `isPrivate` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelves_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelves_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelf_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `shelfId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelf_books_shelfId",
+            "unique": false,
+            "columnNames": [
+              "shelfId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_shelfId` ON `${TABLE_NAME}` (`shelfId`)"
+          },
+          {
+            "name": "index_shelf_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_shelf_books_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_slug",
+            "unique": false,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `tagId` TEXT NOT NULL, `syncId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`, `tagId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "syncId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          },
+          {
+            "name": "index_book_tags_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          },
+          {
+            "name": "index_book_tags_syncId",
+            "unique": true,
+            "columnNames": [
+              "syncId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_book_tags_syncId` ON `${TABLE_NAME}` (`syncId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "moods",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_moods_slug",
+            "unique": false,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_moods_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_moods",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `moodId` TEXT NOT NULL, `syncId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`, `moodId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodId",
+            "columnName": "moodId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "syncId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "moodId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_moods_moodId",
+            "unique": false,
+            "columnNames": [
+              "moodId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_moods_moodId` ON `${TABLE_NAME}` (`moodId`)"
+          },
+          {
+            "name": "index_book_moods_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_moods_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          },
+          {
+            "name": "index_book_moods_syncId",
+            "unique": true,
+            "columnNames": [
+              "syncId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_book_moods_syncId` ON `${TABLE_NAME}` (`syncId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `path` TEXT NOT NULL, `parentId` TEXT, `depth` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "depth",
+            "columnName": "depth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_genres_slug",
+            "unique": true,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_genres_slug` ON `${TABLE_NAME}` (`slug`)"
+          },
+          {
+            "name": "index_genres_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_genres_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `genreId` TEXT NOT NULL, PRIMARY KEY(`bookId`, `genreId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`genreId`) REFERENCES `genres`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreId",
+            "columnName": "genreId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "genreId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_genres_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_genres_genreId",
+            "unique": false,
+            "columnNames": [
+              "genreId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_genreId` ON `${TABLE_NAME}` (`genreId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "genres",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "genreId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `codec` TEXT NOT NULL, `duration` INTEGER NOT NULL, `size` INTEGER NOT NULL, `codecProfile` TEXT, `spatial` TEXT, `bitrate` INTEGER, `sampleRate` INTEGER, `channels` INTEGER, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codec",
+            "columnName": "codec",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecProfile",
+            "columnName": "codecProfile",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spatial",
+            "columnName": "spatial",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channels",
+            "columnName": "channels",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_files_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_files_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `size` INTEGER NOT NULL, `hash` TEXT NOT NULL, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_documents_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_documents_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `endPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `tz` TEXT NOT NULL, `deviceLabel` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endPositionMs",
+            "columnName": "endPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tz",
+            "columnName": "tz",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceLabel",
+            "columnName": "deviceLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_userId_endedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "endedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_endedAt` ON `${TABLE_NAME}` (`userId`, `endedAt`)"
+          },
+          {
+            "name": "index_listening_events_userId_revision",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_revision` ON `${TABLE_NAME}` (`userId`, `revision`)"
+          },
+          {
+            "name": "index_listening_events_userId_bookId",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_bookId` ON `${TABLE_NAME}` (`userId`, `bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "activities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `type` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `bookId` TEXT, `isReread` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `milestoneValue` INTEGER NOT NULL, `milestoneUnit` TEXT, `shelfId` TEXT, `shelfName` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isReread",
+            "columnName": "isReread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneValue",
+            "columnName": "milestoneValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneUnit",
+            "columnName": "milestoneUnit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfName",
+            "columnName": "shelfName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_activities_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_activities_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_activities_deletedAt_revision_id",
+            "unique": false,
+            "columnNames": [
+              "deletedAt",
+              "revision",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_deletedAt_revision_id` ON `${TABLE_NAME}` (`deletedAt`, `revision`, `id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `totalSecondsAllTime` INTEGER NOT NULL, `totalSecondsLast7Days` INTEGER NOT NULL, `totalSecondsLast30Days` INTEGER NOT NULL, `booksStarted` INTEGER NOT NULL, `booksFinished` INTEGER NOT NULL, `currentStreakDays` INTEGER NOT NULL, `longestStreakDays` INTEGER NOT NULL, `lastEventDate` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsAllTime",
+            "columnName": "totalSecondsAllTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast7Days",
+            "columnName": "totalSecondsLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast30Days",
+            "columnName": "totalSecondsLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksStarted",
+            "columnName": "booksStarted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinished",
+            "columnName": "booksFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreakDays",
+            "columnName": "currentStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreakDays",
+            "columnName": "longestStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEventDate",
+            "columnName": "lastEventDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `defaultPlaybackSpeed` REAL NOT NULL, `defaultSkipForwardSec` INTEGER NOT NULL, `defaultSkipBackwardSec` INTEGER NOT NULL, `defaultSleepTimerMin` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPlaybackSpeed",
+            "columnName": "defaultPlaybackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSkipForwardSec",
+            "columnName": "defaultSkipForwardSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSkipBackwardSec",
+            "columnName": "defaultSkipBackwardSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSleepTimerMin",
+            "columnName": "defaultSleepTimerMin",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "public_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `tagline` TEXT, `totalSecondsAllTime` INTEGER NOT NULL, `totalSecondsLast7Days` INTEGER NOT NULL, `totalSecondsLast30Days` INTEGER NOT NULL, `totalSecondsLast365Days` INTEGER NOT NULL, `booksFinished` INTEGER NOT NULL, `currentStreakDays` INTEGER NOT NULL, `longestStreakDays` INTEGER NOT NULL, `booksFinishedLast7Days` INTEGER NOT NULL DEFAULT 0, `booksFinishedLast30Days` INTEGER NOT NULL DEFAULT 0, `booksFinishedLast365Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast7Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast30Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast365Days` INTEGER NOT NULL DEFAULT 0, `avatarUpdatedAt` INTEGER NOT NULL DEFAULT 0, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalSecondsAllTime",
+            "columnName": "totalSecondsAllTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast7Days",
+            "columnName": "totalSecondsLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast30Days",
+            "columnName": "totalSecondsLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast365Days",
+            "columnName": "totalSecondsLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinished",
+            "columnName": "booksFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreakDays",
+            "columnName": "currentStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreakDays",
+            "columnName": "longestStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinishedLast7Days",
+            "columnName": "booksFinishedLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "booksFinishedLast30Days",
+            "columnName": "booksFinishedLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "booksFinishedLast365Days",
+            "columnName": "booksFinishedLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast7Days",
+            "columnName": "longestStreakLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast30Days",
+            "columnName": "longestStreakLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast365Days",
+            "columnName": "longestStreakLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avatarUpdatedAt",
+            "columnName": "avatarUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tentative_span",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `currentPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `lastHeartbeatAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `tz` TEXT NOT NULL, `deviceLabel` TEXT, `processId` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPositionMs",
+            "columnName": "currentPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeartbeatAt",
+            "columnName": "lastHeartbeatAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tz",
+            "columnName": "tz",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceLabel",
+            "columnName": "deviceLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "processId",
+            "columnName": "processId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_cursor",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domainName` TEXT NOT NULL, `revision` INTEGER NOT NULL, PRIMARY KEY(`domainName`))",
+        "fields": [
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "domainName"
+          ]
+        }
+      },
+      {
+        "tableName": "pending_operation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clientOpId` TEXT NOT NULL, `domainName` TEXT NOT NULL, `entityId` TEXT NOT NULL, `opType` TEXT NOT NULL, `payload` TEXT NOT NULL, `enqueuedAt` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `failureCount` INTEGER NOT NULL, `lastError` TEXT, `ownerUserId` TEXT NOT NULL, PRIMARY KEY(`clientOpId`))",
+        "fields": [
+          {
+            "fieldPath": "clientOpId",
+            "columnName": "clientOpId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opType",
+            "columnName": "opType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enqueuedAt",
+            "columnName": "enqueuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failureCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerUserId",
+            "columnName": "ownerUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clientOpId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_operation_domainName_entityId_enqueuedAt",
+            "unique": false,
+            "columnNames": [
+              "domainName",
+              "entityId",
+              "enqueuedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operation_domainName_entityId_enqueuedAt` ON `${TABLE_NAME}` (`domainName`, `entityId`, `enqueuedAt`)"
+          },
+          {
+            "name": "index_pending_operation_ownerUserId",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operation_ownerUserId` ON `${TABLE_NAME}` (`ownerUserId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "admin_user_roster",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `role` TEXT NOT NULL, `status` TEXT NOT NULL, `canShare` INTEGER NOT NULL, `accountCreatedAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canShare",
+            "columnName": "canShare",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountCreatedAt",
+            "columnName": "accountCreatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "book_readership",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `currentProgressPct` INTEGER, `finishesJson` TEXT NOT NULL, `observedAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`, `userId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentProgressPct",
+            "columnName": "currentProgressPct",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishesJson",
+            "columnName": "finishesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "observedAt",
+            "columnName": "observedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_active_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startedAtMs` INTEGER NOT NULL, `observedAt` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "startedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "observedAt",
+            "columnName": "observedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3763a221723426afe01262312540104f')"
+    ]
+  }
+}

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.data.local.db
 import android.content.Context
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_1_2
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -24,6 +25,7 @@ internal actual val platformDatabaseModule: Module =
                 ).setDriver(BundledSQLiteDriver())
                 .setQueryCoroutineContext(Dispatchers.IO)
                 .addCallback(FtsTableCallback())
+                .addMigrations(MIGRATION_1_2)
                 // Non-destructive: a schema mismatch throws (loudly) rather than SILENTLY wiping the
                 // local DB — which includes the unsynced outbox (queued playback positions, listening
                 // history, offline edits not yet pushed). Every schema-version bump MUST ship a Room

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.data.local.db
 
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_1_2
 import com.calypsan.listenup.core.IODispatcher
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -41,6 +42,7 @@ internal actual val platformDatabaseModule: Module =
                 // Without this the FTS5 search tables are never created on Apple platforms,
                 // so every search and FTS rebuild fails with `no such table: books_fts`.
                 .addCallback(FtsTableCallback())
+                .addMigrations(MIGRATION_1_2)
                 // Non-destructive: a schema mismatch throws (loudly) rather than SILENTLY wiping the
                 // local DB — which includes the unsynced outbox (queued playback positions, listening
                 // history, offline edits not yet pushed). Every schema-version bump MUST ship a Room

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionDao.kt
@@ -121,6 +121,20 @@ internal interface CollectionBookDao {
         revision: Long,
     )
 
+    /**
+     * Tombstone a junction row by its opaque wire [syncId] (SERVER-SYNC-04) — the by-identity
+     * counterpart to [tombstone], used when applying a `SyncEvent.Deleted` frame whose payload
+     * has its natural pair blanked (junction tombstones ship identity only). Returns the number
+     * of rows affected (0 when [syncId] matches no local row — a graceful no-op the caller logs,
+     * since there is no longer a composite id to parse and fail on).
+     */
+    @Query("UPDATE collection_books SET deletedAt = :deletedAt, revision = :revision WHERE syncId = :syncId")
+    suspend fun tombstoneBySyncId(
+        syncId: String,
+        deletedAt: Long,
+        revision: Long,
+    ): Int
+
     /** Return the junction row for the given [collectionId]/[bookId] pair, or null if absent. */
     @Query("SELECT * FROM collection_books WHERE collectionId = :collectionId AND bookId = :bookId LIMIT 1")
     suspend fun findByKey(
@@ -172,15 +186,25 @@ internal interface CollectionBookDao {
     suspend fun liveCollectionIdsForBook(bookId: String): List<String>
 
     /**
-     * Live (non-tombstoned) junction ids in the synthetic `"$collectionId:$bookId"` form the
-     * server uses on the wire — used by the access-change reconcile so the local set lines up
-     * with `catchUpTransient`'s returned set.
+     * Live (non-tombstoned) junction ids — the opaque wire [CollectionBookEntity.syncId] values
+     * (SERVER-SYNC-04), used by the access-change reconcile so the local set lines up with
+     * `catchUpTransient`'s returned set.
      */
-    @Query("SELECT collectionId || ':' || bookId FROM collection_books WHERE deletedAt IS NULL")
-    suspend fun liveSyntheticIds(): List<String>
+    @Query("SELECT syncId FROM collection_books WHERE deletedAt IS NULL")
+    suspend fun liveSyncIds(): List<String>
 
     /**
-     * Tombstone the given live junction rows by synthetic `"$collectionId:$bookId"` id — the
+     * Live (non-tombstoned) junction [CollectionBookEntity.syncId] values whose [collectionId] is
+     * one of [collectionIds] — the scoped `AccessDeltaPolicy.Targeted` candidate set. Replaces the
+     * pre-SERVER-SYNC-04 `liveSyncIds().filter { it.substringBefore(':') in scopeCols }` trick: the
+     * opaque wire id no longer encodes [collectionId], so the scope filter must be a real column
+     * predicate instead of string-splitting the id.
+     */
+    @Query("SELECT syncId FROM collection_books WHERE collectionId IN (:collectionIds) AND deletedAt IS NULL")
+    suspend fun liveSyncIdsForCollections(collectionIds: List<String>): List<String>
+
+    /**
+     * Tombstone the given live junction rows by opaque wire [CollectionBookEntity.syncId] — the
      * chunked access-change prune.
      *
      * Local-only eviction. The existing `revision` is preserved (this is not a server tombstone).
@@ -189,7 +213,7 @@ internal interface CollectionBookDao {
      */
     @Query(
         "UPDATE collection_books SET deletedAt = :now " +
-            "WHERE deletedAt IS NULL AND (collectionId || ':' || bookId) IN (:ids)",
+            "WHERE deletedAt IS NULL AND syncId IN (:ids)",
     )
     suspend fun tombstoneByIds(
         ids: List<String>,
@@ -203,10 +227,11 @@ internal interface CollectionBookDao {
     /**
      * All rows (including tombstones) with [revision][CollectionBookEntity.revision] <= [max], for digest computation.
      *
-     * The synthetic id is `"$collectionId:$bookId"` — the same form the server uses on the wire.
+     * The id is the opaque wire [CollectionBookEntity.syncId] (SERVER-SYNC-04) — the same value
+     * the server uses on the wire.
      */
     @Query(
-        "SELECT collectionId || ':' || bookId AS id, revision FROM collection_books WHERE deletedAt IS NULL AND revision <= :max",
+        "SELECT syncId AS id, revision FROM collection_books WHERE deletedAt IS NULL AND revision <= :max",
     )
     suspend fun digestRows(max: Long): List<IdRevision>
 
@@ -219,6 +244,15 @@ internal interface CollectionBookDao {
         collectionId: String,
         bookId: String,
     ): Long?
+
+    /**
+     * The stored revision of the junction row with opaque wire [syncId] (SERVER-SYNC-04),
+     * tombstones included; null when the row has never been seen. The by-identity counterpart to
+     * [revisionOf], used by the [ConflictPolicy.ServerWins] guard now that the wire id no longer
+     * decomposes into the natural pair.
+     */
+    @Query("SELECT revision FROM collection_books WHERE syncId = :syncId LIMIT 1")
+    suspend fun revisionOfSyncId(syncId: String): Long?
 }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionEntities.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionEntities.kt
@@ -46,7 +46,8 @@ internal data class CollectionEntity(
 )
 
 /**
- * Junction row linking a book to a collection (Collections — Room v24).
+ * Junction row linking a book to a collection (Collections — Room v24; `syncId` added Room v2,
+ * SERVER-SYNC-04).
  *
  * One row per `(collectionId, bookId)` pair. Soft-deletes are tombstoned via
  * [deletedAt]; observation queries exclude tombstoned rows so removals reflect
@@ -59,11 +60,17 @@ internal data class CollectionEntity(
     indices = [
         Index(value = ["bookId"]),
         Index(value = ["deletedAt"]),
+        Index(value = ["syncId"], unique = true),
     ],
 )
 internal data class CollectionBookEntity(
     val collectionId: String,
     val bookId: String,
+    /**
+     * Opaque wire sync identity (SERVER-SYNC-04) — matched against `SyncEvent.Deleted.id`;
+     * never parsed. Client-minted for an offline-first create, server-echoed otherwise.
+     */
+    val syncId: String,
     /** Epoch millis when this junction row was first created. */
     val createdAt: Long,
     /** Monotonic server revision, bumped on create or soft-delete. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -15,9 +15,11 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
  *
  * Stores user data, books, and sync metadata for offline-first functionality.
  *
- * Schema is at **v6** — the v5 baseline with the dead `shake_to_reset_sleep_timer` column dropped
- * from `user_preferences`; the shake-to-reset-sleep-timer setting was a placebo (persisted and
- * synced but never wired to any behaviour), so its client projection is gone.
+ * Schema is at **v2** — the post-squash v1 baseline (the pre-1.0 migration chain was squashed to a
+ * single starting point) plus the first post-squash migration: `collection_books`/`book_tags`/
+ * `book_moods` each gain a `syncId` column (SERVER-SYNC-04 — junction wire ids became opaque, so the
+ * client now stores the server-assigned id instead of deriving `"$a:$b"` at read time). See
+ * [MIGRATION_1_2].
  *
  * **Migration policy (non-destructive).** The platform `DatabaseModule`s do NOT call
  * `fallbackToDestructiveMigration`, so a schema mismatch with no migration throws loudly instead of
@@ -27,7 +29,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
  * schema-version bump MUST ship a hand-written [androidx.room.migration.Migration]** (register it on
  * all three builders) that preserves the outbox and other pending rows; the guard
  * `DatabaseMigrationPolicyTest` fails the build if the destructive fallback is ever re-added. The
- * `@Database.exportSchema` on-disk JSON (`schemas/…/1.json`) is the authoritative baseline.
+ * `@Database.exportSchema` on-disk JSON (`schemas/…/2.json`) is the authoritative baseline.
  */
 @Database(
     entities = [
@@ -68,7 +70,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
         BookReadershipEntity::class,
         CachedActiveSessionEntity::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = true,
 )
 @TypeConverters(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/MoodDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/MoodDao.kt
@@ -137,6 +137,20 @@ internal interface BookMoodDao {
     )
 
     /**
+     * Tombstone a junction row by its opaque wire [syncId] (SERVER-SYNC-04) — the by-identity
+     * counterpart to [tombstone], used when applying a `SyncEvent.Deleted` frame whose payload
+     * has its natural pair blanked (junction tombstones ship identity only). Preserves
+     * [tombstone]'s existing `revision + 1` semantics (the event's own revision is not taken).
+     * Returns the number of rows affected (0 when [syncId] matches no local row — a graceful
+     * no-op the caller logs, since there is no longer a composite id to parse and fail on).
+     */
+    @Query("UPDATE book_moods SET deletedAt = :deletedAt, revision = revision + 1 WHERE syncId = :syncId")
+    suspend fun tombstoneBySyncId(
+        syncId: String,
+        deletedAt: Long,
+    ): Int
+
+    /**
      * Return the junction row for the given [bookId]/[moodId] pair, or null if absent.
      */
     @Query("SELECT * FROM book_moods WHERE bookId = :bookId AND moodId = :moodId LIMIT 1")
@@ -166,10 +180,11 @@ internal interface BookMoodDao {
     /**
      * All rows (including tombstones) with [revision][BookMoodEntity.revision] <= [max], for digest computation.
      *
-     * The synthetic id is `"$bookId:$moodId"` — the same form the server uses on the wire.
+     * The id is the opaque wire [BookMoodEntity.syncId] (SERVER-SYNC-04) — the same value the
+     * server uses on the wire.
      */
     @Query(
-        "SELECT bookId || ':' || moodId AS id, revision FROM book_moods WHERE deletedAt IS NULL AND revision <= :max",
+        "SELECT syncId AS id, revision FROM book_moods WHERE deletedAt IS NULL AND revision <= :max",
     )
     suspend fun digestRows(max: Long): List<IdRevision>
 
@@ -182,4 +197,13 @@ internal interface BookMoodDao {
         bookId: String,
         moodId: String,
     ): Long?
+
+    /**
+     * The stored revision of the junction row with opaque wire [syncId] (SERVER-SYNC-04),
+     * tombstones included; null when the row has never been seen. The by-identity counterpart to
+     * [revisionOf], used by the [ConflictPolicy.ServerWins] guard now that the wire id no longer
+     * decomposes into the natural pair.
+     */
+    @Query("SELECT revision FROM book_moods WHERE syncId = :syncId LIMIT 1")
+    suspend fun revisionOfSyncId(syncId: String): Long?
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Relations.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Relations.kt
@@ -236,6 +236,9 @@ internal data class RoleWithBookCount(
  *
  * @property bookId The book this tag is applied to.
  * @property tagId The tag applied to [bookId].
+ * @property syncId Opaque wire sync identity (SERVER-SYNC-04, Room v2) — matched against
+ *   `SyncEvent.Deleted.id`; never parsed. Client-minted for an offline-first create,
+ *   server-echoed otherwise.
  * @property createdAt Epoch millis when this junction row was first created.
  * @property revision Monotonic server revision, bumped on create or soft-delete.
  * @property deletedAt Epoch ms tombstone; null when the junction row is live.
@@ -246,11 +249,13 @@ internal data class RoleWithBookCount(
     indices = [
         Index(value = ["tagId"]),
         Index(value = ["deletedAt"]),
+        Index(value = ["syncId"], unique = true),
     ],
 )
 internal data class BookTagEntity(
     val bookId: String,
     val tagId: String,
+    val syncId: String,
     val createdAt: Long,
     val revision: Long = 0,
     val deletedAt: Long? = null,
@@ -326,6 +331,9 @@ internal data class BookWithTags(
  *
  * @property bookId The book this mood is applied to.
  * @property moodId The mood applied to [bookId].
+ * @property syncId Opaque wire sync identity (SERVER-SYNC-04, Room v2) — matched against
+ *   `SyncEvent.Deleted.id`; never parsed. Client-minted for an offline-first create,
+ *   server-echoed otherwise.
  * @property createdAt Epoch millis when this junction row was first created.
  * @property revision Monotonic server revision, bumped on create or soft-delete.
  * @property deletedAt Epoch ms tombstone; null when the junction row is live.
@@ -336,11 +344,13 @@ internal data class BookWithTags(
     indices = [
         Index(value = ["moodId"]),
         Index(value = ["deletedAt"]),
+        Index(value = ["syncId"], unique = true),
     ],
 )
 internal data class BookMoodEntity(
     val bookId: String,
     val moodId: String,
+    val syncId: String,
     val createdAt: Long,
     val revision: Long = 0,
     val deletedAt: Long? = null,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfBookDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfBookDao.kt
@@ -37,6 +37,25 @@ internal interface ShelfBookDao {
     suspend fun findById(id: String): ShelfBookEntity?
 
     /**
+     * Return the junction row for the natural `(shelfId, bookId)` pair, or null if absent.
+     *
+     * Unlike `collection_books`/`book_tags`/`book_moods` (whose Room primary key IS the natural
+     * pair), `shelf_books`' primary key is its opaque wire [ShelfBookEntity.id] (SERVER-SYNC-04).
+     * A client-minted id and a later server-echoed id for the SAME pair are therefore different
+     * primary keys — [com.calypsan.listenup.client.data.sync.domains.ShelfBookMirrorApply.upsert]
+     * uses this lookup to reconcile the two into one row instead of leaving a duplicate.
+     */
+    @Query("SELECT * FROM shelf_books WHERE shelfId = :shelfId AND bookId = :bookId LIMIT 1")
+    suspend fun findByShelfAndBook(
+        shelfId: String,
+        bookId: String,
+    ): ShelfBookEntity?
+
+    /** Hard-delete a junction row by its synthetic [id] — used to collapse a duplicate (see [findByShelfAndBook]). */
+    @Query("DELETE FROM shelf_books WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    /**
      * The highest [sortOrder][ShelfBookEntity.sortOrder] among the shelf's live junction rows, or
      * null when the shelf has no live members. Used by the offline-first `addBookToShelf` optimistic
      * write to append the new book at the end of the current sort order (mirroring the server).

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TagDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TagDao.kt
@@ -137,6 +137,20 @@ internal interface BookTagDao {
     )
 
     /**
+     * Tombstone a junction row by its opaque wire [syncId] (SERVER-SYNC-04) — the by-identity
+     * counterpart to [tombstone], used when applying a `SyncEvent.Deleted` frame whose payload
+     * has its natural pair blanked (junction tombstones ship identity only). Returns the number
+     * of rows affected (0 when [syncId] matches no local row — a graceful no-op the caller logs,
+     * since there is no longer a composite id to parse and fail on).
+     */
+    @Query("UPDATE book_tags SET deletedAt = :deletedAt, revision = :revision WHERE syncId = :syncId")
+    suspend fun tombstoneBySyncId(
+        syncId: String,
+        deletedAt: Long,
+        revision: Long,
+    ): Int
+
+    /**
      * Cascade-tombstone every live junction row for [tagId] — the client mirror of the server's
      * `deleteTag` cascade (soft-delete all `book_tags` for the tag). Advances each row's revision so
      * the server's own cascade echo (at least one higher) still applies through the revision guard.
@@ -179,9 +193,10 @@ internal interface BookTagDao {
     /**
      * All rows (including tombstones) with [revision][BookTagEntity.revision] <= [max], for digest computation.
      *
-     * The synthetic id is `"$bookId:$tagId"` — the same form the server uses on the wire.
+     * The id is the opaque wire [BookTagEntity.syncId] (SERVER-SYNC-04) — the same value the
+     * server uses on the wire.
      */
-    @Query("SELECT bookId || ':' || tagId AS id, revision FROM book_tags WHERE deletedAt IS NULL AND revision <= :max")
+    @Query("SELECT syncId AS id, revision FROM book_tags WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /**
@@ -193,4 +208,13 @@ internal interface BookTagDao {
         bookId: String,
         tagId: String,
     ): Long?
+
+    /**
+     * The stored revision of the junction row with opaque wire [syncId] (SERVER-SYNC-04),
+     * tombstones included; null when the row has never been seen. The by-identity counterpart to
+     * [revisionOf], used by the [ConflictPolicy.ServerWins] guard now that the wire id no longer
+     * decomposes into the natural pair.
+     */
+    @Query("SELECT revision FROM book_tags WHERE syncId = :syncId LIMIT 1")
+    suspend fun revisionOfSyncId(syncId: String): Long?
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration1To2.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration1To2.kt
@@ -1,0 +1,47 @@
+package com.calypsan.listenup.client.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+/**
+ * Room schema migration v1 → v2 — the first post-squash migration.
+ *
+ * SERVER-SYNC-04: the server's junction wire ids (`collection_books`/`book_tags`/`book_moods`)
+ * stopped encoding the natural pair (`"$a:$b"`) and became opaque per-row values. The client must
+ * store that wire id instead of re-deriving it at read time, so each junction table gains a
+ * `syncId` column (unique, matched against `SyncEvent.Deleted.id`; never parsed).
+ *
+ * -- DESTRUCTIVE (junction mirror rows only): a pre-migration row's real `syncId` is unknowable —
+ * it lived only in the now-superseded composite-id scheme. Rather than fabricate one, this
+ * migration DELETES every `collection_books`/`book_tags`/`book_moods` row; the next digest
+ * reconcile re-pulls them from the server with real `syncId` values. This is intentional healing,
+ * not data loss: the server is the source of truth for these junctions, and the deleted rows are
+ * pure mirrors of server state (no unsynced local edits reference them directly — an in-flight
+ * outbox op for a junction write carries its own `bookId`/`collectionId` pair, not a row id).
+ *
+ * `shelf_books` is NOT touched — its `id` column already stored the wire id (Room v24), and the
+ * VALUE just became opaque server-side; no local schema change is needed for it.
+ */
+val MIGRATION_1_2: Migration =
+    object : Migration(1, 2) {
+        override fun migrate(connection: SQLiteConnection) {
+            connection.execSQL("DELETE FROM collection_books")
+            connection.execSQL("DELETE FROM book_tags")
+            connection.execSQL("DELETE FROM book_moods")
+
+            connection.execSQL("ALTER TABLE collection_books ADD COLUMN syncId TEXT NOT NULL DEFAULT ''")
+            connection.execSQL("ALTER TABLE book_tags ADD COLUMN syncId TEXT NOT NULL DEFAULT ''")
+            connection.execSQL("ALTER TABLE book_moods ADD COLUMN syncId TEXT NOT NULL DEFAULT ''")
+
+            connection.execSQL(
+                "CREATE UNIQUE INDEX IF NOT EXISTS `index_collection_books_syncId` ON `collection_books` (`syncId`)",
+            )
+            connection.execSQL(
+                "CREATE UNIQUE INDEX IF NOT EXISTS `index_book_tags_syncId` ON `book_tags` (`syncId`)",
+            )
+            connection.execSQL(
+                "CREATE UNIQUE INDEX IF NOT EXISTS `index_book_moods_syncId` ON `book_moods` (`syncId`)",
+            )
+        }
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookMutationLocalApply.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookMutationLocalApply.kt
@@ -30,6 +30,7 @@ import com.calypsan.listenup.core.ContributorId
 import com.calypsan.listenup.core.SeriesId
 import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.core.currentEpochMilliseconds
+import kotlin.uuid.Uuid
 
 /**
  * The optimistic Room merge for every [BookMutation], mirroring [com.calypsan.listenup.client.data.sync.domains.BookMirrorApply]'s
@@ -209,6 +210,7 @@ internal class BookMutationLocalApply(
                 CollectionBookEntity(
                     collectionId = collectionId,
                     bookId = bookId.value,
+                    syncId = Uuid.random().toString(),
                     createdAt = now,
                     revision = 0,
                     deletedAt = null,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImpl.kt
@@ -26,6 +26,7 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.CollectionId
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import com.calypsan.listenup.api.result.map
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -136,6 +137,7 @@ internal class CollectionRepositoryImpl(
                 CollectionBookEntity(
                     collectionId = collectionId,
                     bookId = bookId,
+                    syncId = Uuid.random().toString(),
                     createdAt = currentEpochMilliseconds(),
                     revision = 0,
                     deletedAt = null,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/MoodRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/MoodRepositoryImpl.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.client.data.sync.domains.OpKind
 import com.calypsan.listenup.client.data.sync.domains.OutboxChannels
 import com.calypsan.listenup.client.domain.model.Mood
 import com.calypsan.listenup.client.domain.repository.MoodRepository
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -102,6 +103,7 @@ internal class MoodRepositoryImpl(
                     BookMoodEntity(
                         bookId = bookId,
                         moodId = existing.id,
+                        syncId = Uuid.random().toString(),
                         createdAt = currentEpochMilliseconds(),
                         revision = 0,
                         deletedAt = null,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
@@ -26,6 +26,7 @@ import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.core.currentEpochMilliseconds
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -179,21 +180,25 @@ internal class ShelfRepositoryImpl(
     }
 
     /**
-     * Offline-first: enqueue ONE add op per book on the `shelf_books` channel, each keyed by its own
-     * `"$shelfId:$bookId"` envelope id so each junction inherits the per-junction in-flight shield, and
-     * upsert each junction optimistically (revision-0 stub, appended after the current max sort order).
-     * Adds a book mints no server id (the book already exists). Fails fast on the first enqueue failure.
+     * Offline-first: enqueue ONE add op per book on the `shelf_books` channel, each keyed by the
+     * stable `"$shelfId:$bookId"` outbox key (per-junction in-flight-shield dedup — a LOCAL
+     * bookkeeping concept, unrelated to the wire row identity), and upsert each junction
+     * optimistically (revision-0 stub, appended after the current max sort order). The optimistic
+     * row mints its own opaque wire id (SERVER-SYNC-04) via [Uuid.random] — never the natural pair
+     * — since a server round-trip hasn't happened yet; [ShelfBookMirrorApply.upsert] reconciles it
+     * with the server's own id when the Created echo arrives (see its KDoc). Adds a book mints no
+     * server id (the book already exists). Fails fast on the first enqueue failure.
      */
     override suspend fun addBooksToShelf(
         shelfId: ShelfId,
         bookIds: List<BookId>,
     ): AppResult<Unit> {
         bookIds.forEach { bookId ->
-            val id = "${shelfId.value}:${bookId.value}"
+            val outboxKey = "${shelfId.value}:${bookId.value}"
             val result =
                 offlineEditor.edit(
                     OutboxChannels.ShelfBooks,
-                    id,
+                    outboxKey,
                     ShelfBookMutation.Add(shelfId = shelfId.value, bookId = bookId.value),
                     op = OpKind.Create,
                 ) {
@@ -201,7 +206,7 @@ internal class ShelfRepositoryImpl(
                     val nextSort = (shelfBookDao.maxSortOrderForShelf(shelfId.value) ?: -1) + 1
                     shelfBookDao.upsert(
                         ShelfBookEntity(
-                            id = id,
+                            id = Uuid.random().toString(),
                             shelfId = shelfId.value,
                             bookId = bookId.value,
                             sortOrder = nextSort,
@@ -226,15 +231,18 @@ internal class ShelfRepositoryImpl(
         shelfId: ShelfId,
         bookId: BookId,
     ): AppResult<Unit> {
-        val id = "${shelfId.value}:${bookId.value}"
+        val outboxKey = "${shelfId.value}:${bookId.value}"
         return offlineEditor.edit(
             OutboxChannels.ShelfBooks,
-            id,
+            outboxKey,
             ShelfBookMutation.Remove(shelfId = shelfId.value, bookId = bookId.value),
             op = OpKind.Delete,
         ) {
-            shelfBookDao.findById(id)?.let {
-                shelfBookDao.softDelete(id = id, deletedAt = currentEpochMilliseconds(), revision = it.revision)
+            // Looked up by the natural pair, not by a guessed id: the row's opaque wire id
+            // (SERVER-SYNC-04) is minted client-side on add and may since have been reconciled to
+            // the server's own id by ShelfBookMirrorApply.upsert — see its KDoc.
+            shelfBookDao.findByShelfAndBook(shelfId.value, bookId.value)?.let {
+                shelfBookDao.softDelete(id = it.id, deletedAt = currentEpochMilliseconds(), revision = it.revision)
             }
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryImpl.kt
@@ -22,6 +22,7 @@ import com.calypsan.listenup.client.data.sync.domains.OutboxChannels
 import com.calypsan.listenup.client.domain.model.Tag
 import com.calypsan.listenup.client.domain.repository.TagRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -125,6 +126,7 @@ internal class TagRepositoryImpl(
                     BookTagEntity(
                         bookId = bookId,
                         tagId = existing.id,
+                        syncId = Uuid.random().toString(),
                         createdAt = currentEpochMilliseconds(),
                         revision = 0,
                         deletedAt = null,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookMoodsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookMoodsDomain.kt
@@ -29,7 +29,12 @@ internal fun bookMoodsDomain(database: ListenUpDatabase): MirroredDomain<BookMoo
     return MirroredDomain(
         key = SyncDomains.BOOK_MOODS,
         apply = apply,
-        conflict = ConflictPolicy.ServerWins(RevisionGuard { syncId -> database.bookMoodDao().revisionOfSyncId(syncId) }),
+        conflict =
+            ConflictPolicy.ServerWins(
+                RevisionGuard { syncId ->
+                    database.bookMoodDao().revisionOfSyncId(syncId)
+                },
+            ),
         // The DAO advances its own revision on tombstone, so the event revision is dropped (`_`).
         deletes = DeleteSemantics.SoftDelete { id, deletedAt, _ -> apply.tombstoneById(id, deletedAt) },
         digest = fullDigest(database.bookMoodDao()::digestRows),

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookMoodsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookMoodsDomain.kt
@@ -9,19 +9,18 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val logger = KotlinLogging.logger {}
 
 /**
- * The `book_moods` junction domain: composite `(bookId, moodId)` primary key mirrored
- * under the server's synthetic `"$bookId:$moodId"` envelope id. Server-wins apply,
- * soft tombstones, full digest participation, outbox-backed writes. Structurally
- * identical to [bookTagsDomain] — the same junction rules apply: the DAO tombstone
- * keeps the row (advancing its own revision, ignoring the event's revision) so digest
- * reconciliation stays faithful, and re-adds arrive as Created/Updated with
+ * The `book_moods` junction domain: composite `(bookId, moodId)` primary key, mirrored under the
+ * server's opaque per-row wire id (SERVER-SYNC-04 — stored as [BookMoodEntity.syncId], matched by
+ * identity, never parsed). Server-wins apply, soft tombstones, full digest participation,
+ * outbox-backed writes. Structurally identical to [bookTagsDomain] — the same junction rules
+ * apply: the DAO tombstone keeps the row (advancing its own revision, ignoring the event's
+ * revision) so digest reconciliation stays faithful, and re-adds arrive as Created/Updated with
  * `deletedAt = null`.
  *
- * **Outbox writes.** Removing a mood from a book writes the junction tombstone
- * optimistically and queues a durable op on [OutboxChannels.BookMoods], keyed by the
- * same `"$bookId:$moodId"` envelope id; the in-flight shield defers the junction's own
- * echo until that op drains. Adding a mood stays an online RPC (find-or-create may mint
- * a new server-side mood id).
+ * **Outbox writes.** Removing a mood from a book writes the junction tombstone optimistically and
+ * queues a durable op on [OutboxChannels.BookMoods]; the in-flight shield defers the junction's
+ * own echo until that op drains. Adding a mood stays an online RPC (find-or-create may mint a new
+ * server-side mood id).
  *
  * No FK constraints on `book_moods` — sync is responsible for integrity.
  */
@@ -30,17 +29,7 @@ internal fun bookMoodsDomain(database: ListenUpDatabase): MirroredDomain<BookMoo
     return MirroredDomain(
         key = SyncDomains.BOOK_MOODS,
         apply = apply,
-        conflict =
-            ConflictPolicy.ServerWins(
-                RevisionGuard { id ->
-                    val parts = id.split(":")
-                    if (parts.size != 2) {
-                        null
-                    } else {
-                        database.bookMoodDao().revisionOf(bookId = parts[0], moodId = parts[1])
-                    }
-                },
-            ),
+        conflict = ConflictPolicy.ServerWins(RevisionGuard { syncId -> database.bookMoodDao().revisionOfSyncId(syncId) }),
         // The DAO advances its own revision on tombstone, so the event revision is dropped (`_`).
         deletes = DeleteSemantics.SoftDelete { id, deletedAt, _ -> apply.tombstoneById(id, deletedAt) },
         digest = fullDigest(database.bookMoodDao()::digestRows),
@@ -57,6 +46,7 @@ internal class BookMoodMirrorApply(
             BookMoodEntity(
                 bookId = payload.bookId,
                 moodId = payload.moodId,
+                syncId = payload.id,
                 createdAt = payload.createdAt,
                 revision = payload.revision,
                 deletedAt = payload.deletedAt,
@@ -65,26 +55,28 @@ internal class BookMoodMirrorApply(
     }
 
     /**
-     * Tombstone from an SSE `Deleted` frame (`"$bookId:$moodId"` envelope id; `:` is
-     * unambiguous — both parts are UUIDv7 strings). The DAO advances its own revision,
-     * so the event revision is not taken here.
+     * Tombstone from an SSE `Deleted` frame by the opaque wire [id] (SERVER-SYNC-04) — a graceful
+     * no-op if [id] matches no local row (nothing to reconcile locally). The DAO advances its own
+     * revision, so the event revision is not taken here.
      */
     suspend fun tombstoneById(
         id: String,
         deletedAt: Long,
     ) {
-        val parts = id.split(":")
-        if (parts.size != 2) {
-            logger.warn { "book_moods Deleted event has unexpected id format: '$id' — skipping tombstone" }
-            return
+        val affected = database.bookMoodDao().tombstoneBySyncId(id, deletedAt)
+        if (affected == 0) {
+            logger.debug { "book_moods Deleted event matched no local row for id='$id' — graceful no-op" }
         }
-        database.bookMoodDao().tombstone(bookId = parts[0], moodId = parts[1], deletedAt = deletedAt)
     }
 
+    /**
+     * Tombstone from a catch-up item. The pull path blanks [item]'s natural pair on a tombstone
+     * (SERVER-SYNC-04 — junction tombstones ship identity only), so this applies by [item]'s
+     * opaque wire id, never by `bookId`/`moodId`.
+     */
     override suspend fun tombstoneFromItem(item: BookMoodSyncPayload) {
-        database.bookMoodDao().tombstone(
-            bookId = item.bookId,
-            moodId = item.moodId,
+        database.bookMoodDao().tombstoneBySyncId(
+            syncId = item.id,
             deletedAt = item.deletedAt ?: item.createdAt,
         )
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookTagsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookTagsDomain.kt
@@ -9,9 +9,10 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val logger = KotlinLogging.logger {}
 
 /**
- * The `book_tags` junction domain (Tags phase — Room v22): composite `(bookId, tagId)`
- * primary key mirrored under the server's synthetic `"$bookId:$tagId"` envelope id.
- * Server-wins apply, soft tombstones, full digest participation, outbox-backed writes.
+ * The `book_tags` junction domain (Tags phase — Room v22): composite `(bookId, tagId)` primary
+ * key, mirrored under the server's opaque per-row wire id (SERVER-SYNC-04 — stored as
+ * [BookTagEntity.syncId], matched by identity, never parsed). Server-wins apply, soft tombstones,
+ * full digest participation, outbox-backed writes.
  *
  * **Junctions soft-tombstone.** The DAO's `tombstone` keeps the row with `deletedAt`
  * set so [DigestParticipation.Full] still covers it — literally deleting the row
@@ -20,11 +21,10 @@ private val logger = KotlinLogging.logger {}
  * **Re-add semantics.** Re-applying a tag after removal arrives as Created/Updated
  * with `deletedAt = null`; the upsert clears the tombstone.
  *
- * **Outbox writes.** Removing a tag from a book writes the junction tombstone
- * optimistically and queues a durable op on [OutboxChannels.BookTags], keyed by the
- * same `"$bookId:$tagId"` envelope id; the in-flight shield defers the junction's own
- * echo until that op drains. Adding a tag stays an online RPC (find-or-create may mint
- * a new server-side tag id, which can't be mirrored optimistically).
+ * **Outbox writes.** Removing a tag from a book writes the junction tombstone optimistically and
+ * queues a durable op on [OutboxChannels.BookTags]; the in-flight shield defers the junction's own
+ * echo until that op drains. Adding a tag stays an online RPC (find-or-create may mint a new
+ * server-side tag id, which can't be mirrored optimistically).
  *
  * No FK constraints on `book_tags` — sync is responsible for integrity.
  */
@@ -33,17 +33,7 @@ internal fun bookTagsDomain(database: ListenUpDatabase): MirroredDomain<BookTagS
     return MirroredDomain(
         key = SyncDomains.BOOK_TAGS,
         apply = apply,
-        conflict =
-            ConflictPolicy.ServerWins(
-                RevisionGuard { id ->
-                    val parts = id.split(":")
-                    if (parts.size != 2) {
-                        null
-                    } else {
-                        database.bookTagDao().revisionOf(bookId = parts[0], tagId = parts[1])
-                    }
-                },
-            ),
+        conflict = ConflictPolicy.ServerWins(RevisionGuard { syncId -> database.bookTagDao().revisionOfSyncId(syncId) }),
         // Write the event's own revision so a replayed Deleted frame is a true no-op (matches
         // collection_books). The revision is the server-authoritative value from the frame.
         deletes =
@@ -68,6 +58,7 @@ internal class BookTagMirrorApply(
             BookTagEntity(
                 bookId = payload.bookId,
                 tagId = payload.tagId,
+                syncId = payload.id,
                 createdAt = payload.createdAt,
                 revision = payload.revision,
                 deletedAt = payload.deletedAt,
@@ -76,28 +67,29 @@ internal class BookTagMirrorApply(
     }
 
     /**
-     * Tombstone from an SSE `Deleted` frame. The server synthesises `"$bookId:$tagId"`
-     * as the stable envelope id (see `BookTagId.asString()` server-side); the `:`
-     * delimiter cannot appear in either part because book/tag ids are UUIDv7 strings.
-     * The event's own [revision] is written (not `revision + 1`) so a replay is a no-op.
+     * Tombstone from an SSE `Deleted` frame by the opaque wire [id] (SERVER-SYNC-04) — a graceful
+     * no-op if [id] matches no local row (nothing to reconcile locally). The event's own
+     * [revision] is written (not `revision + 1`) so a replay is a no-op.
      */
     suspend fun tombstoneById(
         id: String,
         deletedAt: Long,
         revision: Long,
     ) {
-        val parts = id.split(":")
-        if (parts.size != 2) {
-            logger.warn { "book_tags Deleted event has unexpected id format: '$id' — skipping tombstone" }
-            return
+        val affected = database.bookTagDao().tombstoneBySyncId(id, deletedAt, revision)
+        if (affected == 0) {
+            logger.debug { "book_tags Deleted event matched no local row for id='$id' — graceful no-op" }
         }
-        database.bookTagDao().tombstone(bookId = parts[0], tagId = parts[1], deletedAt = deletedAt, revision = revision)
     }
 
+    /**
+     * Tombstone from a catch-up item. The pull path blanks [item]'s natural pair on a tombstone
+     * (SERVER-SYNC-04 — junction tombstones ship identity only), so this applies by [item]'s
+     * opaque wire id, never by `bookId`/`tagId`.
+     */
     override suspend fun tombstoneFromItem(item: BookTagSyncPayload) {
-        database.bookTagDao().tombstone(
-            bookId = item.bookId,
-            tagId = item.tagId,
+        database.bookTagDao().tombstoneBySyncId(
+            syncId = item.id,
             deletedAt = item.deletedAt ?: item.createdAt,
             revision = item.revision,
         )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookTagsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookTagsDomain.kt
@@ -33,7 +33,12 @@ internal fun bookTagsDomain(database: ListenUpDatabase): MirroredDomain<BookTagS
     return MirroredDomain(
         key = SyncDomains.BOOK_TAGS,
         apply = apply,
-        conflict = ConflictPolicy.ServerWins(RevisionGuard { syncId -> database.bookTagDao().revisionOfSyncId(syncId) }),
+        conflict =
+            ConflictPolicy.ServerWins(
+                RevisionGuard { syncId ->
+                    database.bookTagDao().revisionOfSyncId(syncId)
+                },
+            ),
         // Write the event's own revision so a replayed Deleted frame is a true no-op (matches
         // collection_books). The revision is the server-authoritative value from the frame.
         deletes =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionBooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionBooksDomain.kt
@@ -11,61 +11,46 @@ private val logger = KotlinLogging.logger {}
 
 /**
  * The `collection_books` junction domain (Collections — Room v24): composite
- * `(collectionId, bookId)` primary key mirrored under the server's synthetic
- * `"$collectionId:$bookId"` envelope id (see `CollectionBookId.asString()`
- * server-side). Server-wins apply, soft tombstones (junction rule: row + revision
- * kept for digest), full digest, outbox-backed writes, access-gated.
+ * `(collectionId, bookId)` primary key, mirrored under the server's opaque per-row wire id
+ * (SERVER-SYNC-04 — stored as [CollectionBookEntity.syncId], matched by identity, never parsed).
+ * Server-wins apply, soft tombstones (junction rule: row + revision kept for digest), full digest,
+ * outbox-backed writes, access-gated.
  *
  * **Access gate:** membership rows follow their collection's accessibility;
- * [AccessGate.liveIds] returns synthetic wire-form ids via `liveSyntheticIds()`,
- * and pruning tombstones rows outside the accessible set.
+ * [AccessGate.liveIds] returns opaque wire-form ids via `liveSyncIds()`, and pruning
+ * tombstones rows outside the accessible set.
  *
  * **Re-add semantics.** Re-adding a book arrives as Created/Updated with
  * `deletedAt = null`; the upsert clears the tombstone.
  *
  * **Outbox writes.** Adding and removing a book write the junction optimistically and queue a
- * durable op on [OutboxChannels.CollectionBooks], keyed by the same `"$collectionId:$bookId"`
- * envelope id; the in-flight shield defers the junction's own echo until that op drains. Both are
- * offline-first — the book already exists, so no server id is minted.
+ * durable op on [OutboxChannels.CollectionBooks]; the in-flight shield defers the junction's own
+ * echo until that op drains. Both are offline-first — the book already exists, so no server id is
+ * minted.
  */
 internal fun collectionBooksDomain(database: ListenUpDatabase): MirroredDomain<CollectionBookSyncPayload> {
     val apply = CollectionBookMirrorApply(database)
     return MirroredDomain(
         key = SyncDomains.COLLECTION_BOOKS,
         apply = apply,
-        conflict =
-            ConflictPolicy.ServerWins(
-                RevisionGuard { id ->
-                    val parts = id.split(":")
-                    if (parts.size != 2) {
-                        null
-                    } else {
-                        database.collectionBookDao().revisionOf(collectionId = parts[0], bookId = parts[1])
-                    }
-                },
-            ),
+        conflict = ConflictPolicy.ServerWins(RevisionGuard { syncId -> database.collectionBookDao().revisionOfSyncId(syncId) }),
         deletes = DeleteSemantics.SoftDelete(apply::tombstoneById),
         digest = fullDigest(database.collectionBookDao()::digestRows),
         writes = WriteTier.Outbox(OutboxChannels.CollectionBooks),
         accessGate =
             AccessGate(
-                liveIds = database.collectionBookDao()::liveSyntheticIds,
+                liveIds = database.collectionBookDao()::liveSyncIds,
                 tombstoneByIds = database.collectionBookDao()::tombstoneByIds,
                 // Fetched by the scope's collection ids. The candidate set is the local live
-                // membership rows whose collection is in scope — derived from the synthetic
-                // `"$collectionId:$bookId"` wire id — so a membership in a collection the delta never
-                // named can never be tombstoned.
+                // membership rows whose collection is in scope — a real column predicate now that
+                // the opaque wire id (SERVER-SYNC-04) no longer encodes collectionId.
                 delta =
                     AccessDeltaPolicy.Targeted(
                         order = 1,
                         axis = ScopeAxis.Collections,
                         fetchFor = { TargetedFetch.ByCollectionIds(it) },
                         candidatesFor = { collectionIds ->
-                            val scopeCols = collectionIds.toSet()
-                            database
-                                .collectionBookDao()
-                                .liveSyntheticIds()
-                                .filterTo(mutableSetOf()) { it.substringBefore(':') in scopeCols }
+                            database.collectionBookDao().liveSyncIdsForCollections(collectionIds).toSet()
                         },
                     ),
             ),
@@ -81,6 +66,7 @@ internal class CollectionBookMirrorApply(
             CollectionBookEntity(
                 collectionId = payload.collectionId,
                 bookId = payload.bookId,
+                syncId = payload.id,
                 createdAt = payload.createdAt,
                 revision = payload.revision,
                 deletedAt = payload.deletedAt,
@@ -89,8 +75,8 @@ internal class CollectionBookMirrorApply(
     }
 
     /**
-     * Tombstone from an SSE `Deleted` frame (`"$collectionId:$bookId"` envelope id;
-     * `:` is unambiguous — both parts are UUIDv7 strings). Unlike book_tags, this
+     * Tombstone from an SSE `Deleted` frame by the opaque wire [id] (SERVER-SYNC-04) — a graceful
+     * no-op if [id] matches no local row (nothing to reconcile locally). Unlike book_tags, this
      * DAO's tombstone advances the stored revision.
      */
     suspend fun tombstoneById(
@@ -98,25 +84,20 @@ internal class CollectionBookMirrorApply(
         deletedAt: Long,
         revision: Long,
     ) {
-        val parts = id.split(":")
-        if (parts.size != 2) {
-            logger.warn {
-                "collection_books Deleted event has unexpected id format: '$id' — skipping tombstone"
-            }
-            return
+        val affected = database.collectionBookDao().tombstoneBySyncId(id, deletedAt, revision)
+        if (affected == 0) {
+            logger.debug { "collection_books Deleted event matched no local row for id='$id' — graceful no-op" }
         }
-        database.collectionBookDao().tombstone(
-            collectionId = parts[0],
-            bookId = parts[1],
-            deletedAt = deletedAt,
-            revision = revision,
-        )
     }
 
+    /**
+     * Tombstone from a catch-up item. The pull path blanks [item]'s natural pair on a tombstone
+     * (SERVER-SYNC-04 — junction tombstones ship identity only), so this applies by [item]'s
+     * opaque wire id, never by `collectionId`/`bookId`.
+     */
     override suspend fun tombstoneFromItem(item: CollectionBookSyncPayload) {
-        database.collectionBookDao().tombstone(
-            collectionId = item.collectionId,
-            bookId = item.bookId,
+        database.collectionBookDao().tombstoneBySyncId(
+            syncId = item.id,
             deletedAt = item.deletedAt ?: item.createdAt,
             revision = item.revision,
         )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionBooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionBooksDomain.kt
@@ -33,7 +33,12 @@ internal fun collectionBooksDomain(database: ListenUpDatabase): MirroredDomain<C
     return MirroredDomain(
         key = SyncDomains.COLLECTION_BOOKS,
         apply = apply,
-        conflict = ConflictPolicy.ServerWins(RevisionGuard { syncId -> database.collectionBookDao().revisionOfSyncId(syncId) }),
+        conflict =
+            ConflictPolicy.ServerWins(
+                RevisionGuard { syncId ->
+                    database.collectionBookDao().revisionOfSyncId(syncId)
+                },
+            ),
         deletes = DeleteSemantics.SoftDelete(apply::tombstoneById),
         digest = fullDigest(database.collectionBookDao()::digestRows),
         writes = WriteTier.Outbox(OutboxChannels.CollectionBooks),

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ShelfBooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ShelfBooksDomain.kt
@@ -39,7 +39,22 @@ internal fun shelfBooksDomain(database: ListenUpDatabase): MirroredDomain<ShelfB
 internal class ShelfBookMirrorApply(
     private val database: ListenUpDatabase,
 ) : MirrorApply<ShelfBookSyncPayload> {
+    /**
+     * Unlike the other three junction domains — whose Room primary key IS the natural pair, so a
+     * plain `@Upsert` self-heals a client-minted id to the server-echoed one in place — `shelf_books`'
+     * primary key is its opaque wire [ShelfBookEntity.id] (SERVER-SYNC-04). A client-originated
+     * optimistic add mints its own id before any server round-trip (see
+     * `ShelfRepositoryImpl.addBooksToShelf`); if the server's later Created echo carries a
+     * DIFFERENT id for the SAME `(shelfId, bookId)` pair, a plain `@Upsert` would leave both rows —
+     * the stale client-minted one orphaned forever. Reconcile first: an existing row for the pair
+     * with a different id is deleted before the incoming payload is upserted, so the pair converges
+     * on exactly one row.
+     */
     override suspend fun upsert(payload: ShelfBookSyncPayload) {
+        val existing = database.shelfBookDao().findByShelfAndBook(payload.shelfId, payload.bookId)
+        if (existing != null && existing.id != payload.id) {
+            database.shelfBookDao().deleteById(existing.id)
+        }
         database.shelfBookDao().upsert(
             ShelfBookEntity(
                 id = payload.id,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/CollectionContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/CollectionContractTest.kt
@@ -101,6 +101,7 @@ class CollectionContractTest :
         test("CollectionBookSyncPayload round-trips with all fields") {
             val original =
                 CollectionBookSyncPayload(
+                    id = "a1b2c3d4e5f60718293a4b5c6d7e8f90",
                     collectionId = "col-1",
                     bookId = "book-1",
                     createdAt = 1730000000000L,
@@ -110,11 +111,13 @@ class CollectionContractTest :
             val decoded =
                 json.decodeFromString<CollectionBookSyncPayload>(json.encodeToString(original))
             decoded shouldBe original
+            decoded.id shouldBe "a1b2c3d4e5f60718293a4b5c6d7e8f90"
         }
 
         test("CollectionBookSyncPayload round-trips as tombstone") {
             val original =
                 CollectionBookSyncPayload(
+                    id = "b2c3d4e5f60718293a4b5c6d7e8f9001",
                     collectionId = "col-1",
                     bookId = "book-2",
                     createdAt = 1730000000000L,
@@ -124,6 +127,7 @@ class CollectionContractTest :
             val decoded =
                 json.decodeFromString<CollectionBookSyncPayload>(json.encodeToString(original))
             decoded shouldBe original
+            decoded.id shouldBe "b2c3d4e5f60718293a4b5c6d7e8f9001"
         }
 
         // ── CollectionShareSyncPayload ────────────────────────────────────────

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/MoodContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/MoodContractTest.kt
@@ -53,6 +53,7 @@ class MoodContractTest :
         test("BookMoodSyncPayload round-trips with all fields populated") {
             val original =
                 BookMoodSyncPayload(
+                    id = "a1b2c3d4e5f60718293a4b5c6d7e8f90",
                     bookId = "book-xyz",
                     moodId = "mood-abc123",
                     createdAt = 1_700_000_000_000L,
@@ -60,11 +61,13 @@ class MoodContractTest :
                     deletedAt = null,
                 )
             roundTrip<BookMoodSyncPayload>(original) shouldBe original
+            original.id shouldBe "a1b2c3d4e5f60718293a4b5c6d7e8f90"
         }
 
         test("BookMoodSyncPayload tombstone round-trips") {
             val original =
                 BookMoodSyncPayload(
+                    id = "b2c3d4e5f60718293a4b5c6d7e8f9001",
                     bookId = "book-xyz",
                     moodId = "mood-abc123",
                     createdAt = 1_700_000_000_000L,
@@ -72,6 +75,7 @@ class MoodContractTest :
                     deletedAt = 1_700_001_000_000L,
                 )
             roundTrip<BookMoodSyncPayload>(original) shouldBe original
+            original.id shouldBe "b2c3d4e5f60718293a4b5c6d7e8f9001"
         }
 
         // ── MoodSummary ───────────────────────────────────────────────────────

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/TagContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/TagContractTest.kt
@@ -50,6 +50,7 @@ class TagContractTest :
         test("BookTagSyncPayload round-trips with all fields populated") {
             val original =
                 BookTagSyncPayload(
+                    id = "a1b2c3d4e5f60718293a4b5c6d7e8f90",
                     bookId = "book-xyz",
                     tagId = "tag-abc123",
                     createdAt = 1_700_000_000_000L,
@@ -57,11 +58,13 @@ class TagContractTest :
                     deletedAt = null,
                 )
             roundTrip<BookTagSyncPayload>(original) shouldBe original
+            original.id shouldBe "a1b2c3d4e5f60718293a4b5c6d7e8f90"
         }
 
         test("BookTagSyncPayload tombstone round-trips") {
             val original =
                 BookTagSyncPayload(
+                    id = "b2c3d4e5f60718293a4b5c6d7e8f9001",
                     bookId = "book-xyz",
                     tagId = "tag-abc123",
                     createdAt = 1_700_000_000_000L,
@@ -69,6 +72,7 @@ class TagContractTest :
                     deletedAt = 1_700_001_000_000L,
                 )
             roundTrip<BookTagSyncPayload>(original) shouldBe original
+            original.id shouldBe "b2c3d4e5f60718293a4b5c6d7e8f9001"
         }
 
         // ── TagSummary ────────────────────────────────────────────────────────

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryImplTest.kt
@@ -52,7 +52,7 @@ class TagRepositoryImplTest :
         fun bookTagEntity(
             bookId: String,
             tagId: String,
-        ) = BookTagEntity(bookId = bookId, tagId = tagId, createdAt = 1L)
+        ) = BookTagEntity(bookId = bookId, tagId = tagId, syncId = "$bookId:$tagId", createdAt = 1L)
 
         // ── observeAllTags ────────────────────────────────────────────────────
 

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.jvm.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.data.local.db
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.calypsan.listenup.client.data.local.images.JvmStoragePaths
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_1_2
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -27,6 +28,7 @@ internal actual val platformDatabaseModule: Module =
                 ).setDriver(BundledSQLiteDriver())
                 .setQueryCoroutineContext(Dispatchers.IO)
                 .addCallback(FtsTableCallback())
+                .addMigrations(MIGRATION_1_2)
                 // Non-destructive: a schema mismatch throws (loudly) rather than SILENTLY wiping the
                 // local DB — which includes the unsynced outbox (queued playback positions, listening
                 // history, offline edits not yet pushed). Every schema-version bump MUST ship a Room

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookTagDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookTagDaoTest.kt
@@ -159,6 +159,43 @@ class BookTagDaoTest :
                 }
             }
         }
+
+        // ── SERVER-SYNC-04: opaque syncId ──────────────────────────────────────
+
+        test("tombstoneBySyncId tombstones only the row with that syncId, by identity — never by pair") {
+            runTest {
+                dao.upsert(bookTag("b1", "t1", syncId = "opaque-1"))
+                dao.upsert(bookTag("b1", "t2", syncId = "opaque-2"))
+
+                dao.tombstoneBySyncId("opaque-1", deletedAt = 999L, revision = 5L)
+
+                val tombstoned = dao.findByKey("b1", "t1")!!
+                tombstoned.deletedAt shouldBe 999L
+                tombstoned.revision shouldBe 5L
+                dao.findByKey("b1", "t2")!!.deletedAt shouldBe null
+            }
+        }
+
+        test("tombstoneBySyncId is a graceful no-op (0 rows affected) for an unmatched syncId") {
+            runTest {
+                dao.upsert(bookTag("b1", "t1", syncId = "opaque-1"))
+
+                dao.tombstoneBySyncId("never-seen", deletedAt = 999L, revision = 5L) shouldBe 0
+                dao.findByKey("b1", "t1")!!.deletedAt shouldBe null
+            }
+        }
+
+        test("revisionOfSyncId returns the stored revision by opaque identity, tombstones included") {
+            runTest {
+                dao.upsert(bookTag("b1", "t1", syncId = "opaque-1", revision = 3L))
+                dao.revisionOfSyncId("opaque-1") shouldBe 3L
+
+                dao.tombstoneBySyncId("opaque-1", deletedAt = 1L, revision = 9L)
+                dao.revisionOfSyncId("opaque-1") shouldBe 9L
+
+                dao.revisionOfSyncId("never-seen") shouldBe null
+            }
+        }
     })
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -169,9 +206,11 @@ private fun bookTag(
     createdAt: Long = 1L,
     revision: Long = 1L,
     deletedAt: Long? = null,
+    syncId: String = "$bookId:$tagId",
 ) = BookTagEntity(
     bookId = bookId,
     tagId = tagId,
+    syncId = syncId,
     createdAt = createdAt,
     revision = revision,
     deletedAt = deletedAt,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/CollectionDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/CollectionDaoTest.kt
@@ -115,14 +115,54 @@ class CollectionDaoTest :
                 bookDao.upsert(member("c1", "b1"))
                 bookDao.upsert(member("c1", "b2"))
                 bookDao.upsert(member("c1", "b3"))
-                bookDao.liveSyntheticIds().toSet() shouldBe setOf("c1:b1", "c1:b2", "c1:b3")
+                bookDao.liveSyncIds().toSet() shouldBe setOf("c1:b1", "c1:b2", "c1:b3")
 
                 bookDao.tombstoneByIds(listOf("c1:b1", "c1:b2"), now = 777L)
 
-                bookDao.liveSyntheticIds() shouldBe listOf("c1:b3")
+                bookDao.liveSyncIds() shouldBe listOf("c1:b3")
                 bookDao.findByKey("c1", "b1")!!.deletedAt shouldNotBe null
                 bookDao.findByKey("c1", "b2")!!.deletedAt shouldNotBe null
                 bookDao.findByKey("c1", "b3")!!.deletedAt shouldBe null
+            }
+        }
+
+        // ── SERVER-SYNC-04: opaque syncId ──────────────────────────────────────
+
+        test("tombstoneBySyncId tombstones only the row with that syncId, by identity — never by pair") {
+            runTest {
+                bookDao.upsert(member("c1", "b1", syncId = "opaque-1"))
+                bookDao.upsert(member("c1", "b2", syncId = "opaque-2"))
+
+                bookDao.tombstoneBySyncId("opaque-1", deletedAt = 999L, revision = 5L)
+
+                val tombstoned = bookDao.findByKey("c1", "b1")!!
+                tombstoned.deletedAt shouldBe 999L
+                tombstoned.revision shouldBe 5L
+                bookDao.findByKey("c1", "b2")!!.deletedAt shouldBe null
+            }
+        }
+
+        test("liveSyncIdsForCollections returns only live syncIds for the requested collections") {
+            runTest {
+                bookDao.upsert(member("c1", "b1", syncId = "opaque-1"))
+                bookDao.upsert(member("c2", "b2", syncId = "opaque-2"))
+                bookDao.upsert(member("c3", "b3", syncId = "opaque-3"))
+                bookDao.tombstone(collectionId = "c1", bookId = "b1", deletedAt = 1L, revision = 1L)
+
+                // c1's row is tombstoned; c2 is in scope; c3 is never named — neither survives the filter.
+                bookDao.liveSyncIdsForCollections(listOf("c1", "c2")).toSet() shouldBe setOf("opaque-2")
+            }
+        }
+
+        test("revisionOfSyncId returns the stored revision by opaque identity, tombstones included") {
+            runTest {
+                bookDao.upsert(member("c1", "b1", syncId = "opaque-1"))
+                bookDao.revisionOfSyncId("opaque-1") shouldBe 1L
+
+                bookDao.tombstoneBySyncId("opaque-1", deletedAt = 1L, revision = 9L)
+                bookDao.revisionOfSyncId("opaque-1") shouldBe 9L
+
+                bookDao.revisionOfSyncId("never-seen") shouldBe null
             }
         }
 
@@ -224,9 +264,11 @@ private fun member(
     bookId: String,
     createdAt: Long = 1L,
     deletedAt: Long? = null,
+    syncId: String = "$collectionId:$bookId",
 ) = CollectionBookEntity(
     collectionId = collectionId,
     bookId = bookId,
+    syncId = syncId,
     createdAt = createdAt,
     revision = 1L,
     deletedAt = deletedAt,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/TagDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/TagDaoTest.kt
@@ -181,9 +181,11 @@ private fun bookTag(
     createdAt: Long = 1L,
     revision: Long = 1L,
     deletedAt: Long? = null,
+    syncId: String = "$bookId:$tagId",
 ) = BookTagEntity(
     bookId = bookId,
     tagId = tagId,
+    syncId = syncId,
     createdAt = createdAt,
     revision = revision,
     deletedAt = deletedAt,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaBaselineDriftTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaBaselineDriftTest.kt
@@ -13,13 +13,13 @@ import java.nio.file.Paths
 import kotlinx.coroutines.runBlocking
 
 /**
- * Drift guard for the committed Room schema baseline (currently **v1** — the pre-launch schema
- * squashed back to a single version-1 baseline; there are no production installs to migrate).
+ * Drift guard for the committed Room schema baseline (currently **v2** — the squashed v1 baseline
+ * plus the SERVER-SYNC-04 junction `syncId` columns added by `MIGRATION_1_2`).
  *
- * The current authoritative baseline is `schemas/…/ListenUpDatabase/1.json`. Nothing else asserts
+ * The current authoritative baseline is `schemas/…/ListenUpDatabase/2.json`. Nothing else asserts
  * that this JSON still matches the compiled `@Entity` set: Room's Gradle plugin *re-exports* the
  * JSON on build instead of failing, so an entity edit that forgets to commit the regenerated
- * `1.json` — or a JSON edit that doesn't match the entities — is invisible to CI.
+ * `2.json` — or a JSON edit that doesn't match the entities — is invisible to CI.
  *
  * This test closes that gap. It creates a database whose schema (and stored identity hash)
  * comes from the committed baseline JSON, then reopens the same file with the real compiled
@@ -27,16 +27,14 @@ import kotlinx.coroutines.runBlocking
  * the stored identity hash against the compiled schema on first connection use, so any drift
  * between the JSON and the entities fails this test loudly.
  *
- * The pre-launch policy is `fallbackToDestructiveMigration(true)` with no hand-written
- * migration chain, so a schema change is landed by bumping the DB version and re-exporting the
- * baseline — this guard is then pinned to the new latest version. When a real migration chain
- * begins (fallback flipped to `false` before launch), this evolves into the migration-and-validate
- * suite the [SchemaMigrationSmokeTest] KDoc promises; the temp-file + reopen pattern here is the
- * scaffold for it.
+ * A schema change is landed by bumping the DB version, shipping a hand-written migration (the
+ * destructive fallback is gone — the local DB holds the unsynced outbox), and re-exporting the
+ * baseline — this guard is then pinned to the new latest version. Migration-path validation
+ * itself lives in [SchemaMigrationSmokeTest]; this test only pins baseline↔entity identity.
  */
 class SchemaBaselineDriftTest :
     FunSpec({
-        test("compiled ListenUpDatabase opens a database created from the committed 1.json baseline") {
+        test("compiled ListenUpDatabase opens a database created from the committed 2.json baseline") {
             // Resolve the exported-schema directory the same way the shared helper does:
             // Gradle runs :sharedLogic:jvmTest with the module root as working directory,
             // so `schemas` points at the Room-plugin export folder.
@@ -62,9 +60,9 @@ class SchemaBaselineDriftTest :
                 )
 
             try {
-                // Create the schema in `databasePath` FROM the committed 1.json (this also
+                // Create the schema in `databasePath` FROM the committed 2.json (this also
                 // writes the JSON's identity hash into room_master_table), then release it.
-                helper.createDatabase(version = 1).close()
+                helper.createDatabase(version = 2).close()
 
                 // Reopen the SAME file with the real compiled database — deliberately WITHOUT
                 // fallbackToDestructiveMigration, so Room's identity-hash validation runs
@@ -77,8 +75,8 @@ class SchemaBaselineDriftTest :
 
                 try {
                     withClue(
-                        "committed 1.json no longer matches the compiled @Entity schema — " +
-                            "regenerate sharedLogic/schemas/…/ListenUpDatabase/1.json " +
+                        "committed 2.json no longer matches the compiled @Entity schema — " +
+                            "regenerate sharedLogic/schemas/…/ListenUpDatabase/2.json " +
                             "(the build re-exports it) and commit the diff",
                     ) {
                         // First connection use forces Room to open and validate the stored

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaMigrationSmokeTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaMigrationSmokeTest.kt
@@ -22,26 +22,31 @@ class SchemaMigrationSmokeTest :
             try {
                 val v1 = helper.createDatabase(version = 1)
                 val now = 1_700_000_000_000L
-                v1.prepare(
-                    "INSERT INTO libraries (id, name, metadataPrecedence, accessMode, createdAt, revision) " +
-                        "VALUES ('lib1', 'Lib', 'embedded,abs,sidecar', 'shared', $now, 0)",
-                ).use { it.step() }
-                v1.prepare(
-                    "INSERT INTO collections (id, libraryId, ownerId, name, isInbox, revision, updatedAt) " +
-                        "VALUES ('col1', 'lib1', 'user1', 'Collection', 0, 0, $now)",
-                ).use { it.step() }
-                v1.prepare(
-                    "INSERT INTO collection_books (collectionId, bookId, createdAt, revision, deletedAt) " +
-                        "VALUES ('col1', 'book1', $now, 0, NULL)",
-                ).use { it.step() }
-                v1.prepare(
-                    "INSERT INTO book_tags (bookId, tagId, createdAt, revision, deletedAt) " +
-                        "VALUES ('book1', 'tag1', $now, 0, NULL)",
-                ).use { it.step() }
-                v1.prepare(
-                    "INSERT INTO book_moods (bookId, moodId, createdAt, revision, deletedAt) " +
-                        "VALUES ('book1', 'mood1', $now, 0, NULL)",
-                ).use { it.step() }
+                v1
+                    .prepare(
+                        "INSERT INTO libraries (id, name, metadataPrecedence, accessMode, createdAt, revision) " +
+                            "VALUES ('lib1', 'Lib', 'embedded,abs,sidecar', 'shared', $now, 0)",
+                    ).use { it.step() }
+                v1
+                    .prepare(
+                        "INSERT INTO collections (id, libraryId, ownerId, name, isInbox, revision, updatedAt) " +
+                            "VALUES ('col1', 'lib1', 'user1', 'Collection', 0, 0, $now)",
+                    ).use { it.step() }
+                v1
+                    .prepare(
+                        "INSERT INTO collection_books (collectionId, bookId, createdAt, revision, deletedAt) " +
+                            "VALUES ('col1', 'book1', $now, 0, NULL)",
+                    ).use { it.step() }
+                v1
+                    .prepare(
+                        "INSERT INTO book_tags (bookId, tagId, createdAt, revision, deletedAt) " +
+                            "VALUES ('book1', 'tag1', $now, 0, NULL)",
+                    ).use { it.step() }
+                v1
+                    .prepare(
+                        "INSERT INTO book_moods (bookId, moodId, createdAt, revision, deletedAt) " +
+                            "VALUES ('book1', 'mood1', $now, 0, NULL)",
+                    ).use { it.step() }
                 v1.close()
 
                 val v2 = helper.runMigrationsAndValidate(version = 2, migrations = listOf(MIGRATION_1_2))
@@ -65,10 +70,11 @@ class SchemaMigrationSmokeTest :
                 }
 
                 // The syncId column + unique index now exist and accept a fresh opaque row.
-                v2.prepare(
-                    "INSERT INTO collection_books (collectionId, bookId, syncId, createdAt, revision, deletedAt) " +
-                        "VALUES ('col1', 'book1', 'opaque-id-1', $now, 0, NULL)",
-                ).use { it.step() }
+                v2
+                    .prepare(
+                        "INSERT INTO collection_books (collectionId, bookId, syncId, createdAt, revision, deletedAt) " +
+                            "VALUES ('col1', 'book1', 'opaque-id-1', $now, 0, NULL)",
+                    ).use { it.step() }
                 v2.prepare("SELECT syncId FROM collection_books WHERE collectionId = 'col1'").use { stmt ->
                     stmt.step()
                     stmt.getText(0) shouldBe "opaque-id-1"

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaMigrationSmokeTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaMigrationSmokeTest.kt
@@ -1,38 +1,79 @@
 package com.calypsan.listenup.client.data.local.db.migration
 
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_1_2
 import com.calypsan.listenup.client.test.db.createMigrationTestHelper
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 /**
- * Smoke test for the Room [androidx.room.testing.MigrationTestHelper] harness.
+ * Regression proof for the real v1 → v2 migration (SERVER-SYNC-04): `collection_books`/
+ * `book_tags`/`book_moods` each gain a `syncId` column, and any pre-migration row in those three
+ * tables is deleted (its real opaque wire id is unknowable — see [MIGRATION_1_2]'s KDoc).
  *
- * Proves the test plumbing works end-to-end for `ListenUpDatabase` — schema
- * export on disk, driver wiring, constructor factory — so that when the real
- * v1 → v2 migration lands, schema equivalence can be asserted without
- * scaffolding a helper from scratch. When v2 ships, replace this smoke test
- * with an actual migration-and-validate assertion.
+ * Seeds one row per affected junction table (plus an unrelated `collections` row, to prove the
+ * migration touches only the three junction tables) against the v1 schema, runs the real
+ * [MIGRATION_1_2], and validates the result against the exported v2 schema.
  */
 class SchemaMigrationSmokeTest :
     FunSpec({
-        test("creates current schema database and opens a live connection") {
+        test("v1 to v2 migration adds syncId to junction tables and deletes their pre-migration rows") {
             val helper = createMigrationTestHelper()
             try {
-                // Pin to the latest exported schema — when further schema
-                // changes land, bump this and start asserting actual v(N-1) → v(N) migration
-                // behaviour. Today this just proves the harness can load the schema
-                // bundle and drive [androidx.sqlite.SQLiteConnection].
-                val connection = helper.createDatabase(version = 1)
-                connection.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").use { stmt ->
-                    val tables =
-                        buildList {
-                            while (stmt.step()) add(stmt.getText(0))
-                        }
-                    withClue("schema must define the `books` table — saw $tables") {
-                        ("books" in tables) shouldBe true
+                val v1 = helper.createDatabase(version = 1)
+                val now = 1_700_000_000_000L
+                v1.prepare(
+                    "INSERT INTO libraries (id, name, metadataPrecedence, accessMode, createdAt, revision) " +
+                        "VALUES ('lib1', 'Lib', 'embedded,abs,sidecar', 'shared', $now, 0)",
+                ).use { it.step() }
+                v1.prepare(
+                    "INSERT INTO collections (id, libraryId, ownerId, name, isInbox, revision, updatedAt) " +
+                        "VALUES ('col1', 'lib1', 'user1', 'Collection', 0, 0, $now)",
+                ).use { it.step() }
+                v1.prepare(
+                    "INSERT INTO collection_books (collectionId, bookId, createdAt, revision, deletedAt) " +
+                        "VALUES ('col1', 'book1', $now, 0, NULL)",
+                ).use { it.step() }
+                v1.prepare(
+                    "INSERT INTO book_tags (bookId, tagId, createdAt, revision, deletedAt) " +
+                        "VALUES ('book1', 'tag1', $now, 0, NULL)",
+                ).use { it.step() }
+                v1.prepare(
+                    "INSERT INTO book_moods (bookId, moodId, createdAt, revision, deletedAt) " +
+                        "VALUES ('book1', 'mood1', $now, 0, NULL)",
+                ).use { it.step() }
+                v1.close()
+
+                val v2 = helper.runMigrationsAndValidate(version = 2, migrations = listOf(MIGRATION_1_2))
+
+                // The unrelated collections row survives the migration untouched.
+                v2.prepare("SELECT COUNT(*) FROM collections WHERE id = 'col1'").use { stmt ->
+                    stmt.step()
+                    withClue("the collections row must survive the junction-only migration") {
+                        stmt.getLong(0) shouldBe 1L
                     }
                 }
+
+                // Every pre-migration junction row is gone — the healing path is a re-pull, not a carry-over.
+                for (table in listOf("collection_books", "book_tags", "book_moods")) {
+                    v2.prepare("SELECT COUNT(*) FROM $table").use { stmt ->
+                        stmt.step()
+                        withClue("$table must be emptied by the v1->v2 migration (unknowable pre-migration syncId)") {
+                            stmt.getLong(0) shouldBe 0L
+                        }
+                    }
+                }
+
+                // The syncId column + unique index now exist and accept a fresh opaque row.
+                v2.prepare(
+                    "INSERT INTO collection_books (collectionId, bookId, syncId, createdAt, revision, deletedAt) " +
+                        "VALUES ('col1', 'book1', 'opaque-id-1', $now, 0, NULL)",
+                ).use { it.step() }
+                v2.prepare("SELECT syncId FROM collection_books WHERE collectionId = 'col1'").use { stmt ->
+                    stmt.step()
+                    stmt.getText(0) shouldBe "opaque-id-1"
+                }
+                v2.close()
             } finally {
                 helper.close()
             }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookDetailMoodsTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookDetailMoodsTest.kt
@@ -189,6 +189,7 @@ private suspend fun seedBookMood(
         .toHandler(RoomTransactionRunner(db), ClientSyncDomainRegistry())
         .onCatchUpItem(
             BookMoodSyncPayload(
+                id = "$bookId:$moodId",
                 bookId = bookId,
                 moodId = moodId,
                 createdAt = 100L,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookEditRepositoryOfflineTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookEditRepositoryOfflineTest.kt
@@ -268,7 +268,12 @@ class BookEditRepositoryOfflineTest :
                     db.seedCollection("old")
                     db.seedCollection("new")
                     db.collectionBookDao().upsert(
-                        CollectionBookEntity(collectionId = "old", bookId = bookId.value, createdAt = 1L),
+                        CollectionBookEntity(
+                            collectionId = "old",
+                            bookId = bookId.value,
+                            syncId = "old:${bookId.value}",
+                            createdAt = 1L,
+                        ),
                     )
                     val repo = db.bookEditRepository()
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryOfflineTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryOfflineTest.kt
@@ -5,15 +5,21 @@ import com.calypsan.listenup.api.dto.CollectionSummary
 import com.calypsan.listenup.api.dto.SharePermission
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.SyncEvent
 import com.calypsan.listenup.client.data.local.db.CollectionBookEntity
 import com.calypsan.listenup.client.data.local.db.CollectionEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.RpcChannel
 import com.calypsan.listenup.client.data.remote.forTest
+import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
 import com.calypsan.listenup.client.data.sync.OfflineEditor
 import com.calypsan.listenup.client.data.sync.PendingOperationQueue
 import com.calypsan.listenup.client.data.sync.PendingOperationSender
+import com.calypsan.listenup.client.data.sync.domains.collectionBooksDomain
+import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakeAuthSession
 import com.calypsan.listenup.core.CollectionId
@@ -26,6 +32,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
 
@@ -54,6 +61,7 @@ class CollectionRepositoryOfflineTest :
         ) = CollectionBookEntity(
             collectionId = collectionId,
             bookId = bookId,
+            syncId = "$collectionId:$bookId",
             createdAt = 50L,
             revision = 1,
             deletedAt = null,
@@ -122,10 +130,56 @@ class CollectionRepositoryOfflineTest :
                 val row = db.collectionBookDao().findByKey("c1", "b1").shouldNotBeNull()
                 row.deletedAt.shouldBeNull()
                 row.revision shouldBe 0
+                // SERVER-SYNC-04: the optimistic row already carries a non-blank, client-minted
+                // opaque syncId — never a "$collectionId:$bookId" composite (satisfies the syncId
+                // NOT NULL constraint before any server round-trip).
+                row.syncId.isBlank() shouldBe false
+                row.syncId shouldNotBe "c1:b1"
                 val op = db.pendingOperationV2Dao().nextDispatchable().single()
                 op.domainName shouldBe "collection_books"
                 op.entityId shouldBe "c1:b1"
                 op.opType shouldBe "create"
+                db.close()
+            }
+        }
+
+        test("addBook's optimistic syncId self-heals to the server's authoritative id on echo") {
+            // SERVER-SYNC-04 (Locked Decision #3): the client mints a placeholder syncId offline-first;
+            // the server mints its own authoritative id independently. Room's @Upsert is keyed on the
+            // NATURAL pair (collectionId, bookId) — not syncId — so the server's Created echo (carrying
+            // the real id) overwrites the local row in place instead of creating a duplicate.
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val repo = repo(db)
+                repo.addBook("c1", "b1")
+                val clientMintedSyncId = db.collectionBookDao().findByKey("c1", "b1")!!.syncId
+
+                val handler =
+                    collectionBooksDomain(db).toHandler(RoomTransactionRunner(db), ClientSyncDomainRegistry())
+                val serverSyncId = "server-authoritative-id"
+                handler.onEvent(
+                    SyncEvent.Created(
+                        id = serverSyncId,
+                        revision = 1L,
+                        occurredAt = 200L,
+                        clientOpId = null,
+                        payload =
+                            CollectionBookSyncPayload(
+                                id = serverSyncId,
+                                collectionId = "c1",
+                                bookId = "b1",
+                                createdAt = 200L,
+                                revision = 1L,
+                            ),
+                    ),
+                )
+
+                val row = db.collectionBookDao().findByKey("c1", "b1")!!
+                row.syncId shouldBe serverSyncId
+                row.syncId shouldNotBe clientMintedSyncId
+                row.revision shouldBe 1L
+                // Still exactly one row for the natural pair — no duplicate.
+                db.collectionBookDao().liveSyncIds() shouldBe listOf(serverSyncId)
                 db.close()
             }
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/MoodRepositoryOfflineTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/MoodRepositoryOfflineTest.kt
@@ -38,7 +38,9 @@ class MoodRepositoryOfflineTest :
         test("removeMoodFromBook tombstones the junction and enqueues a book_moods op keyed by \$bookId:\$moodId") {
             runTest {
                 val db = createInMemoryTestDatabase()
-                db.bookMoodDao().upsert(BookMoodEntity(bookId = "b1", moodId = "m1", createdAt = 0L, revision = 1))
+                db.bookMoodDao().upsert(
+                    BookMoodEntity(bookId = "b1", moodId = "m1", syncId = "b1:m1", createdAt = 0L, revision = 1),
+                )
                 val repo = repo(db, mock())
 
                 val result = repo.removeMoodFromBook(bookId = "b1", moodId = "m1")

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/MoodRepositoryTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/MoodRepositoryTest.kt
@@ -113,7 +113,14 @@ private suspend fun seedBookMood(
     bookMoodsDomain(db)
         .toHandler(RoomTransactionRunner(db), ClientSyncDomainRegistry())
         .onCatchUpItem(
-            BookMoodSyncPayload(bookId = bookId, moodId = moodId, createdAt = 100L, revision = 1L, deletedAt = null),
+            BookMoodSyncPayload(
+                id = "$bookId:$moodId",
+                bookId = bookId,
+                moodId = moodId,
+                createdAt = 100L,
+                revision = 1L,
+                deletedAt = null,
+            ),
             isTombstone = false,
         )
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryOfflineTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryOfflineTest.kt
@@ -26,6 +26,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
 
@@ -145,16 +146,14 @@ class ShelfRepositoryOfflineTest :
                 val result = repo.addBooksToShelf(ShelfId("s1"), listOf(BookId("b2"), BookId("b3")))
 
                 result shouldBe AppResult.Success(Unit)
-                db
-                    .shelfBookDao()
-                    .findById("s1:b2")
-                    .shouldNotBeNull()
-                    .sortOrder shouldBe 1
-                db
-                    .shelfBookDao()
-                    .findById("s1:b3")
-                    .shouldNotBeNull()
-                    .sortOrder shouldBe 2
+                // SERVER-SYNC-04: the optimistic row's id is a freshly-minted opaque value, not the
+                // "$shelfId:$bookId" composite — look it up by the natural pair.
+                val row2 = db.shelfBookDao().findByShelfAndBook("s1", "b2").shouldNotBeNull()
+                row2.sortOrder shouldBe 1
+                row2.id.isBlank() shouldBe false
+                row2.id shouldNotBe "s1:b2"
+                val row3 = db.shelfBookDao().findByShelfAndBook("s1", "b3").shouldNotBeNull()
+                row3.sortOrder shouldBe 2
                 val ops = db.pendingOperationV2Dao().nextDispatchable()
                 ops.map { it.entityId }.toSet() shouldBe setOf("s1:b2", "s1:b3")
                 ops.forEach {

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryOfflineTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryOfflineTest.kt
@@ -92,8 +92,8 @@ class TagRepositoryOfflineTest :
             runTest {
                 val f = fixture()
                 f.db.tagDao().upsert(TagEntity(id = "t1", name = "Sci Fi", slug = "sci-fi", revision = 2, updatedAt = 0L))
-                f.db.bookTagDao().upsert(BookTagEntity(bookId = "b1", tagId = "t1", createdAt = 0L, revision = 1))
-                f.db.bookTagDao().upsert(BookTagEntity(bookId = "b2", tagId = "t1", createdAt = 0L, revision = 1))
+                f.db.bookTagDao().upsert(BookTagEntity(bookId = "b1", tagId = "t1", syncId = "b1:t1", createdAt = 0L, revision = 1))
+                f.db.bookTagDao().upsert(BookTagEntity(bookId = "b2", tagId = "t1", syncId = "b2:t1", createdAt = 0L, revision = 1))
                 val repo = f.repo(mock())
 
                 val result = repo.deleteTag("t1")
@@ -129,7 +129,7 @@ class TagRepositoryOfflineTest :
         test("removeTagFromBook tombstones the junction and enqueues a book_tags op keyed by \$bookId:\$tagId") {
             runTest {
                 val f = fixture()
-                f.db.bookTagDao().upsert(BookTagEntity(bookId = "b1", tagId = "t1", createdAt = 0L, revision = 1))
+                f.db.bookTagDao().upsert(BookTagEntity(bookId = "b1", tagId = "t1", syncId = "b1:t1", createdAt = 0L, revision = 1))
                 val repo = f.repo(mock())
 
                 val result = repo.removeTagFromBook(bookId = "b1", tagId = "t1")

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookMoodsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookMoodsDomainTest.kt
@@ -138,6 +138,7 @@ private fun junctionPayload(
     revision: Long = 1L,
     deletedAt: Long? = null,
 ) = BookMoodSyncPayload(
+    id = "$bookId:$moodId",
     bookId = bookId,
     moodId = moodId,
     createdAt = createdAt,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookMoodsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookMoodsDomainTest.kt
@@ -85,12 +85,19 @@ class BookMoodsDomainTest :
             }
         }
 
-        test("Deleted event with malformed id logs and returns Success") {
-            withHandler { handler, _ ->
+        test("Deleted event for an unknown id is a graceful no-op") {
+            // SERVER-SYNC-04: the wire id is opaque and never parsed, so there is no "malformed id"
+            // failure mode anymore — the only failure mode is an id that matches no local row, which
+            // must log and return Success without touching any other row.
+            withHandler { handler, db ->
+                handler.onEvent(created(junctionPayload("b1", "m1", revision = 1L)))
+
                 handler
                     .onEvent(
-                        SyncEvent.Deleted(id = "malformed", revision = 2L, occurredAt = 900L),
+                        SyncEvent.Deleted(id = "never-seen-opaque-id", revision = 2L, occurredAt = 900L),
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                db.bookMoodDao().findByKey("b1", "m1")!!.deletedAt shouldBe null
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookTagsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookTagsDomainTest.kt
@@ -155,6 +155,7 @@ private fun junctionPayload(
     revision: Long = 1L,
     deletedAt: Long? = null,
 ) = BookTagSyncPayload(
+    id = "$bookId:$tagId",
     bookId = bookId,
     tagId = tagId,
     createdAt = createdAt,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookTagsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookTagsDomainTest.kt
@@ -89,13 +89,19 @@ class BookTagsDomainTest :
             }
         }
 
-        test("Deleted event with malformed id logs warning and returns Success") {
-            withHandler { handler, _ ->
-                // Should not throw — just log and return Success
+        test("Deleted event for an unknown id is a graceful no-op") {
+            // SERVER-SYNC-04: the wire id is opaque and never parsed, so there is no "malformed id"
+            // failure mode anymore — the only failure mode is an id that matches no local row, which
+            // must log and return Success without touching any other row.
+            withHandler { handler, db ->
+                handler.onEvent(created(junctionPayload("b1", "t1", revision = 1L)))
+
                 handler
                     .onEvent(
-                        SyncEvent.Deleted(id = "invalid-no-colon", revision = 1L, occurredAt = 100L),
+                        SyncEvent.Deleted(id = "never-seen-opaque-id", revision = 1L, occurredAt = 100L),
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                db.bookTagDao().findByKey("b1", "t1")!!.deletedAt shouldBe null
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionBooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionBooksDomainTest.kt
@@ -87,11 +87,19 @@ class CollectionBooksDomainTest :
             }
         }
 
-        test("collection_books Deleted event with malformed id logs and returns Success") {
-            withHandler { handler, _ ->
+        test("collection_books Deleted event for an unknown id is a graceful no-op") {
+            // SERVER-SYNC-04: the wire id is opaque and never parsed, so there is no "malformed id"
+            // failure mode anymore — the only failure mode is an id that matches no local row, which
+            // must log and return Success without touching any other row.
+            withHandler { handler, db ->
+                handler.onEvent(createdJunction(junctionPayload("c1", "b1", revision = 1L)))
+
                 handler
-                    .onEvent(SyncEvent.Deleted(id = "no-colon-here", revision = 1L, occurredAt = 100L))
+                    .onEvent(SyncEvent.Deleted(id = "never-seen-opaque-id", revision = 1L, occurredAt = 100L))
                     .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                // The unrelated live row is untouched.
+                db.collectionBookDao().findByKey("c1", "b1")!!.deletedAt shouldBe null
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionBooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionBooksDomainTest.kt
@@ -149,6 +149,7 @@ private fun junctionPayload(
     revision: Long = 1L,
     deletedAt: Long? = null,
 ) = CollectionBookSyncPayload(
+    id = "$collectionId:$bookId",
     collectionId = collectionId,
     bookId = bookId,
     createdAt = createdAt,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestParityE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestParityE2ETest.kt
@@ -343,11 +343,29 @@ class DigestParityE2ETest :
                     // Seed three live book-tag junctions (no tombstones — the parity test targets
                     // the id-mapping contract, not the tombstone catch-up path).
                     val payload1 =
-                        BookTagSyncPayload(bookId = "book-1", tagId = "tag-a", createdAt = 1000L, revision = 0L)
+                        BookTagSyncPayload(
+                            id = "book-1:tag-a",
+                            bookId = "book-1",
+                            tagId = "tag-a",
+                            createdAt = 1000L,
+                            revision = 0L,
+                        )
                     val payload2 =
-                        BookTagSyncPayload(bookId = "book-2", tagId = "tag-b", createdAt = 2000L, revision = 0L)
+                        BookTagSyncPayload(
+                            id = "book-2:tag-b",
+                            bookId = "book-2",
+                            tagId = "tag-b",
+                            createdAt = 2000L,
+                            revision = 0L,
+                        )
                     val payload3 =
-                        BookTagSyncPayload(bookId = "book-3", tagId = "tag-c", createdAt = 3000L, revision = 0L)
+                        BookTagSyncPayload(
+                            id = "book-3:tag-c",
+                            bookId = "book-3",
+                            tagId = "tag-c",
+                            createdAt = 3000L,
+                            revision = 0L,
+                        )
                     bookTagRepo.upsert(payload1)
                     bookTagRepo.upsert(payload2)
                     bookTagRepo.upsert(payload3)
@@ -435,6 +453,7 @@ class DigestParityE2ETest :
                     // targets the id-mapping contract, not the tombstone catch-up path).
                     val payload1 =
                         CollectionBookSyncPayload(
+                            id = "col-1:book-1",
                             collectionId = "col-1",
                             bookId = "book-1",
                             createdAt = 1000L,
@@ -442,6 +461,7 @@ class DigestParityE2ETest :
                         )
                     val payload2 =
                         CollectionBookSyncPayload(
+                            id = "col-1:book-2",
                             collectionId = "col-1",
                             bookId = "book-2",
                             createdAt = 2000L,
@@ -449,6 +469,7 @@ class DigestParityE2ETest :
                         )
                     val payload3 =
                         CollectionBookSyncPayload(
+                            id = "col-2:book-3",
                             collectionId = "col-2",
                             bookId = "book-3",
                             createdAt = 3000L,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperTest.kt
@@ -136,14 +136,18 @@ class LibraryResetHelperTest :
                         DomainProbe(
                             domainName = "book_tags",
                             seed = {
-                                db.bookTagDao().upsert(BookTagEntity(bookId = "b1", tagId = "t1", createdAt = 0L))
+                                db.bookTagDao().upsert(
+                                    BookTagEntity(bookId = "b1", tagId = "t1", syncId = "b1:t1", createdAt = 0L),
+                                )
                             },
                             isGone = { db.bookTagDao().findByKey("b1", "t1") == null },
                         ),
                         DomainProbe(
                             domainName = "book_moods",
                             seed = {
-                                db.bookMoodDao().upsert(BookMoodEntity(bookId = "b1", moodId = "m1", createdAt = 0L))
+                                db.bookMoodDao().upsert(
+                                    BookMoodEntity(bookId = "b1", moodId = "m1", syncId = "b1:m1", createdAt = 0L),
+                                )
                             },
                             isGone = { db.bookMoodDao().findByKey("b1", "m1") == null },
                         ),
@@ -346,6 +350,7 @@ class LibraryResetHelperTest :
                                     CollectionBookEntity(
                                         collectionId = "seed-collection",
                                         bookId = "b1",
+                                        syncId = "seed-collection:b1",
                                         createdAt = 0L,
                                     ),
                                 )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelfBooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelfBooksDomainTest.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.sync.ShelfBookSyncPayload
 import com.calypsan.listenup.api.sync.SyncEvent
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.local.db.ShelfBookEntity
 import com.calypsan.listenup.client.data.sync.domains.shelfBooksDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
@@ -36,6 +37,37 @@ class ShelfBooksDomainTest :
                 row.sortOrder shouldBe 0
                 row.revision shouldBe 1L
                 row.deletedAt shouldBe null
+            }
+        }
+
+        test("upsert reconciles a client-minted row to the server's echoed id for the same pair — no duplicate") {
+            // SERVER-SYNC-04: shelf_books' primary key IS the opaque wire id (unlike the other three
+            // junction domains, whose PK is the natural pair), so a client-minted optimistic add and
+            // the server's later Created echo for the SAME (shelfId, bookId) carry DIFFERENT primary
+            // keys. ShelfBookMirrorApply.upsert must collapse them into one row, not leave both.
+            withHandler { handler, db ->
+                db.shelfBookDao().upsert(
+                    ShelfBookEntity(
+                        id = "client-minted-id",
+                        shelfId = "s1",
+                        bookId = "b1",
+                        sortOrder = 0,
+                        revision = 0,
+                        deletedAt = null,
+                        updatedAt = 100L,
+                        createdAt = 100L,
+                    ),
+                )
+
+                handler
+                    .onEvent(createdJunction(junctionPayload("s1", "b1", sortOrder = 0, revision = 1L, id = "server-echoed-id")))
+                    .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                db.shelfBookDao().findById("client-minted-id") shouldBe null
+                val row = db.shelfBookDao().findById("server-echoed-id")
+                row shouldNotBe null
+                row!!.revision shouldBe 1L
+                db.shelfBookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldBe listOf("server-echoed-id")
             }
         }
 
@@ -129,8 +161,9 @@ private fun junctionPayload(
     sortOrder: Int = 0,
     revision: Long = 1L,
     deletedAt: Long? = null,
+    id: String = "$shelfId:$bookId",
 ) = ShelfBookSyncPayload(
-    id = "$shelfId:$bookId",
+    id = id,
     shelfId = shelfId,
     bookId = bookId,
     sortOrder = sortOrder,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/TagSyncE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/TagSyncE2ETest.kt
@@ -180,6 +180,7 @@ private fun bookTagPayload(
 ): BookTagSyncPayload {
     val now = System.currentTimeMillis()
     return BookTagSyncPayload(
+        id = "$bookId:$tagId",
         bookId = bookId,
         tagId = tagId,
         createdAt = now,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/CatchUpRevisionGuardTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/CatchUpRevisionGuardTest.kt
@@ -124,13 +124,15 @@ class CatchUpRevisionGuardTest :
                             id = "b1:t1",
                             revision = 6L,
                             occurredAt = 2L,
-                            payload = BookTagSyncPayload(bookId = "b1", tagId = "t1", createdAt = 1L, revision = 6L),
+                            payload =
+                                BookTagSyncPayload(id = "b1:t1", bookId = "b1", tagId = "t1", createdAt = 1L, revision = 6L),
                         ),
                     )
 
                     // A stale from-zero catch-up page still carries the pre-restore tombstone at rev 5.
                     handler.onCatchUpItem(
                         BookTagSyncPayload(
+                            id = "b1:t1",
                             bookId = "b1",
                             tagId = "t1",
                             createdAt = 1L,


### PR DESCRIPTION
Closes the last open finding from the 2026-07-16 pre-ship audit. Junction-domain wire identity used to BE the natural pair (`"$collectionId:$bookId"`), so ungated tombstone delivery leaked real associations to every authenticated user — on the pull path and the SSE firehose. This lands the uniform fix across all four junction domains (`collection_books`, `book_tags`, `book_moods`, `shelf_books`):

- **Wire ids are opaque and stored, never parsed.** Server mints per-row ids (client-minted for offline-first creates; on a natural-pair conflict the existing row's id wins). Every client-side `split(":")` is deleted.
- **Tombstones blank the pair** via `minimizeTombstone` overrides — same mechanism as the plan-087 domains. The old pinning test ("identity survives") is inverted to "pair blanked, opaque id survives".
- **Live rows still carry the pair** — they're access-filtered; only the identity stops encoding it. SSE Created/Updated visibility now reads the collection id off the event payload (never parsed off the id), hiding defensively on a missing payload.
- **V54** rewrites existing ids (data-only — all four tables already had unique-indexed `id` columns; no golden regen). Digests change → clients full-resync once, the intended healing path.
- **Client Room v1→v2**: junction mirrors gain a `syncId` column; the migration deletes existing junction rows (their old syncIds are unknowable) and lets digest reconciliation re-pull — outbox and pending rows untouched.

Restores the sync invariant by construction: a tombstone strands no secret — a client that never held the row learns nothing from its deletion.

Gates: full `:server:jvmTest` (2,967 tests, 0 failures), `:contract:jvmTest`, targeted sharedLogic suites (domains/DAO/migration/digest-parity/outbox), spotless+detekt, `:server:compileKotlinLinuxX64`. No Swift-export impact (sync payloads are not exported).