### PR TITLE
✨ feat(contract): tolerant-reader fallback for unknown AppError families

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ContractJson.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ContractJson.kt
@@ -1,6 +1,13 @@
 package com.calypsan.listenup.api
 
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.UnknownError
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
 
 /**
  * The canonical [Json] instance for the contract layer — the source-of-truth serialization
@@ -24,9 +31,44 @@ import kotlinx.serialization.json.Json
  * The client-side [com.calypsan.listenup.core.appJson] is a superset that adds
  * client-specific concerns (sync-stream polymorphic defaults) on top of this base configuration.
  */
+@OptIn(ExperimentalSerializationApi::class)
 public val contractJson: Json =
     Json {
         ignoreUnknownKeys = true
         isLenient = true
         prettyPrint = false
+        serializersModule =
+            SerializersModule {
+                // Tolerant reader on the POLYMORPHIC axis. `ignoreUnknownKeys` above covers
+                // unknown *fields*; it does nothing for unknown *subtypes* — an unrecognised
+                // `type` discriminator in a sealed hierarchy throws. Without this, a client in
+                // the field fails on the error path the first time a newer server returns an
+                // error family added after that client shipped. See UnknownError's KDoc.
+                polymorphicDefaultDeserializer(AppError::class) { UnknownErrorDeserializer(it) }
+            }
     }
+
+/**
+ * Decodes an unrecognised [AppError] family as [UnknownError], recording which family actually
+ * arrived.
+ *
+ * Every [AppError] shares the same field names, so decoding the unknown payload *as*
+ * [UnknownError] carries `code`, `message`, `correlationId` and `isRetryable` across for free.
+ * The one thing the payload cannot carry is its own identity — the `type` discriminator is
+ * consumed by the polymorphic machinery — so it is folded into `debugInfo` here. Without it a
+ * reader knows only that *something* unknown arrived, which is the difference between an
+ * actionable log line and a shrug.
+ */
+private class UnknownErrorDeserializer(
+    private val arrivingSerialName: String?,
+) : DeserializationStrategy<UnknownError> {
+    override val descriptor: SerialDescriptor = UnknownError.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): UnknownError {
+        val decoded = UnknownError.serializer().deserialize(decoder)
+        val name = arrivingSerialName ?: return decoded
+        return decoded.copy(
+            debugInfo = listOfNotNull("unknownFamily=$name", decoded.debugInfo).joinToString(" "),
+        )
+    }
+}

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/AppError.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/AppError.kt
@@ -55,6 +55,41 @@ data class InternalError(
 }
 
 /**
+ * The tolerant-reader landing zone for an [AppError] family this build has never heard of.
+ *
+ * `ignoreUnknownKeys` makes a client tolerate new *fields*; it does nothing for new *subtypes* —
+ * an unrecognised `type` discriminator in a sealed hierarchy throws. Without a fallback, a client
+ * already in the field would fail on the error path the first time a newer server returned an
+ * error family added after that client shipped, which is the worst possible moment to fail.
+ *
+ * `contractJson` registers this type as the polymorphic default for [AppError], so an unknown
+ * family decodes here instead. Because every field name matches the shared [AppError] surface,
+ * the diagnostically load-bearing values — [code] and [correlationId] — survive the fallback, and
+ * the operator can still join a user's report to a server log line. [debugInfo] carries the
+ * original serial name so the arriving family is never silently anonymous.
+ *
+ * Every property is defaulted: an unknown payload that omits any of them still decodes.
+ *
+ * This type is never *constructed* by product code — it only ever arrives from the wire. Code
+ * folding [AppError] should treat it as "a newer peer told us something we don't understand,"
+ * which is a prompt-to-update signal, not a domain outcome.
+ */
+@Serializable
+@SerialName("AppError.UnknownError")
+data class UnknownError(
+    @SerialName("code")
+    override val code: String = "UNKNOWN_ERROR",
+    @SerialName("message")
+    override val message: String = "Something went wrong.",
+    @SerialName("correlationId")
+    override val correlationId: String? = null,
+    @SerialName("debugInfo")
+    override val debugInfo: String? = null,
+    @SerialName("isRetryable")
+    override val isRetryable: Boolean = false,
+) : AppError
+
+/**
  * Input failed validation — surfaces both client-side pre-flight checks
  * and server-side `init`-block violations on `@Serializable` requests.
  *

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/CorrelationStamping.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/CorrelationStamping.kt
@@ -63,7 +63,8 @@ public fun AppError.withCorrelationId(id: String?): AppError =
 
         is BackupError -> withCorrelationId(id)
 
-        is ValidationError, is InternalError, is TransportError, is PlaybackError -> leafWithCorrelationId(id)
+        is ValidationError, is InternalError, is TransportError, is PlaybackError, is UnknownError,
+        -> leafWithCorrelationId(id)
     }
 
 /**
@@ -79,6 +80,7 @@ private fun AppError.leafWithCorrelationId(id: String?): AppError =
     when (this) {
         is ValidationError -> copy(correlationId = id)
         is InternalError -> copy(correlationId = id)
+        is UnknownError -> copy(correlationId = id)
         is TransportError -> withCorrelationId(id)
         is PlaybackError -> withCorrelationId(id)
         else -> this // unreachable: only called from the grouped branch above

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/api/error/UnknownErrorSubtypeFallbackTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/api/error/UnknownErrorSubtypeFallbackTest.kt
@@ -1,0 +1,83 @@
+package com.calypsan.listenup.api.error
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * The additive-wire guarantee on the **polymorphic** axis.
+ *
+ * `ignoreUnknownKeys = true` makes an old client tolerate new *fields*. It does nothing for new
+ * *subtypes*: an unrecognised `type` discriminator in a sealed hierarchy throws
+ * `SerializationException`. Without a registered polymorphic default, a client in the field that
+ * meets an `AppError` family added after it shipped fails on the error path — i.e. hardest exactly
+ * when something has already gone wrong.
+ *
+ * That makes every future error-taxonomy change wire-breaking, which is a decision we would rather
+ * not make by accident. These tests pin the fallback.
+ */
+class UnknownErrorSubtypeFallbackTest :
+    FunSpec({
+        // A payload from a hypothetical future server: an AppError family this build has never
+        // heard of. Shaped like every other AppError — the discriminator is the only unknown.
+        val futureFamilyWire =
+            """
+            {"type":"AppError.SomeFutureFamily","correlationId":"cid-future-1",
+             "code":"FUTURE_THING_FAILED","message":"A future thing failed.","isRetryable":true}
+            """.trimIndent()
+
+        test("an AppError subtype this build does not know decodes instead of throwing") {
+            shouldNotThrowAny {
+                contractJson.decodeFromString<AppError>(futureFamilyWire)
+            }
+        }
+
+        test("the fallback preserves the correlation id so the operator can still join the log line") {
+            val decoded = contractJson.decodeFromString<AppError>(futureFamilyWire)
+
+            decoded.correlationId shouldBe "cid-future-1"
+        }
+
+        test("the fallback preserves the wire code rather than flattening it to a constant") {
+            val decoded = contractJson.decodeFromString<AppError>(futureFamilyWire)
+
+            decoded.code shouldBe "FUTURE_THING_FAILED"
+        }
+
+        test("the fallback names the family that arrived, so it is never silently anonymous") {
+            val decoded = contractJson.decodeFromString<AppError>(futureFamilyWire)
+
+            decoded.debugInfo shouldContain "AppError.SomeFutureFamily"
+        }
+
+        test("a known AppError family still decodes to its own type, not the fallback") {
+            val known: AppError = InternalError(correlationId = "cid-known", cause = "IllegalStateException")
+
+            val decoded = contractJson.decodeFromString<AppError>(contractJson.encodeToString(known))
+
+            decoded.shouldBeInstanceOf<InternalError>()
+            decoded shouldBe known
+        }
+
+        // Control probe (canon ch. 09): a rule must be shown to fail when unset, or it proves
+        // nothing. Without the polymorphic default, the very same payload throws — which is
+        // exactly the pre-fix behaviour this fallback exists to remove.
+        test("WITHOUT the polymorphic default the same payload throws — the setting is load-bearing") {
+            val noFallbackJson =
+                Json {
+                    ignoreUnknownKeys = true
+                    isLenient = true
+                }
+
+            shouldThrow<SerializationException> {
+                noFallbackJson.decodeFromString<AppError>(futureFamilyWire)
+            }
+        }
+    })

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -27,6 +27,7 @@ import com.calypsan.listenup.api.error.SocialError
 import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.error.TagError
 import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.error.UnknownError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.api.error.withCorrelationId as stampCorrelationId
 import com.calypsan.listenup.api.result.AppResult
@@ -160,10 +161,14 @@ internal fun AppError.toHttpStatus(): HttpStatusCode =
 
         is ValidationError -> HttpStatusCode.BadRequest
 
-        // InternalError, TransportError, and PlaybackError are all server-bug / client-local paths;
-        // grouped into a single branch so the function stays under the cyclomatic-complexity threshold
-        // while remaining exhaustive — a new AppError subtype will still fail this when at compile time.
-        is InternalError, is TransportError, is PlaybackError -> HttpStatusCode.InternalServerError
+        // InternalError, TransportError, PlaybackError, and UnknownError are all server-bug /
+        // client-local paths; grouped into a single branch so the function stays under the
+        // cyclomatic-complexity threshold while remaining exhaustive — a new AppError subtype will
+        // still fail this when at compile time. UnknownError is receive-only (the polymorphic
+        // fallback in contractJson); a server holding one means it decoded an error family it does
+        // not know, which is a 500 by definition.
+        is InternalError, is TransportError, is PlaybackError, is UnknownError,
+        -> HttpStatusCode.InternalServerError
     }
 
 private fun AuthError.toHttpStatus(): HttpStatusCode =


### PR DESCRIPTION
## Why

`contractJson` and `appJson` configured only `ignoreUnknownKeys = true`. That covers unknown **fields**; it does nothing for unknown **polymorphic subtypes** — an unrecognised `type` discriminator in a sealed hierarchy throws `SerializationException`.

No `serializersModule` with a polymorphic default existed anywhere in the repo. So a client already in the field would fail on the **error path** the first time a newer server returned an `AppError` family added after that client shipped — failing hardest exactly when something has already gone wrong.

This makes every future error-taxonomy change wire-breaking. Fixing it costs ~10 lines now; after launch it costs a client release plus a drain window before the option is usable again.

Proven, not asserted — the RED run:

```
Serializer for subclass 'AppError.SomeFutureFamily' is not found
in the polymorphic scope of 'AppError'
```

## What

- `UnknownError` — the tolerant-reader landing zone for an unrecognised `AppError` family. Every property defaulted, so a payload omitting any of them still decodes.
- `contractJson` registers it as the polymorphic default for `AppError`. Because `contractJson` is the single choke point for client RPC (`RpcProxyCache`), server RPC, and REST `ContentNegotiation`, one registration covers all three transports.
- Field names match the shared `AppError` surface, so `code`, `message`, `correlationId` and `isRetryable` survive the fallback — the operator can still join a user's report to a server log line.
- The arriving family's serial name is folded into `debugInfo` (`unknownFamily=…`), since the `type` discriminator is consumed by the polymorphic machinery and would otherwise be lost.

The compiler then identified the only other site needing a decision — `AppErrorStatusPages.toHttpStatus()`, where `UnknownError` maps to 500. That is the contract-as-compiled-artifact property working as intended.

## Tests

Six, RED-first:

- unknown subtype decodes instead of throwing
- fallback preserves `correlationId`
- fallback preserves the wire `code`
- fallback names the arriving family
- known families still decode to their own type
- **control probe** — without the polymorphic default, the same payload throws

The control probe is the falsifiability check: it proves the setting is load-bearing rather than decorative.

## Verification

```
contract:  33 specs,  108 tests, 0 failures, 0 errors
server:   512 specs, 2973 tests, 0 failures, 0 errors, 5 skipped
spotlessCheck + detekt: BUILD SUCCESSFUL
```