### PR TITLE
🐛 fix: two-letter searches say "no results" when trigram cannot answer them

### DIFF
--- a/app/iosApp/ListenUp/Features/BookEdit/RelationSearchField.swift
+++ b/app/iosApp/ListenUp/Features/BookEdit/RelationSearchField.swift
@@ -35,8 +35,14 @@ struct RelationSearchField: View {
 
     /// The create row shows only when creation is permitted, the query is long enough, nothing is
     /// loading, and no result already matches the typed name exactly (case-insensitively).
+    ///
+    /// Gated on the same `minSearchQueryLength` floor as search itself: below it, the local index
+    /// cannot yet tell us whether a matching entry already exists, so inviting the user to *create*
+    /// one is exactly how duplicates get made.
     private var showsCreateRow: Bool {
-        guard allowsCreate, onCreate != nil, !isLoading, trimmedQuery.count >= 2 else { return false }
+        guard allowsCreate, onCreate != nil, !isLoading, trimmedQuery.count >= minSearchQueryLength else {
+            return false
+        }
         return !results.contains { $0.name.caseInsensitiveCompare(trimmedQuery) == .orderedSame }
     }
 
@@ -62,10 +68,21 @@ struct RelationSearchField: View {
             if !results.isEmpty || showsCreateRow {
                 resultsList
             } else if !trimmedQuery.isEmpty, !isLoading {
-                Text(String(localized: "book.edit_no_matches"))
+                // Below the floor, the local index hasn't run at all — "No matches." would lie
+                // about the state of the world. Prompt the user to keep typing instead.
+                if trimmedQuery.count < minSearchQueryLength {
+                    Text(
+                        String(format: String(localized: "search.keep_typing_description"), minSearchQueryLength)
+                    )
                     .font(.subheadline)
                     .foregroundStyle(Color.luLabel3)
                     .padding(.horizontal, 4)
+                } else {
+                    Text(String(localized: "book.edit_no_matches"))
+                        .font(.subheadline)
+                        .foregroundStyle(Color.luLabel3)
+                        .padding(.horizontal, 4)
+                }
             }
         }
     }
@@ -137,7 +154,7 @@ struct RelationSearchField: View {
     private func submit() {
         if let top = results.first {
             onSelect(top)
-        } else if allowsCreate, let onCreate, trimmedQuery.count >= 2 {
+        } else if allowsCreate, let onCreate, trimmedQuery.count >= minSearchQueryLength {
             onCreate(trimmedQuery)
         }
     }

--- a/app/iosApp/ListenUp/Features/Search/SearchModels.swift
+++ b/app/iosApp/ListenUp/Features/Search/SearchModels.swift
@@ -206,11 +206,24 @@ enum SearchRoute: Hashable {
 /// The render phase of the search screen, flattened from the shared `SearchUiState`.
 enum SearchPhase: Equatable {
     case idle
+    case tooShort
     case searching
     case results
     case empty
     case error(String)
 }
+
+/// Mirrors the shared `MIN_SEARCH_QUERY_LENGTH` floor
+/// (`client/.../domain/model/Search.kt`) — the client's local FTS5 index is built with
+/// `tokenize='trigram'`, which cannot match a query shorter than this at all.
+///
+/// The Kotlin constant is a top-level `const val`, not a type, so it isn't part of the
+/// flat-typealias Swift Export surface (`tools/scripts/export-surface-inventory.sh`
+/// only covers exported types/objects — see `SearchResultCaps.shared` for that pattern)
+/// and no existing Swift call site bridges a top-level Kotlin constant to confirm the
+/// generated symbol name. Kept here as a single named constant, mirrored by hand, rather
+/// than scattering the literal `3` across `SearchView`/`RelationSearchField`.
+let minSearchQueryLength = 3
 
 extension String {
     var nilIfEmpty: String? { isEmpty ? nil : self }

--- a/app/iosApp/ListenUp/Features/Search/SearchObserver.swift
+++ b/app/iosApp/ListenUp/Features/Search/SearchObserver.swift
@@ -69,6 +69,9 @@ final class SearchObserver {
         case .idle:
             phase = .idle
             groups = SearchHitGroups()
+        case .tooShort:
+            phase = .tooShort
+            groups = SearchHitGroups()
         case .searching:
             phase = .searching
         case .results(let results):

--- a/app/iosApp/ListenUp/Features/Search/SearchView.swift
+++ b/app/iosApp/ListenUp/Features/Search/SearchView.swift
@@ -63,6 +63,14 @@ struct SearchView: View {
                 systemImage: "magnifyingglass",
                 description: Text(String(localized: "search.find_description"))
             )
+        case .tooShort:
+            ContentUnavailableView(
+                String(localized: "search.keep_typing"),
+                systemImage: "keyboard",
+                description: Text(
+                    String(format: String(localized: "search.keep_typing_description"), minSearchQueryLength)
+                )
+            )
         case .searching:
             LoadingStateView(label: String(localized: "search.searching"))
         case .empty:

--- a/app/iosApp/ListenUp/Features/Search/SeeAllSearchObserver.swift
+++ b/app/iosApp/ListenUp/Features/Search/SeeAllSearchObserver.swift
@@ -46,6 +46,11 @@ final class SeeAllSearchObserver {
             phase = .idle
         case .loading:
             phase = .loading
+        case .tooShort:
+            // Must precede any empty-collapse: routing this through .empty (or, before this case
+            // existed, through .unknown's error branch) tells the user their search failed when
+            // they have simply not typed enough for the trigram index to answer yet.
+            phase = .tooShort
         case .results(let results):
             phase = results.hits.isEmpty ? .empty : .results(results.hits.map { SearchRow($0) })
         case .error(let error):
@@ -72,6 +77,7 @@ final class SeeAllSearchObserver {
 enum SeeAllPhase: Equatable {
     case idle
     case loading
+    case tooShort
     case results([SearchRow])
     case empty
     case error(String)

--- a/app/iosApp/ListenUp/Features/Search/SeeAllSearchView.swift
+++ b/app/iosApp/ListenUp/Features/Search/SeeAllSearchView.swift
@@ -43,6 +43,14 @@ struct SeeAllSearchView: View {
         switch observer.phase {
         case .idle, .loading:
             LoadingStateView(label: String(localized: "search.searching"))
+        case .tooShort:
+            ContentUnavailableView(
+                String(localized: "search.keep_typing"),
+                systemImage: "keyboard",
+                description: Text(
+                    String(format: String(localized: "search.keep_typing_description"), minSearchQueryLength)
+                )
+            )
         case .empty:
             ContentUnavailableView.search(text: destination.query)
         case .error(let message):

--- a/app/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/app/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -10541,6 +10541,26 @@
         }
       }
     },
+    "search.keep_typing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep typing"
+          }
+        }
+      }
+    },
+    "search.keep_typing_description": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter at least %1$d characters to search"
+          }
+        }
+      }
+    },
     "search.no_results_for_query": {
       "localizations": {
         "en": {

--- a/app/iosApp/ListenUpTests/SearchObserverTests.swift
+++ b/app/iosApp/ListenUpTests/SearchObserverTests.swift
@@ -4,6 +4,14 @@ import Shared
 
 /// Pure-mapping coverage for the search observer's two seams: the single-select
 /// scope ↔ `Set<SearchHitType>` projection, and the de-duplicating hit grouping.
+///
+/// `SearchObserver.apply`'s flatten of the sealed `SearchUiState` (including the
+/// `.tooShort` phase added for the trigram-index minimum-query-length floor) can't be
+/// exercised here: SKIE bridges `SearchUiState` as a sealed protocol whose cases aren't
+/// constructible from Swift, so that `onEnum` mapping — including the new `TooShort` →
+/// `.tooShort` arm landing before any empty-collapse logic — is proven at the
+/// green-build pass (the app target's exhaustive `switch` compiling). What *is* pure and
+/// constructible is the mirrored `minSearchQueryLength` floor, pinned below.
 struct SearchObserverTests {
     // MARK: - Scope ↔ types projection
 
@@ -130,6 +138,32 @@ struct SearchObserverTests {
         #expect(SearchSeeAllType.book.hitType == .book)
         #expect(SearchSeeAllType.contributor.hitType == .contributor)
         #expect(SearchSeeAllType.series.hitType == .series)
+    }
+
+    // MARK: - Minimum query length floor
+
+    /// Mirrors `MIN_SEARCH_QUERY_LENGTH` (`client/.../domain/model/Search.kt`). Unlike
+    /// `SearchDisplayCap`, this can't cross-check against the shared source directly — the
+    /// Kotlin constant is a top-level `const val`, not an exported type/object, so it isn't
+    /// part of the Swift Export surface (see `SearchModels.swift`). This pins the mirrored
+    /// value so a change on either side without the other shows up as a failing test rather
+    /// than silent drift.
+    @Test func minSearchQueryLengthMatchesTheSharedFloor() {
+        #expect(minSearchQueryLength == 3)
+    }
+
+    @Test func tooShortPhaseIsDistinctFromOtherPhases() {
+        #expect(SearchPhase.tooShort != .idle)
+        #expect(SearchPhase.tooShort != .searching)
+        #expect(SearchPhase.tooShort != .empty)
+        #expect(SearchPhase.tooShort != .results)
+    }
+
+    @Test func seeAllTooShortPhaseIsDistinctFromOtherPhases() {
+        #expect(SeeAllPhase.tooShort != .idle)
+        #expect(SeeAllPhase.tooShort != .loading)
+        #expect(SeeAllPhase.tooShort != .empty)
+        #expect(SeeAllPhase.tooShort != .results([]))
     }
 
     // MARK: - Helpers

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryImpl.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryImpl.kt
@@ -18,6 +18,7 @@ import com.calypsan.listenup.client.data.remote.RpcChannel
 import com.calypsan.listenup.client.data.repository.common.QueryUtils
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
 import com.calypsan.listenup.client.domain.model.Contributor
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.client.domain.model.ContributorSearchResponse
 import com.calypsan.listenup.client.domain.model.ContributorSearchResult
@@ -190,7 +191,7 @@ internal class ContributorRepositoryImpl(
         limit: Int,
     ): ContributorSearchResponse {
         val sanitizedQuery = QueryUtils.sanitize(query)
-        if (sanitizedQuery.isBlank() || sanitizedQuery.length < 2) {
+        if (sanitizedQuery.isBlank() || sanitizedQuery.length < MIN_SEARCH_QUERY_LENGTH) {
             return ContributorSearchResponse(
                 contributors = emptyList(),
                 isOfflineResult = false,

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImpl.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImpl.kt
@@ -15,6 +15,7 @@ import com.calypsan.listenup.client.data.remote.RpcChannel
 import com.calypsan.listenup.api.sync.SeriesSyncPayload
 import com.calypsan.listenup.client.data.repository.common.QueryUtils
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.Series
 import com.calypsan.listenup.client.domain.model.SeriesSearchResponse
 import com.calypsan.listenup.client.domain.model.SeriesSearchResult
@@ -235,7 +236,7 @@ internal class SeriesRepositoryImpl(
         limit: Int,
     ): SeriesSearchResponse {
         val sanitizedQuery = QueryUtils.sanitize(query)
-        if (sanitizedQuery.isBlank() || sanitizedQuery.length < 2) {
+        if (sanitizedQuery.isBlank() || sanitizedQuery.length < MIN_SEARCH_QUERY_LENGTH) {
             return SeriesSearchResponse(
                 series = emptyList(),
                 isOfflineResult = false,

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/Search.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/Search.kt
@@ -4,6 +4,22 @@ import com.calypsan.listenup.client.core.DurationFormatter
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
+ * Shortest query the local search index can answer.
+ *
+ * The client's FTS5 tables are built with `tokenize='trigram'`, which indexes three-character
+ * sequences and therefore **cannot match a shorter query at all** — not "matches nothing", but
+ * "can never match". A query below this length must not be run: doing so returns an empty result
+ * that is indistinguishable from a genuine miss, so the UI reports "no results" for something the
+ * user could still complete by typing one more letter.
+ *
+ * It lives here, once, on purpose. This floor was previously copied into each caller as a private
+ * constant, and when the tokenizer moved from `porter` (which had no such floor) to trigram, none
+ * of the copies were updated — every search surface silently kept a stale value. A property of the
+ * index belongs with the domain, not duplicated across its consumers.
+ */
+const val MIN_SEARCH_QUERY_LENGTH: Int = 3
+
+/**
  * Type of search result.
  */
 enum class SearchHitType {

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.client.domain.model.Collection
 import com.calypsan.listenup.client.domain.model.CollectionBookItem
 import com.calypsan.listenup.client.domain.model.CollectionShare
 import com.calypsan.listenup.client.core.error.ErrorMapper
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.SearchHit
 import com.calypsan.listenup.client.domain.model.SearchHitType
 import com.calypsan.listenup.client.domain.repository.AdminRepository
@@ -244,11 +245,15 @@ class AdminCollectionDetailViewModel internal constructor(
      * `.debounce()` flow pipeline), so the debounce lives in the launched job, not in the state flow.
      * A backend search failure is surfaced (logged + emitted to [errorBus]) rather than swallowed, so
      * it isn't indistinguishable from "no results"; results then collapse to empty.
+     *
+     * A query below [MIN_SEARCH_QUERY_LENGTH] is treated the same as a blank one: the trigram FTS5
+     * index cannot match anything shorter, so running the search would only produce a false "no
+     * results" rather than a genuine miss.
      */
     fun onBookQueryChange(query: String) {
         updateReady { it.copy(bookQuery = query) }
         bookSearchJob?.cancel()
-        if (query.isBlank()) {
+        if (query.isBlank() || query.length < MIN_SEARCH_QUERY_LENGTH) {
             updateReady { it.copy(bookResults = emptyList(), isSearchingBooks = false) }
             return
         }

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/imports/ImportFlowViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/imports/ImportFlowViewModel.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.api.dto.imports.ImportEvent
 import com.calypsan.listenup.api.error.ImportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.onFailure
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.SearchHitType
 import com.calypsan.listenup.client.domain.repository.AdminRepository
 import com.calypsan.listenup.client.domain.repository.ImportRepository
@@ -277,7 +278,9 @@ class ImportFlowViewModel(
      *
      * Cancels the previous search job and launches a new one. After a 300 ms debounce,
      * calls [SearchRepository.search] filtered to [SearchHitType.BOOK] and maps the hits
-     * to [BookSearchHit]s. A blank [query] clears results without triggering a search call.
+     * to [BookSearchHit]s. A blank [query], or one shorter than [MIN_SEARCH_QUERY_LENGTH],
+     * clears results without triggering a search call — the trigram FTS5 index can never
+     * match a query below that floor, so running it would only produce a false "no results".
      *
      * Stale-result guard: results are only applied when the current
      * [ImportFlowUiState.Review.bookSearch]'s [absItemId] and query still match the search
@@ -298,7 +301,7 @@ class ImportFlowViewModel(
 
         bookSearchJob?.cancel()
 
-        if (query.isBlank()) {
+        if (query.isBlank() || query.length < MIN_SEARCH_QUERY_LENGTH) {
             updateReview { it.copy(bookSearch = it.bookSearch?.copy(results = emptyList(), isSearching = false)) }
             return
         }

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/ContributorEditDelegate.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/ContributorEditDelegate.kt
@@ -3,6 +3,7 @@
 package com.calypsan.listenup.client.presentation.bookedit.delegates
 
 import com.calypsan.listenup.client.domain.model.ContributorSearchResult
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.repository.ContributorRepository
 import com.calypsan.listenup.client.presentation.bookedit.BookEditUiState
 import com.calypsan.listenup.client.presentation.bookedit.ContributorRole
@@ -23,7 +24,6 @@ import kotlinx.coroutines.launch
 private val logger = KotlinLogging.logger {}
 
 private const val SEARCH_DEBOUNCE_MS = 300L
-private const val MIN_QUERY_LENGTH = 2
 private const val SEARCH_LIMIT = 10
 
 /**
@@ -62,7 +62,7 @@ class ContributorEditDelegate(
         queryFlow
             .debounce(SEARCH_DEBOUNCE_MS)
             .distinctUntilChanged()
-            .filter { it.length >= MIN_QUERY_LENGTH || it.isEmpty() }
+            .filter { it.length >= MIN_SEARCH_QUERY_LENGTH || it.isEmpty() }
             .onEach { query ->
                 if (query.isBlank()) {
                     state.update {

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/SeriesEditDelegate.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/SeriesEditDelegate.kt
@@ -2,6 +2,7 @@
 
 package com.calypsan.listenup.client.presentation.bookedit.delegates
 
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.SeriesSearchResult
 import com.calypsan.listenup.client.domain.repository.SeriesRepository
 import com.calypsan.listenup.client.presentation.bookedit.BookEditUiState
@@ -24,7 +25,6 @@ import kotlinx.coroutines.flow.update
 private val logger = KotlinLogging.logger {}
 
 private const val SEARCH_DEBOUNCE_MS = 300L
-private const val MIN_QUERY_LENGTH = 2
 private const val SEARCH_LIMIT = 10
 
 /**
@@ -196,7 +196,7 @@ class SeriesEditDelegate(
         seriesQueryFlow
             .debounce(SEARCH_DEBOUNCE_MS)
             .distinctUntilChanged()
-            .filter { it.length >= MIN_QUERY_LENGTH || it.isEmpty() }
+            .filter { it.length >= MIN_SEARCH_QUERY_LENGTH || it.isEmpty() }
             .flatMapLatest { query ->
                 if (query.isBlank()) {
                     flowOf<SeriesSearchFlowResult>(SeriesSearchFlowResult.Empty)

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.core.error.ErrorBus
 import com.calypsan.listenup.client.core.error.ErrorMapper
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.SearchHit
 import com.calypsan.listenup.client.domain.model.SearchHitType
 import com.calypsan.listenup.client.domain.model.SearchResult
@@ -38,10 +39,23 @@ sealed interface SearchUiState {
     val query: String
     val selectedTypes: Set<SearchHitType>
 
-    /** No query entered, or query too short to trigger a search. */
+    /** No query entered. */
     data class Idle(
         override val query: String = "",
         override val selectedTypes: Set<SearchHitType> = emptySet(),
+    ) : SearchUiState
+
+    /**
+     * [query] is non-blank but shorter than [MIN_SEARCH_QUERY_LENGTH], so no search was run.
+     *
+     * Distinct from [Results] with zero hits, and the distinction is the whole point: the user has
+     * typed something the index *cannot* answer yet, which is a prompt to keep typing, not a
+     * report that their book isn't there. Rendering this as "no results" is what made a two-letter
+     * search look like a broken app.
+     */
+    data class TooShort(
+        override val query: String,
+        override val selectedTypes: Set<SearchHitType>,
     ) : SearchUiState
 
     /** A search is in flight for the current [query] and [selectedTypes]. */
@@ -113,6 +127,7 @@ class SearchViewModel(
         combine(queryFlow, typesFlow, phaseFlow()) { query, types, phase ->
             when (phase) {
                 is Phase.Idle -> SearchUiState.Idle(query, types)
+                is Phase.TooShort -> SearchUiState.TooShort(query, types)
                 is Phase.Searching -> SearchUiState.Searching(query, types)
                 is Phase.Results -> SearchUiState.Results(query, types, phase.data)
                 is Phase.Error -> SearchUiState.Error(query, types, phase.message)
@@ -133,7 +148,13 @@ class SearchViewModel(
                 flow {
                     when {
                         query.isBlank() -> emit(Phase.Idle)
-                        query.length < MIN_QUERY_LENGTH -> Unit
+
+                        // Emit, don't skip. Emitting nothing here left the previous phase in place
+                        // while the query text moved on underneath it, so backspacing out of a
+                        // finished search stranded its hits on screen under a query that no longer
+                        // produced them.
+                        query.length < MIN_SEARCH_QUERY_LENGTH -> emit(Phase.TooShort)
+
                         else -> emitSearch(query, types)
                     }
                 }
@@ -214,6 +235,9 @@ class SearchViewModel(
     private sealed interface Phase {
         data object Idle : Phase
 
+        /** Query is below [MIN_SEARCH_QUERY_LENGTH]; no search was issued. */
+        data object TooShort : Phase
+
         data object Searching : Phase
 
         /** Search call completed successfully; carries the raw result for the public state. */
@@ -229,7 +253,6 @@ class SearchViewModel(
 
     companion object {
         private const val SEARCH_DEBOUNCE_MS = 300L
-        private const val MIN_QUERY_LENGTH = 2
         private const val DEFAULT_RESULT_LIMIT = 30
         private const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
     }

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/search/SeeAllSearchViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/search/SeeAllSearchViewModel.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.presentation.search
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.client.core.error.ErrorMapper
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.SearchHit
 import com.calypsan.listenup.client.domain.model.SearchHitType
 import com.calypsan.listenup.client.domain.repository.SearchRepository
@@ -31,6 +32,14 @@ private val logger = KotlinLogging.logger {}
 sealed interface SeeAllSearchUiState {
     /** No request loaded yet. */
     data object Idle : SeeAllSearchUiState
+
+    /**
+     * [Request.query] is non-blank but shorter than [MIN_SEARCH_QUERY_LENGTH], so no search was
+     * run. The FTS5 index is `tokenize='trigram'` and cannot match below that floor — a doomed
+     * search would surface as "no results" rather than the "keep typing" prompt this state exists
+     * to render instead.
+     */
+    data object TooShort : SeeAllSearchUiState
 
     /** A search is in flight for the requested type. */
     data object Loading : SeeAllSearchUiState
@@ -69,10 +78,10 @@ class SeeAllSearchViewModel(
         request
             .flatMapLatest { current ->
                 flow {
-                    if (current == null) {
-                        emit(SeeAllSearchUiState.Idle)
-                    } else {
-                        emitSearch(current.query, current.type)
+                    when {
+                        current == null -> emit(SeeAllSearchUiState.Idle)
+                        current.query.length < MIN_SEARCH_QUERY_LENGTH -> emit(SeeAllSearchUiState.TooShort)
+                        else -> emitSearch(current.query, current.type)
                     }
                 }
             }.stateIn(

--- a/app/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/app/sharedLogic/src/commonMain/resources/strings/en.json
@@ -594,6 +594,8 @@
     "count_books": "%1$s books",
     "cover_for": "Cover for %1$s",
     "find_description": "Find books by title, author, narrator, or series",
+    "keep_typing": "Keep typing",
+    "keep_typing_description": "Enter at least %1$d characters to search",
     "no_results_for_query": "No results for “%1$s”",
     "people": "People",
     "results_count_for": "%1$d results for “%2$s”",

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryImplTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryImplTest.kt
@@ -11,16 +11,20 @@ import com.calypsan.listenup.api.sync.ContributorSyncPayload
 import com.calypsan.listenup.client.data.remote.RpcChannel
 import com.calypsan.listenup.client.data.remote.forTest
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
@@ -1039,6 +1043,60 @@ class ContributorRepositoryImplTest :
                 result.size shouldBe 1
                 result[0].sortName shouldBe "Kramer, Michael"
                 result[0].asin shouldBe "B0029Y7RL0"
+            }
+        }
+
+        // ========== searchContributors Tests ==========
+        // The local FTS5 index uses `tokenize='trigram'`, which cannot match a query shorter
+        // than MIN_SEARCH_QUERY_LENGTH — a below-floor query must never reach the index.
+
+        test("searchContributors below MIN_SEARCH_QUERY_LENGTH never queries the FTS index") {
+            runTest {
+                val searchDao = mock<SearchDao>(MockMode.autoUnit)
+                val networkMonitor = mock<NetworkMonitor>()
+                every { networkMonitor.isOnline() } returns false
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockDao(),
+                        bookDao = mock<BookDao>(MockMode.autoUnit),
+                        searchDao = searchDao,
+                        networkMonitor = networkMonitor,
+                        imageStorage = mock<ImageStorage>(),
+                        channel = RpcChannel.forTest(mock<ContributorService>(MockMode.autoUnit)),
+                        contributorSyncHandler = mock<SyncDomainHandler<ContributorSyncPayload>>(MockMode.autoUnit),
+                    )
+
+                val belowFloor = "a".repeat(MIN_SEARCH_QUERY_LENGTH - 1)
+                val result = repository.searchContributors(belowFloor, limit = 10)
+
+                result.contributors.shouldBeEmpty()
+                verifySuspend(VerifyMode.not) { searchDao.searchContributors(any(), any()) }
+            }
+        }
+
+        test("searchContributors at MIN_SEARCH_QUERY_LENGTH queries the FTS index") {
+            runTest {
+                val searchDao = mock<SearchDao>(MockMode.autoUnit)
+                everySuspend { searchDao.searchContributors(any(), any()) } returns
+                    listOf(createTestContributorEntity(id = "contrib-1", name = "Abcdef"))
+                val networkMonitor = mock<NetworkMonitor>()
+                every { networkMonitor.isOnline() } returns false
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockDao(),
+                        bookDao = mock<BookDao>(MockMode.autoUnit),
+                        searchDao = searchDao,
+                        networkMonitor = networkMonitor,
+                        imageStorage = mock<ImageStorage>(),
+                        channel = RpcChannel.forTest(mock<ContributorService>(MockMode.autoUnit)),
+                        contributorSyncHandler = mock<SyncDomainHandler<ContributorSyncPayload>>(MockMode.autoUnit),
+                    )
+
+                val atFloor = "a".repeat(MIN_SEARCH_QUERY_LENGTH)
+                val result = repository.searchContributors(atFloor, limit = 10)
+
+                result.contributors.map { it.id } shouldBe listOf("contrib-1")
+                verifySuspend { searchDao.searchContributors(any(), any()) }
             }
         }
     })

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImplTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImplTest.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.api.sync.SeriesSyncPayload
 import com.calypsan.listenup.client.data.remote.RpcChannel
 import com.calypsan.listenup.client.data.remote.forTest
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.api.result.AppResult
@@ -29,8 +30,10 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
@@ -978,6 +981,60 @@ class SeriesRepositoryImplTest :
                 result.shouldNotBeNull()
                 result.coverPath shouldBe null
                 result.asin shouldBe null
+            }
+        }
+
+        // ========== searchSeries Tests ==========
+        // The local FTS5 index uses `tokenize='trigram'`, which cannot match a query shorter
+        // than MIN_SEARCH_QUERY_LENGTH — a below-floor query must never reach the index.
+
+        test("searchSeries below MIN_SEARCH_QUERY_LENGTH never queries the FTS index") {
+            runTest {
+                val searchDao = mock<SearchDao>(MockMode.autoUnit)
+                val networkMonitor = mock<NetworkMonitor>()
+                every { networkMonitor.isOnline() } returns false
+                val repository =
+                    SeriesRepositoryImpl(
+                        seriesDao = createMockDao(),
+                        bookDao = mock<BookDao>(MockMode.autoUnit),
+                        searchDao = searchDao,
+                        networkMonitor = networkMonitor,
+                        imageStorage = mock<ImageStorage>(),
+                        channel = RpcChannel.forTest(mock<SeriesService>(MockMode.autoUnit)),
+                        seriesSyncHandler = mock<SyncDomainHandler<SeriesSyncPayload>>(MockMode.autoUnit),
+                    )
+
+                val belowFloor = "a".repeat(MIN_SEARCH_QUERY_LENGTH - 1)
+                val result = repository.searchSeries(belowFloor, limit = 10)
+
+                result.series.shouldBeEmpty()
+                verifySuspend(VerifyMode.not) { searchDao.searchSeries(any(), any()) }
+            }
+        }
+
+        test("searchSeries at MIN_SEARCH_QUERY_LENGTH queries the FTS index") {
+            runTest {
+                val searchDao = mock<SearchDao>(MockMode.autoUnit)
+                everySuspend { searchDao.searchSeries(any(), any()) } returns
+                    listOf(createTestSeriesEntity(id = "series-1", name = "Abcdef"))
+                val networkMonitor = mock<NetworkMonitor>()
+                every { networkMonitor.isOnline() } returns false
+                val repository =
+                    SeriesRepositoryImpl(
+                        seriesDao = createMockDao(),
+                        bookDao = mock<BookDao>(MockMode.autoUnit),
+                        searchDao = searchDao,
+                        networkMonitor = networkMonitor,
+                        imageStorage = mock<ImageStorage>(),
+                        channel = RpcChannel.forTest(mock<SeriesService>(MockMode.autoUnit)),
+                        seriesSyncHandler = mock<SyncDomainHandler<SeriesSyncPayload>>(MockMode.autoUnit),
+                    )
+
+                val atFloor = "a".repeat(MIN_SEARCH_QUERY_LENGTH)
+                val result = repository.searchSeries(atFloor, limit = 10)
+
+                result.series.map { it.id } shouldBe listOf("series-1")
+                verifySuspend { searchDao.searchSeries(any(), any()) }
             }
         }
     })

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModelSearchTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModelSearchTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.local.db.BookWithContributors
 import com.calypsan.listenup.client.data.local.db.ContributorEntity
 import com.calypsan.listenup.client.domain.model.Collection
 import com.calypsan.listenup.client.domain.model.CollectionShare
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.SearchFacets
 import com.calypsan.listenup.client.domain.model.SearchHit
 import com.calypsan.listenup.client.domain.model.SearchHitType
@@ -33,6 +34,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -235,6 +237,73 @@ class AdminCollectionDetailViewModelSearchTest :
                 // Only the non-member hit should appear
                 ready.bookResults.map { it.id } shouldBe listOf("b-new")
                 ready.isSearchingBooks shouldBe false
+            }
+        }
+
+        // Regression: the client's FTS5 tables are tokenize='trigram', which cannot match a query
+        // shorter than MIN_SEARCH_QUERY_LENGTH — not "matches nothing", but "can never match". Running
+        // the search anyway would produce an indistinguishable false "no results".
+        test("onBookQueryChange below the trigram floor never calls search and clears stale results") {
+            runTest(dispatcher) {
+                val f = Fixture()
+                everySuspend {
+                    f.searchRepo.search(
+                        query = "dun",
+                        types = listOf(SearchHitType.BOOK),
+                        limit = 20,
+                    )
+                } returns searchResult(searchHit("b-new", "Dune Messiah"))
+                val vm = f.build()
+                advanceUntilIdle()
+
+                vm.openAddBooks()
+                // A prior at-floor query populated real hits...
+                vm.onBookQueryChange("dun")
+                advanceTimeBy(301L)
+                advanceUntilIdle()
+                vm.state.value
+                    .shouldBeInstanceOf<AdminCollectionDetailUiState.Ready>()
+                    .bookResults
+                    .map { it.id } shouldBe listOf("b-new")
+
+                // ...but backspacing below the floor must not strand them on screen.
+                vm.onBookQueryChange("du")
+                advanceTimeBy(301L)
+                advanceUntilIdle()
+
+                val ready = vm.state.value.shouldBeInstanceOf<AdminCollectionDetailUiState.Ready>()
+                ready.bookResults shouldBe emptyList()
+                ready.isSearchingBooks shouldBe false
+                verifySuspend(VerifyMode.not) {
+                    f.searchRepo.search(query = "du", types = any(), limit = any())
+                }
+            }
+        }
+
+        test("onBookQueryChange at the trigram floor invokes search") {
+            runTest(dispatcher) {
+                val f = Fixture()
+                val floorQuery = "d".repeat(MIN_SEARCH_QUERY_LENGTH)
+                everySuspend {
+                    f.searchRepo.search(
+                        query = floorQuery,
+                        types = listOf(SearchHitType.BOOK),
+                        limit = 20,
+                    )
+                } returns searchResult(searchHit("b-new", "Dune Messiah"))
+                val vm = f.build()
+                advanceUntilIdle()
+
+                vm.openAddBooks()
+                vm.onBookQueryChange(floorQuery)
+                advanceTimeBy(301L)
+                advanceUntilIdle()
+
+                val ready = vm.state.value.shouldBeInstanceOf<AdminCollectionDetailUiState.Ready>()
+                ready.bookResults.map { it.id } shouldBe listOf("b-new")
+                verifySuspend {
+                    f.searchRepo.search(query = floorQuery, types = listOf(SearchHitType.BOOK), limit = 20)
+                }
             }
         }
 

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/imports/ImportFlowViewModelTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/imports/ImportFlowViewModelTest.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.client.domain.model.AdminUserInfo
 import com.calypsan.listenup.client.domain.model.FacetCount
 import com.calypsan.listenup.client.domain.model.InviteInfo
 import com.calypsan.listenup.client.domain.model.Library
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.ScanProgressState
 import com.calypsan.listenup.client.domain.model.SearchFacets
 import com.calypsan.listenup.client.domain.model.SearchHit
@@ -800,6 +801,74 @@ class ImportFlowViewModelTest :
                 bookSearch.query shouldBe ""
                 bookSearch.results.shouldBeEmpty()
                 // Only 1 search call was made (for "something"); blank didn't trigger another
+                searchRepo.searchCallCount shouldBe 1
+            }
+        }
+
+        // Regression: the client's FTS5 tables are tokenize='trigram', which cannot match a query
+        // shorter than MIN_SEARCH_QUERY_LENGTH — not "matches nothing", but "can never match". Running
+        // the search anyway would produce an indistinguishable false "no matches".
+        test("updateBookSearchQuery below the trigram floor never calls search and clears stale results") {
+            runTest(testDispatcher) {
+                val floorQuery = "d".repeat(MIN_SEARCH_QUERY_LENGTH)
+                val duneHit = SearchHit(id = "book-dune", type = SearchHitType.BOOK, name = "Dune", author = "Frank Herbert")
+                val searchRepo = FakeSearchRepository(results = listOf(duneHit))
+                val repo =
+                    FakeImportRepository(
+                        uploadResult = AppResult.Success(importSummary()),
+                        analyzeResult = AppResult.Success(importAnalysis()),
+                    )
+                val vm = ImportFlowViewModel(repo, ErrorBus(), FakeSyncRepository(), FakeAdminRepository(), searchRepo)
+                driveToReview(vm, repo)
+                vm.openBookSearch(AbsItemId("abs-item-99"))
+
+                // An at-floor query populates real hits...
+                vm.updateBookSearchQuery(floorQuery)
+                advanceTimeBy(301)
+                advanceUntilIdle()
+                vm.uiState.value
+                    .shouldBeInstanceOf<ImportFlowUiState.Review>()
+                    .bookSearch!!
+                    .results.size shouldBe 1
+                searchRepo.searchCallCount shouldBe 1
+
+                // ...but backspacing below the floor must not strand them on screen, and must not search.
+                val belowFloorQuery = floorQuery.dropLast(1)
+                vm.updateBookSearchQuery(belowFloorQuery)
+                advanceTimeBy(301)
+                advanceUntilIdle()
+
+                val review = vm.uiState.value.shouldBeInstanceOf<ImportFlowUiState.Review>()
+                val bookSearch = review.bookSearch.shouldNotBeNull()
+                bookSearch.query shouldBe belowFloorQuery
+                bookSearch.results.shouldBeEmpty()
+                bookSearch.isSearching shouldBe false
+                // No additional search call was made for the below-floor query.
+                searchRepo.searchCallCount shouldBe 1
+            }
+        }
+
+        test("updateBookSearchQuery at the trigram floor invokes search") {
+            runTest(testDispatcher) {
+                val floorQuery = "d".repeat(MIN_SEARCH_QUERY_LENGTH)
+                val duneHit = SearchHit(id = "book-dune", type = SearchHitType.BOOK, name = "Dune", author = "Frank Herbert")
+                val searchRepo = FakeSearchRepository(results = listOf(duneHit))
+                val repo =
+                    FakeImportRepository(
+                        uploadResult = AppResult.Success(importSummary()),
+                        analyzeResult = AppResult.Success(importAnalysis()),
+                    )
+                val vm = ImportFlowViewModel(repo, ErrorBus(), FakeSyncRepository(), FakeAdminRepository(), searchRepo)
+                driveToReview(vm, repo)
+                vm.openBookSearch(AbsItemId("abs-item-99"))
+
+                vm.updateBookSearchQuery(floorQuery)
+                advanceTimeBy(301)
+                advanceUntilIdle()
+
+                val review = vm.uiState.value.shouldBeInstanceOf<ImportFlowUiState.Review>()
+                val bookSearch = review.bookSearch.shouldNotBeNull()
+                bookSearch.results.size shouldBe 1
                 searchRepo.searchCallCount shouldBe 1
             }
         }

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/ContributorEditDelegateTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/ContributorEditDelegateTest.kt
@@ -1,0 +1,93 @@
+package com.calypsan.listenup.client.presentation.bookedit.delegates
+
+import com.calypsan.listenup.client.domain.model.ContributorSearchResponse
+import com.calypsan.listenup.client.domain.model.ContributorSearchResult
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
+import com.calypsan.listenup.client.domain.repository.ContributorRepository
+import com.calypsan.listenup.client.presentation.bookedit.BookEditUiState
+import com.calypsan.listenup.client.presentation.bookedit.ContributorRole
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [ContributorEditDelegate]'s per-role debounced search-query gating.
+ *
+ * The client's local FTS5 index uses `tokenize='trigram'`, which cannot match a query
+ * shorter than [MIN_SEARCH_QUERY_LENGTH] — a query below the floor must never reach
+ * [ContributorRepository.searchContributors], let alone the index itself.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+class ContributorEditDelegateTest :
+    FunSpec({
+
+        class Fixture {
+            val state = MutableStateFlow(BookEditUiState(bookId = "book-1"))
+            val contributorRepository: ContributorRepository = mock()
+
+            fun build(scope: CoroutineScope): ContributorEditDelegate =
+                ContributorEditDelegate(
+                    state = state,
+                    contributorRepository = contributorRepository,
+                    scope = scope,
+                    onChangesMade = {},
+                )
+        }
+
+        test("updateSearchQuery below MIN_SEARCH_QUERY_LENGTH never calls searchContributors") {
+            runTest {
+                val fixture = Fixture()
+                val delegate = fixture.build(backgroundScope)
+                delegate.setupRoleSearch(ContributorRole.AUTHOR)
+
+                delegate.updateSearchQuery(ContributorRole.AUTHOR, "ab")
+                advanceTimeBy(SEARCH_DEBOUNCE_MS + DEBOUNCE_MARGIN_MS)
+                runCurrent()
+
+                verifySuspend(VerifyMode.not) {
+                    fixture.contributorRepository.searchContributors(any(), any())
+                }
+            }
+        }
+
+        test("updateSearchQuery at MIN_SEARCH_QUERY_LENGTH calls searchContributors and populates results") {
+            runTest {
+                val fixture = Fixture()
+                everySuspend { fixture.contributorRepository.searchContributors(any(), any()) } returns
+                    ContributorSearchResponse(
+                        contributors = listOf(ContributorSearchResult(id = "contrib-1", name = "Brandon", bookCount = 5)),
+                        isOfflineResult = true,
+                        tookMs = 1L,
+                    )
+                val delegate = fixture.build(backgroundScope)
+                delegate.setupRoleSearch(ContributorRole.AUTHOR)
+
+                delegate.updateSearchQuery(ContributorRole.AUTHOR, "bra")
+                advanceTimeBy(SEARCH_DEBOUNCE_MS + DEBOUNCE_MARGIN_MS)
+                runCurrent()
+
+                verifySuspend { fixture.contributorRepository.searchContributors("bra", limit = 10) }
+                fixture.state.value
+                    .searchResultsForRole(ContributorRole.AUTHOR)
+                    .map { it.id } shouldContainExactly listOf("contrib-1")
+            }
+        }
+    })
+
+/** The delegate's debounce window; virtual time must clear it before the search fires. */
+private const val SEARCH_DEBOUNCE_MS = 300L
+
+/** Slack past the debounce so the test never sits exactly on the boundary. */
+private const val DEBOUNCE_MARGIN_MS = 50L

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/SeriesEditDelegateTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/SeriesEditDelegateTest.kt
@@ -1,0 +1,87 @@
+package com.calypsan.listenup.client.presentation.bookedit.delegates
+
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
+import com.calypsan.listenup.client.domain.model.SeriesSearchResponse
+import com.calypsan.listenup.client.domain.model.SeriesSearchResult
+import com.calypsan.listenup.client.domain.repository.SeriesRepository
+import com.calypsan.listenup.client.presentation.bookedit.BookEditUiState
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [SeriesEditDelegate]'s debounced search-query gating.
+ *
+ * The client's local FTS5 index uses `tokenize='trigram'`, which cannot match a query
+ * shorter than [MIN_SEARCH_QUERY_LENGTH] — a query below the floor must never reach
+ * [SeriesRepository.searchSeries], let alone the index itself.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+class SeriesEditDelegateTest :
+    FunSpec({
+
+        class Fixture {
+            val state = MutableStateFlow(BookEditUiState(bookId = "book-1"))
+            val seriesRepository: SeriesRepository = mock()
+
+            fun build(scope: CoroutineScope): SeriesEditDelegate =
+                SeriesEditDelegate(
+                    state = state,
+                    seriesRepository = seriesRepository,
+                    scope = scope,
+                    onChangesMade = {},
+                )
+        }
+
+        test("updateSearchQuery below MIN_SEARCH_QUERY_LENGTH never calls searchSeries") {
+            runTest {
+                val fixture = Fixture()
+                val delegate = fixture.build(backgroundScope)
+
+                delegate.updateSearchQuery("ab")
+                advanceTimeBy(SEARCH_DEBOUNCE_MS + DEBOUNCE_MARGIN_MS)
+                runCurrent()
+
+                verifySuspend(VerifyMode.not) { fixture.seriesRepository.searchSeries(any(), any()) }
+            }
+        }
+
+        test("updateSearchQuery at MIN_SEARCH_QUERY_LENGTH calls searchSeries and populates results") {
+            runTest {
+                val fixture = Fixture()
+                everySuspend { fixture.seriesRepository.searchSeries(any(), any()) } returns
+                    SeriesSearchResponse(
+                        series = listOf(SeriesSearchResult(id = "series-1", name = "Cosmere", bookCount = 3)),
+                        isOfflineResult = true,
+                        tookMs = 1L,
+                    )
+                val delegate = fixture.build(backgroundScope)
+
+                delegate.updateSearchQuery("cos")
+                advanceTimeBy(SEARCH_DEBOUNCE_MS + DEBOUNCE_MARGIN_MS)
+                runCurrent()
+
+                verifySuspend { fixture.seriesRepository.searchSeries("cos", limit = 10) }
+                fixture.state.value.seriesSearchResults
+                    .map { it.id } shouldContainExactly listOf("series-1")
+            }
+        }
+    })
+
+/** The delegate's debounce window; virtual time must clear it before the search fires. */
+private const val SEARCH_DEBOUNCE_MS = 300L
+
+/** Slack past the debounce so the test never sits exactly on the boundary. */
+private const val DEBOUNCE_MARGIN_MS = 50L

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModelTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModelTest.kt
@@ -11,6 +11,7 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import dev.mokkery.verify.VerifyMode.Companion.not
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -137,7 +138,7 @@ class SearchViewModelTest :
             }
         }
 
-        test("search triggers after debounce for query with min 2 chars") {
+        test("search triggers after debounce once the query reaches the trigram floor") {
             runTest {
                 val fixture = createFixture()
                 everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
@@ -149,7 +150,7 @@ class SearchViewModelTest :
                 keepStateHot(viewModel)
                 advanceUntilIdle()
 
-                viewModel.onQueryChanged("te")
+                viewModel.onQueryChanged("tes")
 
                 // Before debounce fires: phase still Idle (search hasn't started).
                 // Don't call advanceUntilIdle here — it would advance through the 300ms debounce.
@@ -163,12 +164,35 @@ class SearchViewModelTest :
                 results.result.hits.size shouldBe 1
                 verifySuspend {
                     fixture.searchRepository.search(
-                        query = "te",
+                        query = "tes",
                         types = null,
                         genres = null,
                         genrePath = null,
                         limit = 30,
                     )
+                }
+            }
+        }
+
+        // The trigram tokenizer cannot match a query shorter than three characters, so a two-char
+        // query is not "a search that found nothing" — it is a search that could never succeed.
+        // Running it anyway is what produced a "no results" screen for `JK`, indistinguishable from
+        // a real miss. The floor is MIN_SEARCH_QUERY_LENGTH; below it we must not query at all.
+        test("a below-floor query surfaces TooShort and never reaches the repository") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.onQueryChanged("te")
+                advanceTimeBy(500.milliseconds)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value.shouldBeInstanceOf<SearchUiState.TooShort>()
+                state.query shouldBe "te"
+                verifySuspend(not) {
+                    fixture.searchRepository.search(any(), any(), any(), any(), any())
                 }
             }
         }
@@ -184,9 +208,33 @@ class SearchViewModelTest :
                 advanceTimeBy(500.milliseconds)
                 advanceUntilIdle()
 
-                // Phase stays Idle; search never executes.
-                viewModel.state.value.shouldBeInstanceOf<SearchUiState.Idle>()
+                viewModel.state.value.shouldBeInstanceOf<SearchUiState.TooShort>()
                 viewModel.state.value.query shouldBe "a"
+            }
+        }
+
+        // Backspacing out of a completed search used to leave the old hits on screen: the
+        // below-floor branch emitted nothing at all, so the phase kept its last value while the
+        // query text updated underneath it — results for a query the user no longer had typed.
+        test("backspacing below the floor clears prior results instead of stranding them") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
+                    createSearchResult(query = "test", hits = listOf(createBookHit()))
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.onQueryChanged("test")
+                advanceTimeBy(500.milliseconds)
+                advanceUntilIdle()
+                viewModel.state.value.shouldBeInstanceOf<SearchUiState.Results>()
+
+                viewModel.onQueryChanged("te")
+                advanceTimeBy(500.milliseconds)
+                advanceUntilIdle()
+
+                viewModel.state.value.shouldBeInstanceOf<SearchUiState.TooShort>()
             }
         }
 

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/search/SeeAllSearchViewModelTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/search/SeeAllSearchViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.presentation.search
 
 import app.cash.turbine.test
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.SearchHit
 import com.calypsan.listenup.client.domain.model.SearchHitType
 import com.calypsan.listenup.client.domain.model.SearchResult
@@ -11,6 +12,7 @@ import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -75,6 +77,48 @@ class SeeAllSearchViewModelTest :
                 advanceUntilIdle()
 
                 viewModel.state.value shouldBe SeeAllSearchUiState.Idle
+            }
+        }
+
+        test("load below MIN_SEARCH_QUERY_LENGTH emits TooShort without calling search") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+
+                val belowFloor = "a".repeat(MIN_SEARCH_QUERY_LENGTH - 1)
+                viewModel.load(query = belowFloor, type = SearchHitType.BOOK)
+                advanceUntilIdle()
+
+                viewModel.state.value shouldBe SeeAllSearchUiState.TooShort
+                verifySuspend(VerifyMode.not) {
+                    fixture.searchRepository.search(any(), any(), any(), any(), any())
+                }
+            }
+        }
+
+        test("load at MIN_SEARCH_QUERY_LENGTH calls search") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
+                    searchResult(emptyList())
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+
+                val atFloor = "a".repeat(MIN_SEARCH_QUERY_LENGTH)
+                viewModel.load(query = atFloor, type = SearchHitType.BOOK)
+                advanceUntilIdle()
+
+                viewModel.state.value.shouldBeInstanceOf<SeeAllSearchUiState.Results>()
+                verifySuspend {
+                    fixture.searchRepository.search(
+                        query = atFloor,
+                        types = listOf(SearchHitType.BOOK),
+                        genres = null,
+                        genrePath = null,
+                        limit = 100,
+                    )
+                }
             }
         }
 

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/domain/model/SwiftSearchFloorMirrorTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/domain/model/SwiftSearchFloorMirrorTest.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.client.domain.model
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+/**
+ * Pins the iOS mirror of [MIN_SEARCH_QUERY_LENGTH] to the Kotlin original.
+ *
+ * The floor is a Kotlin top-level `const val`, and a top-level constant is not a *type*, so it does
+ * not cross the flat-typealias Swift Export surface the way an exported `object` does. iOS therefore
+ * keeps a hand-written mirror, `let minSearchQueryLength`, in `SearchModels.swift`.
+ *
+ * A hand-written mirror is exactly what caused the bug this constant exists to fix: the floor was
+ * copied into every caller, the FTS tokenizer moved from `porter` to `trigram`, and not one copy
+ * followed — so a two-character search ran against an index that could never answer it and the UI
+ * reported "no results". The Kotlin copies are gone; this test is what stops the remaining Swift one
+ * from drifting the same way, since no compiler can check across the language boundary.
+ *
+ * If Swift Export ever does expose the constant directly, delete the mirror and this test together.
+ */
+class SwiftSearchFloorMirrorTest :
+    FunSpec({
+
+        test("the Swift minSearchQueryLength mirror equals the Kotlin MIN_SEARCH_QUERY_LENGTH") {
+            val searchModels =
+                File(Konsist.projectRootPath, "app/iosApp/ListenUp/Features/Search/SearchModels.swift")
+            check(searchModels.isFile) {
+                "Expected the Swift mirror at ${searchModels.path}. If the file moved, update this " +
+                    "test — do not delete it, or the mirror silently stops being checked."
+            }
+
+            val mirrored =
+                MIRROR_DECLARATION
+                    .find(searchModels.readText())
+                    ?.groupValues
+                    ?.get(1)
+                    ?.toInt()
+
+            // A null here means the declaration was renamed or reshaped, which would make a plain
+            // equality check pass vacuously against nothing at all.
+            check(mirrored != null) {
+                "No `let minSearchQueryLength = <int>` declaration found in ${searchModels.name}. " +
+                    "The mirror was renamed or removed; this gate cannot verify what it cannot find."
+            }
+
+            mirrored shouldBe MIN_SEARCH_QUERY_LENGTH
+        }
+    })
+
+private val MIRROR_DECLARATION = Regex("""\blet\s+minSearchQueryLength\s*(?::\s*Int\s*)?=\s*(\d+)""")

--- a/app/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/app/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -1055,6 +1055,8 @@ One beautiful library.</string>
     <string name="search_count_books">%1$s books</string>
     <string name="search_cover_for">Cover for %1$s</string>
     <string name="search_find_description">Find books by title, author, narrator, or series</string>
+    <string name="search_keep_typing">Keep typing</string>
+    <string name="search_keep_typing_description">Enter at least %1$d characters to search</string>
     <string name="search_no_results_for_query">No results for “%1$s”</string>
     <string name="search_people">People</string>
     <string name="search_results_count_for">%1$d results for “%2$s”</string>

--- a/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpAutocompleteField.kt
+++ b/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpAutocompleteField.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
@@ -23,9 +24,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.common_add_name
+import listenup.composeapp.generated.resources.search_keep_typing
+import listenup.composeapp.generated.resources.search_keep_typing_description
 
 /**
  * Search field with autocomplete dropdown results.
@@ -43,7 +47,11 @@ import listenup.composeapp.generated.resources.common_add_name
  * @param placeholder Hint text for search field
  * @param modifier Optional modifier
  * @param isLoading Whether search is in progress
- * @param emptyResultsContent Optional content to show when results are empty but query is valid
+ * @param emptyResultsContent Optional content to show when results are empty and the query is
+ * non-blank — invoked for both a below-floor query (too short to have searched) and a genuinely
+ * empty result, since this field has no notion of the caller's search floor. Callers wanting the
+ * two cases to read differently pass [AutocompleteEmptyResultsHint], which makes that distinction
+ * using [MIN_SEARCH_QUERY_LENGTH].
  */
 @Composable
 @Suppress("UnusedParameter")
@@ -83,9 +91,53 @@ fun <T> ListenUpAutocompleteField(
                     }
                 }
             }
-        } else if (value.length >= 2 && !isLoading && emptyResultsContent != null) {
-            // Show empty state when query is valid but no results
+        } else if (value.isNotBlank() && !isLoading && emptyResultsContent != null) {
+            // Show empty state whenever there's a query and no results. Previously gated on
+            // `value.length >= 2`, which silently dropped a 1-character query entirely (no
+            // dropdown, no hint) — the caller, not this generic field, owns the notion of a
+            // search floor, so the gate here is just "there's something to say something about."
             emptyResultsContent()
+        }
+    }
+}
+
+/**
+ * Content for [ListenUpAutocompleteField]'s `emptyResultsContent` slot: nudges the user to keep
+ * typing when [query] is shorter than [MIN_SEARCH_QUERY_LENGTH] — below the floor, no search
+ * could have run, so "no results" would be a lie. Renders nothing for a [query] at or above the
+ * floor, preserving the field's existing (silent) behaviour for a genuinely empty result.
+ *
+ * @param query The current search text, used only to decide which of the two cases applies.
+ */
+@Composable
+fun AutocompleteEmptyResultsHint(
+    query: String,
+    modifier: Modifier = Modifier,
+) {
+    if (query.length < MIN_SEARCH_QUERY_LENGTH) {
+        Row(
+            modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column {
+                Text(
+                    text = stringResource(Res.string.search_keep_typing),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = stringResource(Res.string.search_keep_typing_description, MIN_SEARCH_QUERY_LENGTH),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookedit/components/SeriesSection.kt
+++ b/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookedit/components/SeriesSection.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.features.bookedit.components
 
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -22,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.design.components.AutocompleteEmptyResultsHint
 import com.calypsan.listenup.client.design.components.AutocompleteResultItem
 import com.calypsan.listenup.client.design.components.ListenUpAutocompleteField
 import com.calypsan.listenup.client.domain.model.SeriesSearchResult
@@ -81,7 +83,7 @@ fun SeriesSection(
                     val topResult = searchResults.firstOrNull()
                     if (topResult != null) {
                         onSeriesSelected(topResult)
-                    } else if (trimmed.length >= 2) {
+                    } else if (trimmed.length >= MIN_SEARCH_QUERY_LENGTH) {
                         onSeriesEntered(trimmed)
                     }
                 }
@@ -100,6 +102,7 @@ fun SeriesSection(
             },
             placeholder = "Add series...",
             isLoading = isLoading,
+            emptyResultsContent = { AutocompleteEmptyResultsHint(query = searchQuery) },
         )
 
         // Add new chip
@@ -108,7 +111,7 @@ fun SeriesSection(
             searchResults.any {
                 it.name.equals(trimmedQuery, ignoreCase = true)
             }
-        if (trimmedQuery.length >= 2 && !isLoading && !hasExactMatch) {
+        if (trimmedQuery.length >= MIN_SEARCH_QUERY_LENGTH && !isLoading && !hasExactMatch) {
             AssistChip(
                 onClick = { onSeriesEntered(trimmedQuery) },
                 label = { Text(stringResource(Res.string.book_edit_add_trimmedquery, trimmedQuery)) },

--- a/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookedit/components/TalentSection.kt
+++ b/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookedit/components/TalentSection.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.features.bookedit.components
 
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -31,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.design.components.AutocompleteEmptyResultsHint
 import com.calypsan.listenup.client.design.components.AutocompleteResultItem
 import com.calypsan.listenup.client.design.components.ListenUpAutocompleteField
 import com.calypsan.listenup.client.design.components.ListenUpDestructiveDialog
@@ -207,7 +209,7 @@ private fun RoleContributorSection(
                     val topResult = searchResults.firstOrNull()
                     if (topResult != null) {
                         onResultSelected(topResult)
-                    } else if (trimmed.length >= 2) {
+                    } else if (trimmed.length >= MIN_SEARCH_QUERY_LENGTH) {
                         onNameEntered(trimmed)
                     }
                 }
@@ -226,12 +228,13 @@ private fun RoleContributorSection(
             },
             placeholder = "Add ${role.displayName.lowercase()}...",
             isLoading = isSearching,
+            emptyResultsContent = { AutocompleteEmptyResultsHint(query = searchQuery) },
         )
 
         // Add new chip
         val trimmedQuery = searchQuery.trim()
         val hasExactMatch = searchResults.any { it.name.equals(trimmedQuery, ignoreCase = true) }
-        if (trimmedQuery.length >= 2 && !isSearching && !hasExactMatch) {
+        if (trimmedQuery.length >= MIN_SEARCH_QUERY_LENGTH && !isSearching && !hasExactMatch) {
             AssistChip(
                 onClick = { onNameEntered(trimmedQuery) },
                 label = { Text(stringResource(Res.string.book_edit_add_trimmedquery, trimmedQuery)) },

--- a/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/search/SearchResultsOverlay.kt
+++ b/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/search/SearchResultsOverlay.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -68,6 +69,7 @@ import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.window.core.layout.WindowSizeClass
 import com.calypsan.listenup.client.design.components.BookCoverImage
 import com.calypsan.listenup.client.design.components.ContentRow
+import com.calypsan.listenup.client.design.components.EmptyState
 import com.calypsan.listenup.client.design.components.FullScreenLoadingIndicator
 import com.calypsan.listenup.client.design.components.PillChip
 import com.calypsan.listenup.client.design.components.ScallopBadge
@@ -75,6 +77,7 @@ import com.calypsan.listenup.client.design.components.toCoverModel
 import com.calypsan.listenup.client.design.components.highlightMatch
 import com.calypsan.listenup.client.design.util.PlatformBackHandler
 import com.calypsan.listenup.client.features.library.BookCard
+import com.calypsan.listenup.client.domain.model.MIN_SEARCH_QUERY_LENGTH
 import com.calypsan.listenup.client.domain.model.SearchHit
 import com.calypsan.listenup.client.domain.model.SearchHitType
 import com.calypsan.listenup.client.domain.model.SearchResult
@@ -93,6 +96,8 @@ import listenup.composeapp.generated.resources.genre_book_count
 import listenup.composeapp.generated.resources.genre_books_count
 import listenup.composeapp.generated.resources.library_books
 import listenup.composeapp.generated.resources.search_cover_for
+import listenup.composeapp.generated.resources.search_keep_typing
+import listenup.composeapp.generated.resources.search_keep_typing_description
 import listenup.composeapp.generated.resources.search_no_results_for_query
 import listenup.composeapp.generated.resources.search_people
 import listenup.composeapp.generated.resources.search_results_count_for
@@ -193,6 +198,10 @@ fun SearchResultsOverlay(
 
                     when (state) {
                         is SearchUiState.Idle -> {
+                        }
+
+                        is SearchUiState.TooShort -> {
+                            TooShortState(modifier = Modifier.weight(1f))
                         }
 
                         is SearchUiState.Searching -> {
@@ -323,7 +332,7 @@ private fun ResultsContent(
     modifier: Modifier = Modifier,
 ) {
     if (result.hits.isEmpty()) {
-        EmptyState(query = query, modifier = modifier)
+        NoResultsState(query = query, modifier = modifier)
         return
     }
     val grouped = result.hits.groupBy { it.type }
@@ -682,13 +691,17 @@ private fun SearchSeeAllPage(
                     LoadingState(modifier = Modifier.weight(1f))
                 }
 
+                is SeeAllSearchUiState.TooShort -> {
+                    TooShortState(modifier = Modifier.weight(1f))
+                }
+
                 is SeeAllSearchUiState.Error -> {
                     ErrorState(message = current.message, modifier = Modifier.weight(1f))
                 }
 
                 is SeeAllSearchUiState.Results -> {
                     if (current.hits.isEmpty()) {
-                        EmptyState(query = query, modifier = Modifier.weight(1f))
+                        NoResultsState(query = query, modifier = Modifier.weight(1f))
                     } else {
                         SeeAllList(
                             type = type,
@@ -1009,29 +1022,32 @@ private fun LoadingState(modifier: Modifier = Modifier) {
     FullScreenLoadingIndicator(modifier = modifier)
 }
 
+/** A search for [query] returned zero hits — reuses the canonical [EmptyState] scaffolding. */
 @Composable
-private fun EmptyState(
+private fun NoResultsState(
     query: String,
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = stringResource(Res.string.search_no_results_for_query, query),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(Res.string.search_try_a_different_search_term),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
+    EmptyState(
+        title = stringResource(Res.string.search_no_results_for_query, query),
+        subtitle = stringResource(Res.string.search_try_a_different_search_term),
+        modifier = modifier,
+    )
+}
+
+/**
+ * [query] is below [MIN_SEARCH_QUERY_LENGTH], so no search ran. Reuses the same [EmptyState]
+ * scaffolding as [NoResultsState] but with keep-typing copy and a search icon, so the two states
+ * read as visually related while staying unmistakably distinct in meaning.
+ */
+@Composable
+private fun TooShortState(modifier: Modifier = Modifier) {
+    EmptyState(
+        title = stringResource(Res.string.search_keep_typing),
+        subtitle = stringResource(Res.string.search_keep_typing_description, MIN_SEARCH_QUERY_LENGTH),
+        modifier = modifier,
+        icon = Icons.Default.Search,
+    )
 }
 
 @Composable


### PR DESCRIPTION
Searching for `JK` or any two-letter query returns "No results" today, on every platform. Not because nothing matches — because the query can never match.

The client's FTS5 index moved from `porter` to `tokenize='trigram'` in the Room 3 migration (#1213). Trigram indexes three-character sequences, so it **cannot answer a query shorter than three characters at all**. Every search surface still gated at `MIN_QUERY_LENGTH = 2`, so a two-character query ran a search that was guaranteed to return nothing, and the UI reported that as a genuine miss.

`SearchTokenizerCharacterizationTest` already pinned the limitation as accepted at migration time, with a note that the UI must say "keep typing". This is that follow-up.

## The fix is one constant, not four

The floor was copied into each caller as a private constant. When the tokenizer changed, **not one copy followed** — that duplication *is* the bug, so bumping four copies would have left the same trap set for the next tokenizer change.

`MIN_SEARCH_QUERY_LENGTH = 3` now lives once, in `domain/model/Search.kt`, next to the index it describes. Every FTS-backed caller references it.

## What the user sees

`SearchUiState` gains a `TooShort` variant rather than overloading `Idle` — the exhaustive `when` then forces every UI to handle it instead of letting it collapse into an empty state. Compose and SwiftUI both render a "keep typing" hint (`search.keep_typing`), with the character count formatted from the constant so the copy can't drift from the code.

**Six entry points were affected**, and they failed differently:

| Surface | Before | After |
|---|---|---|
| Global search (Compose + iOS) | "No results for '‹query›'" | Keep-typing hint |
| See-all page | "No results" | Keep-typing hint |
| Book edit → series | **Silent on Android** — no dropdown, just an "Add '‹query›'" chip | Hint; Add chip now also waits for the floor |
| Book edit → contributor | Same silent case | Same |
| Admin → add books | "No books found." | No doomed search, results cleared |
| Import → book match | "No books found." | Same |

The two book-edit cases were the worst: Android showed *nothing at all* while inviting the user to create a series or contributor that search simply hadn't been able to look for yet. That is how duplicates get made, so the Add affordance now waits for the same floor.

**`GenreTagEditDelegate` is deliberately untouched.** It filters an already-loaded in-memory list and never touches FTS, so its floor of 2 is correct; raising it would have been an unrelated behaviour change.

## A second bug, fixed by the same change

The below-floor branch previously emitted *nothing*. Because the outer `combine` forwards on any upstream emission, the query text advanced while the phase kept its last value — so backspacing out of a finished search left the old hits on screen under a query that no longer produced them. Emitting `TooShort` fixes it, and `"backspacing below the floor clears prior results instead of stranding them"` covers it.

## The iOS mirror is now guarded

`MIN_SEARCH_QUERY_LENGTH` is a top-level Kotlin `const val`, not a type, so it does not cross the flat-typealias Swift Export surface; iOS keeps a hand-written `let minSearchQueryLength`. A hand-written mirror is exactly what caused this bug, so `SwiftSearchFloorMirrorTest` reads `SearchModels.swift` and asserts the mirrored literal equals the Kotlin constant. It rides `:app:sharedLogic:jvmTest`, so it needed no new CI gate, and it fails loudly if the declaration is renamed rather than passing vacuously against nothing.

## Verification

One existing test was **encoding the bug** — `"search triggers after debounce for query with min 2 chars"` asserted that a two-character query searches, and passed only because the repository was mocked. It now uses three.

**Control-probed:** setting the shared floor back to `2` fails **five** guards — both delegate below-floor tests, both new `SearchViewModel` tests, and the Swift mirror test. They bind to the constant rather than to a coincidence.

**Linux `verifyLocal`:** BUILD SUCCESSFUL — 9,269 tests, 0 failures (sharedLogic jvm 3444 · android 2489 · sharedUI 255 · contract 108 · server 2973).

**macOS lane (Mac mini, not CI):** `Build (iOS)` Release SUCCEEDED · `Test (iOS)` 536 passed / 0 failed · export surface matches baseline (493 types, verified against the freshly-built artifact) · appresult-await clean.

## Not done

**No Compose UI test covers the new state.** There is no existing `runComposeUiTest`/Robolectric coverage of `SearchResultsOverlay`, `ListenUpAutocompleteField`, or the book-edit sections at all, so rather than invent a harness here the rendering is covered only by the iOS observer tests and the shared ViewModel tests. Pre-existing gap, worth its own pass.

**The two admin screens have no visible hint** — they correctly stop searching and clear stale results, but neither carries a "too short" signal in its state, so surfacing a hint there would need a UI-side length check. Deliberately left, since the harmful half is fixed.
