### PR TITLE
✅ test(quality): every JVM lane gets Kotest safety settings and a count floor

### DIFF
--- a/app/sharedLogic/build.gradle.kts
+++ b/app/sharedLogic/build.gradle.kts
@@ -170,6 +170,35 @@ kotlin {
     }
 }
 
+// "Did this lane actually run?" guard, not a coverage target (canon-alignment plan A3) — a
+// collapsed classpath (a source set silently dropped from the compilation, a broken dependency)
+// still reports BUILD SUCCESSFUL with zero failures, which is worse than a run that fails
+// outright. Registered on the Gradle `Test` task itself rather than a Kotest `afterProject`
+// listener so it always reads the TASK TOTAL: Gradle aggregates every forked worker's results
+// into one root suite (`desc.parent == null`), whereas a Kotest-side listener fires once per
+// worker JVM and only sees that worker's slice — the same trap the `io.kotest.provided.
+// ProjectConfig` retry-ledger KDoc documents for `:server:jvmTest`'s forked workers. Shared by
+// this module's two JUnit-Platform Test tasks (jvmTest, testAndroidHostTest) below — a private
+// script-local helper, not new build-logic infrastructure. Raising [floor] is a conscious edit,
+// not a rubber stamp for a red build.
+private fun Test.failBelowDiscoveredTestCount(
+    floor: Int,
+    taskLabel: String,
+) {
+    afterSuite(
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ desc, result ->
+            if (desc.parent == null && result.testCount < floor) {
+                throw GradleException(
+                    "$taskLabel discovered only ${result.testCount} tests, below the floor of " +
+                        "$floor. This usually means a source set silently dropped out of the " +
+                        "compilation rather than a legitimate test deletion — investigate before " +
+                        "lowering this floor.",
+                )
+            }
+        }),
+    )
+}
+
 // Kotest uses JUnit 5 as its runner on JVM
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
@@ -178,6 +207,10 @@ tasks.named<Test>("jvmTest") {
     // worker, and the Konsist architectural rules, which hold a single shared PSI scope of the whole
     // production tree (~1.5k files) for the lifetime of the run (see konsist/KonsistScope.kt).
     maxHeapSize = "4g"
+    // Catches COLLAPSE, not attrition — 3,423 ran green on 2026-07-25 and the bar sits well below,
+    // so an honest deletion never trips it. A floor hugging the current count is a ratchet, and a
+    // ratchet here just teaches people to edit the number without reading it.
+    failBelowDiscoveredTestCount(2700, ":app:sharedLogic:jvmTest")
     // Pin the E2E retry ledger (written by HeavyweightE2ERetryExtension) to an absolute path under
     // this module's build/, so its location is workingDir-independent and identical in shape to the
     // server's — CI reads app/sharedLogic/build/e2e-retries.log.
@@ -211,6 +244,8 @@ tasks.matching { it.name == "testAndroidHostTest" }.configureEach {
         // Mirror jvmTest's heap: this surface runs the same Konsist rules, which hold a single
         // shared PSI scope of the whole production tree. The 512m default OOMs on it.
         maxHeapSize = "4g"
+        // Same posture as jvmTest above: 2,471 ran green on 2026-07-25; the bar catches collapse only.
+        failBelowDiscoveredTestCount(1950, ":app:sharedLogic:testAndroidHostTest")
     }
 }
 

--- a/app/sharedLogic/src/androidHostTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/app/sharedLogic/src/androidHostTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,0 +1,21 @@
+package io.kotest.provided
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.names.DuplicateTestNameMode
+
+/**
+ * Kotest project configuration for the **`:app:sharedLogic` `testAndroidHostTest`** run
+ * (auto-discovered by Kotest as `io.kotest.provided.ProjectConfig` on the androidHostTest test
+ * classpath — a *different* classpath from `:app:sharedLogic:jvmTest`'s, which carries its own
+ * copy under `src/jvmTest/`. androidHostTest compiles the same `commonTest` specs but is not part
+ * of the jvmTest source set tree, so `ProjectConfig` is not inherited between them).
+ *
+ * - [failOnEmptyTestSuite]: a spec that registers zero tests is almost always a mistake (a
+ *   misnamed `test`, a `context` that never adds leaves) — fail instead of passing silently.
+ * - [duplicateTestNameMode]: two tests with the same name inside one spec silently shadow each
+ *   other's results — make it an error so the copy-paste is caught.
+ */
+class ProjectConfig : AbstractProjectConfig() {
+    override val failOnEmptyTestSuite: Boolean = true
+    override val duplicateTestNameMode: DuplicateTestNameMode = DuplicateTestNameMode.Error
+}

--- a/app/sharedUI/build.gradle.kts
+++ b/app/sharedUI/build.gradle.kts
@@ -294,6 +294,33 @@ tasks.withType<Test>().configureEach {
     if (name == "testAndroidHostTest" || name == "desktopTest") {
         useJUnitPlatform()
     }
+    // "Did this lane actually run?" guard, not a coverage target (canon-alignment plan A3) — a
+    // collapsed classpath still reports BUILD SUCCESSFUL with zero failures, which is worse than
+    // a run that fails outright. Registered on the Gradle `Test` task itself rather than a Kotest
+    // `afterProject` listener so it always reads the TASK TOTAL, aggregated across any forked
+    // workers (`desc.parent == null`) — see `io.kotest.provided.ProjectConfig`'s retry-ledger
+    // KDoc for the per-worker trap this avoids. `testAndroidHostTest` only: `desktopTest` is not
+    // part of `verifyLocal`/CI's `test-jvm` job, so it has no floor to protect.
+    //
+    // The floor catches COLLAPSE, not attrition: 255 tests ran green on 2026-07-25, and the bar sits
+    // far enough below that a normal deletion does not trip it. Deliberately not a ratchet — a floor
+    // set just under the current count fails honest deletions and trains people to edit the number
+    // without reading it.
+    if (name == "testAndroidHostTest") {
+        val minDiscoveredTests = 200
+        afterSuite(
+            KotlinClosure2<TestDescriptor, TestResult, Unit>({ desc, result ->
+                if (desc.parent == null && result.testCount < minDiscoveredTests) {
+                    throw GradleException(
+                        ":app:sharedUI:testAndroidHostTest discovered only ${result.testCount} " +
+                            "tests, below the floor of $minDiscoveredTests. This usually means a " +
+                            "source set silently dropped out of the compilation rather than a " +
+                            "legitimate test deletion — investigate before lowering this floor.",
+                    )
+                }
+            }),
+        )
+    }
 }
 
 // Compose UI tooling for Android preview support

--- a/app/sharedUI/src/androidHostTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,0 +1,20 @@
+package io.kotest.provided
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.names.DuplicateTestNameMode
+
+/**
+ * Kotest project configuration for the **`:app:sharedUI` `testAndroidHostTest`** run
+ * (auto-discovered by Kotest as `io.kotest.provided.ProjectConfig` on this androidHostTest test
+ * classpath — `ProjectConfig` is discovered per test *classpath*, so `:app:sharedUI:desktopTest`
+ * and every other module's test lane each carry their own copy rather than sharing this one).
+ *
+ * - [failOnEmptyTestSuite]: a spec that registers zero tests is almost always a mistake (a
+ *   misnamed `test`, a `context` that never adds leaves) — fail instead of passing silently.
+ * - [duplicateTestNameMode]: two tests with the same name inside one spec silently shadow each
+ *   other's results — make it an error so the copy-paste is caught.
+ */
+class ProjectConfig : AbstractProjectConfig() {
+    override val failOnEmptyTestSuite: Boolean = true
+    override val duplicateTestNameMode: DuplicateTestNameMode = DuplicateTestNameMode.Error
+}

--- a/app/sharedUI/src/desktopTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/app/sharedUI/src/desktopTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,0 +1,24 @@
+package io.kotest.provided
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.names.DuplicateTestNameMode
+
+/**
+ * Kotest project configuration for the **`:app:sharedUI` `desktopTest`** run (auto-discovered by
+ * Kotest as `io.kotest.provided.ProjectConfig` on this desktopTest test classpath — `ProjectConfig`
+ * is discovered per test *classpath*, so `:app:sharedUI:testAndroidHostTest` and every other
+ * module's test lane each carry their own copy rather than sharing this one).
+ *
+ * - [failOnEmptyTestSuite]: a spec that registers zero tests is almost always a mistake (a
+ *   misnamed `test`, a `context` that never adds leaves) — fail instead of passing silently.
+ * - [duplicateTestNameMode]: two tests with the same name inside one spec silently shadow each
+ *   other's results — make it an error so the copy-paste is caught.
+ *
+ * No discovered-count floor is wired for this lane (see `app/sharedUI/build.gradle.kts`) —
+ * `desktopTest` is not part of `verifyLocal`/CI's `test-jvm` job, so a collapse here wouldn't be
+ * caught by the gate a floor exists to protect anyway.
+ */
+class ProjectConfig : AbstractProjectConfig() {
+    override val failOnEmptyTestSuite: Boolean = true
+    override val duplicateTestNameMode: DuplicateTestNameMode = DuplicateTestNameMode.Error
+}

--- a/contract/build.gradle.kts
+++ b/contract/build.gradle.kts
@@ -73,6 +73,33 @@ kotlin {
 // Kotest uses JUnit 5 as its runner on JVM
 tasks.named<org.gradle.api.tasks.testing.Test>("jvmTest") {
     useJUnitPlatform()
+    // "Did this lane actually run?" guard, not a coverage target (canon-alignment plan A3) — a
+    // collapsed classpath (a source set silently dropped from the compilation, a broken
+    // dependency) still reports BUILD SUCCESSFUL with zero failures, which is worse than a run
+    // that fails outright. Registered on the Gradle `Test` task itself rather than a Kotest
+    // `afterProject` listener so it always reads the TASK TOTAL: Gradle aggregates every forked
+    // worker's results into one root suite (`desc.parent == null`), whereas a Kotest-side listener
+    // fires once per worker JVM and only sees that worker's slice — the same trap the
+    // `io.kotest.provided.ProjectConfig` retry-ledger KDoc documents for `:server:jvmTest`'s
+    // forked workers.
+    //
+    // The floor catches COLLAPSE, not attrition: 108 tests ran green on 2026-07-25, and the bar sits
+    // far enough below that a normal deletion does not trip it. Deliberately not a ratchet — PR #1214
+    // removed ~180 server tests in one legitimate change, so a floor set just under the current count
+    // would fail honest work and train people to edit the number without reading it.
+    val minDiscoveredTests = 85
+    afterSuite(
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ desc, result ->
+            if (desc.parent == null && result.testCount < minDiscoveredTests) {
+                throw GradleException(
+                    ":contract:jvmTest discovered only ${result.testCount} tests, below the floor " +
+                        "of $minDiscoveredTests. This usually means a source set silently dropped " +
+                        "out of the compilation rather than a legitimate test deletion — " +
+                        "investigate before lowering this floor.",
+                )
+            }
+        }),
+    )
 }
 
 dependencies {

--- a/contract/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/contract/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,0 +1,23 @@
+package io.kotest.provided
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.names.DuplicateTestNameMode
+
+/**
+ * Kotest project configuration for the **`:contract`** JVM test run (auto-discovered by Kotest as
+ * `io.kotest.provided.ProjectConfig` on this module's test classpath — `ProjectConfig` is
+ * discovered per test *classpath*, so `:app:sharedLogic:jvmTest` and `:server:jvmTest` each carry
+ * their own copy rather than sharing this one).
+ *
+ * - [failOnEmptyTestSuite]: a spec that registers zero tests is almost always a mistake (a
+ *   misnamed `test`, a `context` that never adds leaves) — fail instead of passing silently.
+ * - [duplicateTestNameMode]: two tests with the same name inside one spec silently shadow each
+ *   other's results — make it an error so the copy-paste is caught.
+ *
+ * No [extensions] here: the contract round-trip tests are pure serialization checks with no
+ * process-global state (Koin, a live server) to isolate between specs.
+ */
+class ProjectConfig : AbstractProjectConfig() {
+    override val failOnEmptyTestSuite: Boolean = true
+    override val duplicateTestNameMode: DuplicateTestNameMode = DuplicateTestNameMode.Error
+}

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -426,6 +426,33 @@ tasks.named<Test>("jvmTest") {
         // last batch. Truncating here (pre-fork, once) lets every worker's appends accumulate.
         e2eRetryLedger.delete()
     }
+    // "Did this lane actually run?" guard, not a coverage target (canon-alignment plan A3) — a
+    // collapsed classpath still reports BUILD SUCCESSFUL with zero failures, which is worse than
+    // a run that fails outright. Deliberately NOT a Kotest `afterProject` listener (the pattern
+    // `io.kotest.provided.ProjectConfig`'s retry ledger uses): this task forks a fresh worker JVM
+    // every 25 classes (setForkEvery above), and such a listener fires once *per worker*, seeing
+    // only that worker's slice. This `afterSuite` is registered on the Gradle `Test` task itself,
+    // which aggregates every forked worker's results into one root suite (`desc.parent == null`)
+    // — so it always sees the TASK TOTAL.
+    //
+    // The floor catches COLLAPSE, not attrition: 2,790 tests ran green on 2026-07-25, and the bar
+    // sits far enough below that a normal deletion does not trip it. This lane is the reason the
+    // margin is generous — PR #1214 legitimately removed ~180 tests here in one change, so a floor
+    // set just under the current count would fail honest work and train people to edit the number
+    // without reading it.
+    val minDiscoveredTests = 2200
+    afterSuite(
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ desc, result ->
+            if (desc.parent == null && result.testCount < minDiscoveredTests) {
+                throw GradleException(
+                    ":server:jvmTest discovered only ${result.testCount} tests, below the floor " +
+                        "of $minDiscoveredTests. This usually means a source set silently dropped " +
+                        "out of the compilation rather than a legitimate test deletion — " +
+                        "investigate before lowering this floor.",
+                )
+            }
+        }),
+    )
 }
 
 // Regenerate the committed golden schema snapshot from the runner (the SSOT after Flyway's

--- a/server/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/server/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -5,6 +5,7 @@ import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.listeners.AfterProjectListener
 import io.kotest.core.listeners.BeforeProjectListener
+import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestType
 import io.kotest.engine.test.TestResult
@@ -32,10 +33,23 @@ import kotlinx.coroutines.delay
  *    CI job as the ultimate backstop for a non-interruptible thread deadlock.)
  *  - [extensions] → [FlakyServerSpecRetryExtension] — bounded auto-retry for the known timing-flaky
  *    specs + the heavyweight end-to-end specs.
+ *  - [failOnEmptyTestSuite]: a spec that registers zero tests is almost always a mistake (a
+ *    misnamed `test`, a `context` that never adds leaves) — fail instead of passing silently.
+ *  - [duplicateTestNameMode]: two tests with the same name inside one spec silently shadow each
+ *    other's results — make it an error so the copy-paste is caught.
+ *
+ * The discovered-test-count floor for this lane lives in Gradle (`server/build.gradle.kts`'s
+ * `jvmTest` task), not here — this task forks a fresh worker JVM every 25 classes
+ * (`setForkEvery(25)`), and a Kotest [io.kotest.core.listeners.AfterProjectListener] like the one
+ * [FlakyServerSpecRetryExtension] uses for its retry ledger fires once *per worker*, so it would
+ * only ever see that worker's slice of tests — never the task's true total. Gradle's `Test` task
+ * aggregates every worker's results into one root suite, so the floor belongs there.
  */
 class ProjectConfig : AbstractProjectConfig() {
     override val timeout: Duration = 120.seconds
     override val extensions: List<Extension> = listOf(FlakyServerSpecRetryExtension)
+    override val failOnEmptyTestSuite: Boolean = true
+    override val duplicateTestNameMode: DuplicateTestNameMode = DuplicateTestNameMode.Error
 }
 
 /**


### PR DESCRIPTION
A gate running green over less code than you think is worse than one that fails. Two of the five `verifyLocal` test lanes had no Kotest `ProjectConfig` at all, one had a config missing both safety settings, and **no lane had any floor on how many tests it discovered**.

## Settings parity

`failOnEmptyTestSuite` and `duplicateTestNameMode = Error` now cover every lane. A spec registering zero tests is almost always a misnamed `test` or a `context` with no leaves; two same-named tests in one spec silently shadow each other's results.

| Lane | Before | Now |
|---|---|---|
| `:contract:jvmTest` | no config | both settings |
| `:app:sharedLogic:jvmTest` | both settings | unchanged |
| `:app:sharedLogic:testAndroidHostTest` | no config (2,471 tests) | both settings |
| `:server:jvmTest` | timeout + retry only | both settings added |
| `:app:sharedUI:testAndroidHostTest` | no config | both settings |
| `:app:sharedUI:desktopTest` | no config | both settings |

`ProjectConfig` is discovered per test **classpath**, so each source set needs its own file — the existing `jvmTest` one never applied to `androidHostTest`. The server's existing `timeout` and `FlakyServerSpecRetryExtension` are untouched.

## Discovered-count floors

Each lane fails if it discovers implausibly few tests: contract 85, sharedLogic jvm 2700, sharedLogic android 1950, server 2200, sharedUI android 200.

**These live in Gradle, not Kotest, and that is load-bearing.** `:server:jvmTest` sets `setForkEvery(25)`, so a Kotest `afterProject` listener fires once *per worker JVM* and sees only that worker's slice — the same trap the existing retry-ledger KDoc documents. Gradle's `Test` task aggregates every worker into one root suite (`desc.parent == null`), so the check always reads the task total.

**The floors catch collapse, not attrition.** They sit ~20-25% below current counts rather than hugging them. PR #1214 legitimately deleted ~180 server tests in one change; a floor set just under the current count would have failed honest work and taught everyone to edit the number without reading it. Sequencing note: these land before the Kotest Gradle plugin adoption, which sets `failOnNoDiscoveredTests = false` project-wide and removes Gradle's own zero-test guard.

## Verification

**Control-probed** — raising the contract floor to an impossible value fails the build with the right message. That probe also caught a defect worth mentioning: the floor was duplicated between the condition and the error text, so my first pass reported "below the floor of 100" while actually checking 85. Each floor is now a single named `val` that both read, which is the same drift the sibling search-floor PR exists to fix.

**Linux `verifyLocal`:** BUILD SUCCESSFUL with every floor active — contract 108, sharedLogic jvm 3423, sharedLogic android 2471, server 2790, sharedUI 255, 0 failures.

No new convention plugin: each build script repeats a small `afterSuite` block locally, and `:app:sharedLogic` uses a file-private helper for its two lanes.