### PR TITLE
✅ test(server): run the native lane through Kotest — it was executing 28 of 82 tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -268,6 +268,10 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+# Kotest 6 renamed the multiplatform plugin to `io.kotest` and replaced its compiler plugin with
+# KSP. It generates the Kotlin/Native test entry point, which is the only thing the native lane
+# was missing — `kotest-framework-engine` is already on that classpath via commonTest.
+kotest = { id = "io.kotest", version.ref = "kotest" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 # Quality Tools
 detekt = { id = "dev.detekt", version.ref = "detekt" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.sqldelight)
     alias(libs.plugins.kover)
+    // KSP must be applied BEFORE the Kotest plugin — Kotest 6 generates the Kotlin/Native test
+    // entry point through KSP, and the processor is only registered if KSP is already present.
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotest)
 }
 
 sqldelight {
@@ -449,6 +453,42 @@ tasks.named<Test>("jvmTest") {
                         "of $minDiscoveredTests. This usually means a source set silently dropped " +
                         "out of the compilation rather than a legitimate test deletion — " +
                         "investigate before lowering this floor.",
+                )
+            }
+        }),
+    )
+}
+
+// Give the native test binaries a real temp directory — the native mirror of the `java.io.tmpdir`
+// redirect on jvmTest above. The Kotlin/Native test runner inherits the ambient environment, and
+// TMPDIR is unset on a stock Linux login; kotlinx.io resolves
+// `SystemTemporaryDirectory` as `getenv("TMPDIR") ?: getenv("TMP") ?: ""`, so with neither set it
+// hands back the EMPTY path and every `createTempFileIn(SystemTemporaryDirectory, …)` dies with
+// `mkdir failed: No such file or directory`. That is why the older native specs root their
+// scratch dirs under $HOME instead. Pointing TMPDIR under build/ makes commonTest specs behave
+// identically on both lanes and keeps the artefacts inside `clean`'s reach.
+tasks.withType<org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest>().configureEach {
+    val nativeTestTmpDir = layout.buildDirectory.dir("native-test-tmp/$name").get().asFile
+    environment("TMPDIR", nativeTestTmpDir.absolutePath)
+    doFirst {
+        nativeTestTmpDir.deleteRecursively()
+        nativeTestTmpDir.mkdirs()
+    }
+    // "Did this lane actually run?" guard, the native counterpart of the jvmTest floor above.
+    // This lane earned one: before the Kotest plugin was applied it reported a green 28 tests while
+    // 54 Kotest specs from commonTest sat on the classpath unexecuted — the K/N runner only ever
+    // collected the `kotlin.test`-annotated ones, so a lane running a third of its own suite looked
+    // indistinguishable from a healthy one. The floor catches COLLAPSE, not attrition: 82 tests ran
+    // green on 2026-07-25, and the bar sits far enough below that honest deletion does not trip it.
+    val minDiscoveredTests = 65
+    afterSuite(
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ desc, result ->
+            if (desc.parent == null && result.testCount < minDiscoveredTests) {
+                throw GradleException(
+                    ":server:$name discovered only ${result.testCount} tests, below the floor " +
+                        "of $minDiscoveredTests. This usually means a source set silently dropped " +
+                        "out of the compilation, or the Kotest native entry point stopped being " +
+                        "generated — investigate before lowering this floor.",
                 )
             }
         }),

--- a/server/src/commonTest/kotlin/com/calypsan/listenup/server/auth/NfcNormalizeParityTest.kt
+++ b/server/src/commonTest/kotlin/com/calypsan/listenup/server/auth/NfcNormalizeParityTest.kt
@@ -1,7 +1,7 @@
 package com.calypsan.listenup.server.auth
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import kotlin.test.Test
 
 private const val GRAVE = "̀"
 private const val ACUTE = "́"
@@ -24,108 +24,106 @@ private const val OGONEK = "̨"
  * for the realistic lowercase Latin email domain. Because JVM is true Unicode NFC, any wrong table
  * entry (or a composition exclusion) fails the JVM run here too.
  */
-class NfcNormalizeParityTest {
-    @Test
-    fun composesLowercaseLatinDiacriticsIdenticallyOnJvmAndNative() {
-        // (base, combining mark) -> NFC precomposed letter. Input is `base + mark` (decomposed, NFD).
-        val cases =
-            listOf(
-                Triple("a", GRAVE, "à"),
-                Triple("a", ACUTE, "á"),
-                Triple("a", CIRCUMFLEX, "â"),
-                Triple("a", TILDE, "ã"),
-                Triple("a", DIAERESIS, "ä"),
-                Triple("a", RING_ABOVE, "å"),
-                Triple("a", MACRON, "ā"),
-                Triple("a", BREVE, "ă"),
-                Triple("a", OGONEK, "ą"),
-                Triple("c", CEDILLA, "ç"),
-                Triple("c", ACUTE, "ć"),
-                Triple("c", CIRCUMFLEX, "ĉ"),
-                Triple("c", DOT_ABOVE, "ċ"),
-                Triple("c", CARON, "č"),
-                Triple("d", CARON, "ď"),
-                Triple("e", GRAVE, "è"),
-                Triple("e", ACUTE, "é"),
-                Triple("e", CIRCUMFLEX, "ê"),
-                Triple("e", DIAERESIS, "ë"),
-                Triple("e", MACRON, "ē"),
-                Triple("e", BREVE, "ĕ"),
-                Triple("e", DOT_ABOVE, "ė"),
-                Triple("e", OGONEK, "ę"),
-                Triple("e", CARON, "ě"),
-                Triple("g", CIRCUMFLEX, "ĝ"),
-                Triple("g", BREVE, "ğ"),
-                Triple("g", DOT_ABOVE, "ġ"),
-                Triple("g", CEDILLA, "ģ"),
-                Triple("h", CIRCUMFLEX, "ĥ"),
-                Triple("i", GRAVE, "ì"),
-                Triple("i", ACUTE, "í"),
-                Triple("i", CIRCUMFLEX, "î"),
-                Triple("i", DIAERESIS, "ï"),
-                Triple("i", TILDE, "ĩ"),
-                Triple("i", MACRON, "ī"),
-                Triple("i", BREVE, "ĭ"),
-                Triple("i", OGONEK, "į"),
-                Triple("j", CIRCUMFLEX, "ĵ"),
-                Triple("k", CEDILLA, "ķ"),
-                Triple("l", ACUTE, "ĺ"),
-                Triple("l", CEDILLA, "ļ"),
-                Triple("l", CARON, "ľ"),
-                Triple("n", TILDE, "ñ"),
-                Triple("n", ACUTE, "ń"),
-                Triple("n", CEDILLA, "ņ"),
-                Triple("n", CARON, "ň"),
-                Triple("o", GRAVE, "ò"),
-                Triple("o", ACUTE, "ó"),
-                Triple("o", CIRCUMFLEX, "ô"),
-                Triple("o", TILDE, "õ"),
-                Triple("o", DIAERESIS, "ö"),
-                Triple("o", MACRON, "ō"),
-                Triple("o", BREVE, "ŏ"),
-                Triple("o", DOUBLE_ACUTE, "ő"),
-                Triple("r", ACUTE, "ŕ"),
-                Triple("r", CEDILLA, "ŗ"),
-                Triple("r", CARON, "ř"),
-                Triple("s", ACUTE, "ś"),
-                Triple("s", CIRCUMFLEX, "ŝ"),
-                Triple("s", CEDILLA, "ş"),
-                Triple("s", CARON, "š"),
-                Triple("t", CEDILLA, "ţ"),
-                Triple("t", CARON, "ť"),
-                Triple("u", GRAVE, "ù"),
-                Triple("u", ACUTE, "ú"),
-                Triple("u", CIRCUMFLEX, "û"),
-                Triple("u", DIAERESIS, "ü"),
-                Triple("u", TILDE, "ũ"),
-                Triple("u", MACRON, "ū"),
-                Triple("u", BREVE, "ŭ"),
-                Triple("u", RING_ABOVE, "ů"),
-                Triple("u", DOUBLE_ACUTE, "ű"),
-                Triple("u", OGONEK, "ų"),
-                Triple("w", CIRCUMFLEX, "ŵ"),
-                Triple("y", ACUTE, "ý"),
-                Triple("y", DIAERESIS, "ÿ"),
-                Triple("y", CIRCUMFLEX, "ŷ"),
-                Triple("z", ACUTE, "ź"),
-                Triple("z", DOT_ABOVE, "ż"),
-                Triple("z", CARON, "ž"),
-            )
-        cases.forEach { (base, mark, composed) -> normalizeNfc(base + mark) shouldBe composed }
-    }
+class NfcNormalizeParityTest :
+    FunSpec({
+        test("composes lowercase Latin diacritics identically on JVM and native") {
+            // (base, combining mark) -> NFC precomposed letter. Input is `base + mark` (decomposed, NFD).
+            val cases =
+                listOf(
+                    Triple("a", GRAVE, "à"),
+                    Triple("a", ACUTE, "á"),
+                    Triple("a", CIRCUMFLEX, "â"),
+                    Triple("a", TILDE, "ã"),
+                    Triple("a", DIAERESIS, "ä"),
+                    Triple("a", RING_ABOVE, "å"),
+                    Triple("a", MACRON, "ā"),
+                    Triple("a", BREVE, "ă"),
+                    Triple("a", OGONEK, "ą"),
+                    Triple("c", CEDILLA, "ç"),
+                    Triple("c", ACUTE, "ć"),
+                    Triple("c", CIRCUMFLEX, "ĉ"),
+                    Triple("c", DOT_ABOVE, "ċ"),
+                    Triple("c", CARON, "č"),
+                    Triple("d", CARON, "ď"),
+                    Triple("e", GRAVE, "è"),
+                    Triple("e", ACUTE, "é"),
+                    Triple("e", CIRCUMFLEX, "ê"),
+                    Triple("e", DIAERESIS, "ë"),
+                    Triple("e", MACRON, "ē"),
+                    Triple("e", BREVE, "ĕ"),
+                    Triple("e", DOT_ABOVE, "ė"),
+                    Triple("e", OGONEK, "ę"),
+                    Triple("e", CARON, "ě"),
+                    Triple("g", CIRCUMFLEX, "ĝ"),
+                    Triple("g", BREVE, "ğ"),
+                    Triple("g", DOT_ABOVE, "ġ"),
+                    Triple("g", CEDILLA, "ģ"),
+                    Triple("h", CIRCUMFLEX, "ĥ"),
+                    Triple("i", GRAVE, "ì"),
+                    Triple("i", ACUTE, "í"),
+                    Triple("i", CIRCUMFLEX, "î"),
+                    Triple("i", DIAERESIS, "ï"),
+                    Triple("i", TILDE, "ĩ"),
+                    Triple("i", MACRON, "ī"),
+                    Triple("i", BREVE, "ĭ"),
+                    Triple("i", OGONEK, "į"),
+                    Triple("j", CIRCUMFLEX, "ĵ"),
+                    Triple("k", CEDILLA, "ķ"),
+                    Triple("l", ACUTE, "ĺ"),
+                    Triple("l", CEDILLA, "ļ"),
+                    Triple("l", CARON, "ľ"),
+                    Triple("n", TILDE, "ñ"),
+                    Triple("n", ACUTE, "ń"),
+                    Triple("n", CEDILLA, "ņ"),
+                    Triple("n", CARON, "ň"),
+                    Triple("o", GRAVE, "ò"),
+                    Triple("o", ACUTE, "ó"),
+                    Triple("o", CIRCUMFLEX, "ô"),
+                    Triple("o", TILDE, "õ"),
+                    Triple("o", DIAERESIS, "ö"),
+                    Triple("o", MACRON, "ō"),
+                    Triple("o", BREVE, "ŏ"),
+                    Triple("o", DOUBLE_ACUTE, "ő"),
+                    Triple("r", ACUTE, "ŕ"),
+                    Triple("r", CEDILLA, "ŗ"),
+                    Triple("r", CARON, "ř"),
+                    Triple("s", ACUTE, "ś"),
+                    Triple("s", CIRCUMFLEX, "ŝ"),
+                    Triple("s", CEDILLA, "ş"),
+                    Triple("s", CARON, "š"),
+                    Triple("t", CEDILLA, "ţ"),
+                    Triple("t", CARON, "ť"),
+                    Triple("u", GRAVE, "ù"),
+                    Triple("u", ACUTE, "ú"),
+                    Triple("u", CIRCUMFLEX, "û"),
+                    Triple("u", DIAERESIS, "ü"),
+                    Triple("u", TILDE, "ũ"),
+                    Triple("u", MACRON, "ū"),
+                    Triple("u", BREVE, "ŭ"),
+                    Triple("u", RING_ABOVE, "ů"),
+                    Triple("u", DOUBLE_ACUTE, "ű"),
+                    Triple("u", OGONEK, "ų"),
+                    Triple("w", CIRCUMFLEX, "ŵ"),
+                    Triple("y", ACUTE, "ý"),
+                    Triple("y", DIAERESIS, "ÿ"),
+                    Triple("y", CIRCUMFLEX, "ŷ"),
+                    Triple("z", ACUTE, "ź"),
+                    Triple("z", DOT_ABOVE, "ż"),
+                    Triple("z", CARON, "ž"),
+                )
+            cases.forEach { (base, mark, composed) -> normalizeNfc(base + mark) shouldBe composed }
+        }
 
-    @Test
-    fun passesThroughAsciiAndAlreadyComposedText() {
-        normalizeNfc("user.name@example.com") shouldBe "user.name@example.com"
-        normalizeNfc("café") shouldBe "café"
-        normalizeNfc("señor@correo.es") shouldBe "señor@correo.es"
-        normalizeNfc("") shouldBe ""
-    }
+        test("passes through ASCII and already-composed text") {
+            normalizeNfc("user.name@example.com") shouldBe "user.name@example.com"
+            normalizeNfc("café") shouldBe "café"
+            normalizeNfc("señor@correo.es") shouldBe "señor@correo.es"
+            normalizeNfc("") shouldBe ""
+        }
 
-    @Test
-    fun composesDecomposedSequencesWithinFullEmailStrings() {
-        normalizeNfc("jose" + ACUTE + "@example.com") shouldBe "josé@example.com"
-        normalizeNfc("mu" + DIAERESIS + "ller@firma.de") shouldBe "müller@firma.de"
-        normalizeNfc("dvor" + CARON + "ak@hudba.cz") shouldBe "dvořak@hudba.cz"
-    }
-}
+        test("composes decomposed sequences within full email strings") {
+            normalizeNfc("jose" + ACUTE + "@example.com") shouldBe "josé@example.com"
+            normalizeNfc("mu" + DIAERESIS + "ller@firma.de") shouldBe "müller@firma.de"
+            normalizeNfc("dvor" + CARON + "ak@hudba.cz") shouldBe "dvořak@hudba.cz"
+        }
+    })

--- a/server/src/commonTest/kotlin/com/calypsan/listenup/server/foundation/FoundationSmokeTest.kt
+++ b/server/src/commonTest/kotlin/com/calypsan/listenup/server/foundation/FoundationSmokeTest.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.auth.JwtConfiguration
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO as ClientCIO
@@ -17,8 +18,6 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
-import kotlin.test.Test
-import kotlinx.coroutines.runBlocking
 import kotlinx.rpc.krpc.ktor.client.installKrpc
 import kotlinx.rpc.krpc.ktor.client.rpc
 import kotlinx.rpc.krpc.ktor.client.rpcConfig
@@ -27,38 +26,39 @@ import kotlinx.rpc.krpc.serialization.json.json
 import kotlinx.rpc.registerService
 import kotlinx.rpc.withService
 
+// One JwtConfiguration shared by the server (via deps) and the token minting, so a minted token
+// verifies against the same secret. Liveness is always-true: a validly-signed token is accepted.
+private val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client")
+
+private fun deps(): FoundationDeps = FoundationDeps(jwt) { true }
+
+/** Test-scope ping impl — unguarded by design (the rpc-guard decorator is jvmMain-only). */
+private class TestPing : PingService {
+    override suspend fun ping(): AppResult<String> = AppResult.Success("pong")
+}
+
 /**
  * Foundation smoke: the three-transport proof that the native HTTP skeleton actually *serves* —
  * REST, JWT auth, and kotlinx.rpc. As `commonTest` it runs on JVM **and** linuxX64; the native run
  * is the load-bearing "serves native" evidence (not just "compiles native").
  *
- * Uses `kotlin.test.@Test` + `runBlocking`, not Kotest FunSpec: Kotest 6.x dropped the multiplatform
- * Gradle plugin that generates native test entry points, so FunSpec specs are invisible to the K/N
- * runner. Kotest's assertions still compile and run on linuxX64, so they're kept.
+ * Uses Kotest FunSpec: the `:server` module's Kotest 6 Gradle plugin (`io.kotest`) plus KSP generates
+ * the Kotlin/Native test entry point, so FunSpec specs run on both the JVM and linuxX64 lanes.
  *
  * REST / auth go through `testApplication`. RPC goes through a real `embeddedServer(CIO)` on an
  * ephemeral port via [foundationServer], because the testApplication WebSocket bridge is unimplemented
  * on native and kotlinx.rpc rides WebSocket.
  */
-class FoundationSmokeTest {
-    // One JwtConfiguration shared by the server (via deps) and the token minting, so a minted token
-    // verifies against the same secret. Liveness is always-true: a validly-signed token is accepted.
-    private val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client")
-
-    private fun deps(): FoundationDeps = FoundationDeps(jwt) { true }
-
-    @Test
-    fun restHealthzServesOk(): Unit =
-        runBlocking {
+class FoundationSmokeTest :
+    FunSpec({
+        test("REST /healthz serves ok") {
             testApplication {
                 application { installFoundation(deps()) }
                 client.get("/healthz").bodyAsText().contains("ok") shouldBe true
             }
         }
 
-    @Test
-    fun whoamiRejectsAnonymousAndEchoesAuthedUser(): Unit =
-        runBlocking {
+        test("whoami rejects anonymous requests and echoes the authed user") {
             testApplication {
                 application { installFoundation(deps()) }
                 client.get("/healthz/whoami").status shouldBe HttpStatusCode.Unauthorized
@@ -70,9 +70,7 @@ class FoundationSmokeTest {
             }
         }
 
-    @Test
-    fun rpcPingServesOverRealCioServer(): Unit =
-        runBlocking {
+        test("RPC ping serves over a real CIO server") {
             // installFoundation installs the Krpc transport but registers no service (guarded
             // registration is jvmMain-only today — see installFoundation's KDoc); the smoke
             // registers an unguarded test ping via the configure hook, in test scope.
@@ -113,9 +111,4 @@ class FoundationSmokeTest {
                 server.stop(0, 0)
             }
         }
-
-    /** Test-scope ping impl — unguarded by design (the rpc-guard decorator is jvmMain-only). */
-    private class TestPing : PingService {
-        override suspend fun ping(): AppResult<String> = AppResult.Success("pong")
-    }
-}
+    })

--- a/server/src/commonTest/kotlin/com/calypsan/listenup/server/io/SeekableSourceContentTest.kt
+++ b/server/src/commonTest/kotlin/com/calypsan/listenup/server/io/SeekableSourceContentTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.io
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
@@ -14,8 +15,26 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
-import kotlin.test.Test
-import kotlinx.coroutines.runBlocking
+
+private val payload = ByteArray(256) { it.toByte() }
+
+private suspend fun serving(block: suspend (HttpClient) -> Unit) =
+    testApplication {
+        application {
+            install(PartialContent)
+            routing {
+                get("/f") {
+                    call.respond(
+                        SeekableSourceContent(
+                            length = payload.size.toLong(),
+                            contentType = ContentType.Application.OctetStream,
+                        ) { ByteArraySeekableSource(payload) },
+                    )
+                }
+            }
+        }
+        block(client)
+    }
 
 /**
  * Proves the streaming file-response seam serves on JVM **and** linuxX64: [SeekableSourceContent] over
@@ -23,43 +42,22 @@ import kotlinx.coroutines.runBlocking
  * sub-range, with the windowed bytes produced by a real seek (not loaded whole). The native run is the
  * "serves native" proof that `respondSeekable` can replace `LocalFileContent`/`respondFile`.
  */
-class SeekableSourceContentTest {
-    private val payload = ByteArray(256) { it.toByte() }
-
-    private fun serving(block: suspend (HttpClient) -> Unit) =
-        runBlocking {
-            testApplication {
-                application {
-                    install(PartialContent)
-                    routing {
-                        get("/f") {
-                            call.respond(
-                                SeekableSourceContent(
-                                    length = payload.size.toLong(),
-                                    contentType = ContentType.Application.OctetStream,
-                                ) { ByteArraySeekableSource(payload) },
-                            )
-                        }
-                    }
-                }
-                block(client)
+class SeekableSourceContentTest :
+    FunSpec({
+        test("full request streams the whole file as 200") {
+            serving { client ->
+                val resp = client.get("/f")
+                resp.status shouldBe HttpStatusCode.OK
+                resp.readRawBytes().toList() shouldBe payload.toList()
             }
         }
 
-    @Test
-    fun fullRequestStreamsWholeFileAs200(): Unit =
-        serving { client ->
-            val resp = client.get("/f")
-            resp.status shouldBe HttpStatusCode.OK
-            resp.readRawBytes().toList() shouldBe payload.toList()
+        test("range request streams the exact window as 206") {
+            serving { client ->
+                val resp = client.get("/f") { header(HttpHeaders.Range, "bytes=100-149") }
+                resp.status shouldBe HttpStatusCode.PartialContent
+                resp.headers[HttpHeaders.ContentRange] shouldBe "bytes 100-149/256"
+                resp.readRawBytes().toList() shouldBe payload.copyOfRange(100, 150).toList()
+            }
         }
-
-    @Test
-    fun rangeRequestStreamsExactWindowAs206(): Unit =
-        serving { client ->
-            val resp = client.get("/f") { header(HttpHeaders.Range, "bytes=100-149") }
-            resp.status shouldBe HttpStatusCode.PartialContent
-            resp.headers[HttpHeaders.ContentRange] shouldBe "bytes 100-149/256"
-            resp.readRawBytes().toList() shouldBe payload.copyOfRange(100, 150).toList()
-        }
-}
+    })

--- a/server/src/commonTest/kotlin/com/calypsan/listenup/server/sync/SlugDiacriticsTest.kt
+++ b/server/src/commonTest/kotlin/com/calypsan/listenup/server/sync/SlugDiacriticsTest.kt
@@ -1,8 +1,10 @@
 package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.api.result.AppResult
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import kotlin.test.Test
+
+private fun slug(raw: String): String = (TagSlug.normalize(raw) as AppResult.Success).data
 
 /**
  * Proves slug normalization yields the SAME output on JVM (`java.text.Normalizer` NFKD) and linuxX64
@@ -10,30 +12,26 @@ import kotlin.test.Test
  * native run is the proof the seam matches the historical JVM behaviour for realistic Latin display
  * names. (The full slug rules — errors, length — stay covered by the existing `TagSlugTest`.)
  */
-class SlugDiacriticsTest {
-    private fun slug(raw: String): String = (TagSlug.normalize(raw) as AppResult.Success).data
+class SlugDiacriticsTest :
+    FunSpec({
+        test("folds Latin diacritics identically on JVM and native") {
+            slug("Café") shouldBe "cafe"
+            slug("Köln") shouldBe "koln"
+            slug("Señor") shouldBe "senor"
+            slug("Naïve") shouldBe "naive"
+            slug("Façade") shouldBe "facade"
+            slug("Mötley Crüe") shouldBe "motley-crue"
+            slug("Antonín Dvořák") shouldBe "antonin-dvorak"
+            slug("Žižek") shouldBe "zizek"
+        }
 
-    @Test
-    fun foldsLatinDiacriticsIdenticallyOnJvmAndNative() {
-        slug("Café") shouldBe "cafe"
-        slug("Köln") shouldBe "koln"
-        slug("Señor") shouldBe "senor"
-        slug("Naïve") shouldBe "naive"
-        slug("Façade") shouldBe "facade"
-        slug("Mötley Crüe") shouldBe "motley-crue"
-        slug("Antonín Dvořák") shouldBe "antonin-dvorak"
-        slug("Žižek") shouldBe "zizek"
-    }
+        test("foldDiacritics preserves case and plain text") {
+            foldDiacritics("Crème Brûlée") shouldBe "Creme Brulee"
+            foldDiacritics("plain ascii 123") shouldBe "plain ascii 123"
+        }
 
-    @Test
-    fun foldDiacriticsPreservesCaseAndPlainText() {
-        foldDiacritics("Crème Brûlée") shouldBe "Creme Brulee"
-        foldDiacritics("plain ascii 123") shouldBe "plain ascii 123"
-    }
-
-    @Test
-    fun slugPipelineStillHandlesAmpersandAndPunctuation() {
-        slug("Rock & Roll") shouldBe "rock-and-roll"
-        slug("Sci-Fi / Fantasy!") shouldBe "sci-fi-fantasy"
-    }
-}
+        test("slug pipeline still handles ampersand and punctuation") {
+            slug("Rock & Roll") shouldBe "rock-and-roll"
+            slug("Sci-Fi / Fantasy!") shouldBe "sci-fi-fantasy"
+        }
+    })

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/NativeServerBootTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/NativeServerBootTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import platform.posix.setenv
+import platform.posix.unsetenv
 import kotlin.test.Test
 
 /**
@@ -27,6 +28,8 @@ import kotlin.test.Test
  * where any remaining cinterop/glibc gap surfaces. The data home is a distinct hidden dir under
  * `$HOME` (the native test runner has no usable temp dir), so the boot never writes into the worktree.
  */
+private const val LISTENUP_HOME_ENV = "LISTENUP_HOME"
+
 class NativeServerBootTest {
     @OptIn(ExperimentalForeignApi::class)
     @Test
@@ -38,7 +41,12 @@ class NativeServerBootTest {
             val home =
                 readEnv("HOME")?.takeIf { it.isNotBlank() }?.let { "$it/.lu-native-boot-test" }
                     ?: "lu-native-boot-test"
-            setenv("LISTENUP_HOME", home, 1)
+            // LISTENUP_HOME is process-global and the native lane runs every spec in ONE process, so
+            // this has to be put back below — the finally deletes the directory, and a later spec that
+            // resolves its data home from the environment would otherwise silently boot against this
+            // deleted path instead of its own.
+            val originalListenupHome = readEnv(LISTENUP_HOME_ENV)
+            setenv(LISTENUP_HOME_ENV, home, 1)
             val server =
                 embeddedServer(
                     factory = CIO,
@@ -60,6 +68,11 @@ class NativeServerBootTest {
                 client.close()
                 server.stop(0, 0)
                 runCatching { deleteRecursivelyIfPresent(Path(home)) }
+                if (originalListenupHome != null) {
+                    setenv(LISTENUP_HOME_ENV, originalListenupHome, 1)
+                } else {
+                    unsetenv(LISTENUP_HOME_ENV)
+                }
             }
         }
 }

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/NativeServerBootTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/NativeServerBootTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server
 
 import com.calypsan.listenup.server.io.readEnv
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.HttpClient
@@ -13,12 +14,12 @@ import io.ktor.server.engine.EngineConnectorBuilder
 import io.ktor.server.engine.applicationEnvironment
 import io.ktor.server.engine.embeddedServer
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import platform.posix.setenv
 import platform.posix.unsetenv
-import kotlin.test.Test
+
+private const val LISTENUP_HOME_ENV = "LISTENUP_HOME"
 
 /**
  * Boots the REAL [Application.module] on a Kotlin/Native `embeddedServer(CIO)`
@@ -26,15 +27,12 @@ import kotlin.test.Test
  * SQLite driver (schema migrations), native crypto (the auto-generated JWT/refresh secrets), file I/O
  * (`$LISTENUP_HOME/secrets.properties`), the full Koin graph, and the request pipeline — so this is
  * where any remaining cinterop/glibc gap surfaces. The data home is a distinct hidden dir under
- * `$HOME` (the native test runner has no usable temp dir), so the boot never writes into the worktree.
+ * `$HOME`, so the boot never writes into the worktree.
  */
-private const val LISTENUP_HOME_ENV = "LISTENUP_HOME"
-
-class NativeServerBootTest {
-    @OptIn(ExperimentalForeignApi::class)
-    @Test
-    fun nativeServerBootsAndServesHealthz(): Unit =
-        runBlocking {
+@OptIn(ExperimentalForeignApi::class)
+class NativeServerBootTest :
+    FunSpec({
+        test("native server boots and serves healthz") {
             // Isolate the test data home under $HOME (a distinct hidden dir — never the real
             // ~/ListenUp), so the boot never writes into the worktree. Falls back to a CWD-relative
             // dir only if $HOME is somehow unset in the test runner.
@@ -75,7 +73,7 @@ class NativeServerBootTest {
                 }
             }
         }
-}
+    })
 
 private fun deleteRecursivelyIfPresent(path: Path) {
     val meta = SystemFileSystem.metadataOrNull(path) ?: return

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/auth/PasswordHasherNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/auth/PasswordHasherNativeTest.kt
@@ -1,9 +1,8 @@
 package com.calypsan.listenup.server.auth
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
-import kotlinx.coroutines.runBlocking
-import kotlin.test.Test
 
 /**
  * Native parity proof for [PasswordHasher] — the libargon2-cinterop actual. The cross-impl vector test
@@ -12,10 +11,9 @@ import kotlin.test.Test
  * drifts from password4j's encoding, native verify returns false and existing users can no longer log in
  * on the native server — this test fails first.
  */
-class PasswordHasherNativeTest {
-    @Test
-    fun nativeHashVerifyRoundTrips(): Unit =
-        runBlocking {
+class PasswordHasherNativeTest :
+    FunSpec({
+        test("native hash-verify round-trips") {
             val hasher = PasswordHasher()
             val phc = hasher.hash("native-round-trip-password")
             phc shouldStartWith "$" + "argon2id"
@@ -23,9 +21,7 @@ class PasswordHasherNativeTest {
             hasher.verify("wrong-password!!", phc) shouldBe false
         }
 
-    @Test
-    fun nativeVerifyAcceptsAJvmProducedHash(): Unit =
-        runBlocking {
+        test("native verify accepts a jvm-produced hash") {
             // VECTOR PROVENANCE: produced by the JVM actual (password4j) from `plaintext` below, via the
             // plan's Step 3 generation procedure. Do NOT hand-edit. If the Argon2 parameters ever change,
             // regenerate it from the JVM impl — a hand-written value defeats the anti-drift purpose.
@@ -34,4 +30,4 @@ class PasswordHasherNativeTest {
                 "\$argon2id\$v=19\$m=65536,t=3,p=4\$9j3C+x1TtkZNN1++COnYDQ\$x2M9twfkhkgdGh8DmhzTs4P2tKulagocBE6BDiontW4"
             PasswordHasher().verify(plaintext, jvmProducedHash) shouldBe true
         }
-}
+    })

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/collections/CollectionCreateNativeRpcTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/collections/CollectionCreateNativeRpcTest.kt
@@ -26,14 +26,13 @@ import com.calypsan.listenup.server.sync.CollectionBookRepository
 import com.calypsan.listenup.server.sync.CollectionGrantRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO as ClientCIO
 import io.ktor.client.plugins.websocket.WebSockets as ClientWebSockets
 import io.ktor.server.routing.routing
 import kotlin.random.Random
-import kotlin.test.Test
-import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.rpc.krpc.ktor.client.installKrpc
@@ -43,6 +42,9 @@ import kotlinx.rpc.krpc.ktor.server.rpc
 import kotlinx.rpc.krpc.serialization.json.json
 import kotlinx.rpc.registerService
 import kotlinx.rpc.withService
+
+private const val JWT_SECRET_LEN = 32
+private const val HEX_RADIX = 16
 
 /**
  * Native (linuxX64) proof for the create-collection RPC — the exact Kotlin/Native kotlinx.rpc
@@ -56,19 +58,16 @@ import kotlinx.rpc.withService
  * native CIO/krpc WebSocket transport — if the create RPC (complex `CollectionSummary` return)
  * fails on native, it reproduces HERE, on Linux, where it can be fixed.
  *
- * Structure mirrors [com.calypsan.listenup.server.rpcguard.RpcGuardNativeTest]: `kotlin.test.@Test`
- * + `runBlocking` (Kotest's FunSpec is invisible to the K/N test runner), a real [foundationServer]
- * over the native CIO engine, and a native CIO/krpc client opening the service proxy.
+ * Drives a real [foundationServer] over the native CIO engine and a native CIO/krpc client
+ * opening the service proxy.
  */
-class CollectionCreateNativeRpcTest {
-    private val jwt = JwtConfiguration("x".repeat(JWT_SECRET_LEN), "listenup", "listenup-client")
+class CollectionCreateNativeRpcTest :
+    FunSpec({
+        test("create collection round-trips over native krpc") {
+            val jwt = JwtConfiguration("x".repeat(JWT_SECRET_LEN), "listenup", "listenup-client")
 
-    @Test
-    fun createCollectionRoundTripsOverNativeKrpc(): Unit =
-        runBlocking {
-            // A real, writable, ABSOLUTE dir under $HOME (the native test runner has no usable temp
-            // dir — see NativeServerBootTest). Absolute so MigrationRunner's admin connection and
-            // SQLiter's driver resolve to the SAME file: a bare filename sends SQLiter to its default
+            // A real, writable, ABSOLUTE dir under $HOME. Absolute so MigrationRunner's admin connection
+            // and SQLiter's driver resolve to the SAME file: a bare filename sends SQLiter to its default
             // dir while the admin connection opens it cwd-relative, and the two never meet
             // (DriverFactory.linux splits name/basePath).
             val home = readEnv("HOME")?.takeIf { it.isNotBlank() } ?: "."
@@ -172,9 +171,4 @@ class CollectionCreateNativeRpcTest {
                 }
             }
         }
-
-    private companion object {
-        const val JWT_SECRET_LEN = 32
-        const val HEX_RADIX = 16
-    }
-}
+    })

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/DataDirLockPermissionNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/DataDirLockPermissionNativeTest.kt
@@ -2,6 +2,9 @@
 
 package com.calypsan.listenup.server.db
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.io.files.Path
 import platform.posix.S_IRUSR
@@ -10,9 +13,6 @@ import platform.posix.geteuid
 import platform.posix.getpid
 import platform.posix.mkdir
 import platform.posix.rmdir
-import kotlin.test.Test
-import kotlin.test.assertContains
-import kotlin.test.assertFailsWith
 
 /**
  * Native proof that an *unwritable* data dir surfaces as a clear permission error — not the misleading
@@ -21,24 +21,24 @@ import kotlin.test.assertFailsWith
  * volume left the nonroot server unable to create `<dataHome>/.lock`, and `tryLockFile` reported that
  * `open()` failure as a lock conflict.
  */
-class DataDirLockPermissionNativeTest {
-    @Test
-    fun openFailureOnUnwritableDirThrowsPermissionErrorNotLockConflict() {
-        // root bypasses directory permission bits — open() would succeed, so the test proves nothing.
-        // CI typically runs as root (container), where this is skipped; it validates locally as non-root.
-        if (geteuid() == 0u) return
+class DataDirLockPermissionNativeTest :
+    FunSpec({
+        test("open failure on unwritable dir throws permission error not lock conflict") {
+            // root bypasses directory permission bits — open() would succeed, so the test proves nothing.
+            // CI typically runs as root (container), where this is skipped; it validates locally as non-root.
+            if (geteuid() == 0u) return@test
 
-        val dir = "/tmp/lu-lock-perm-${getpid()}"
-        rmdir(dir) // defensive: clear a leftover from a previously-crashed run
-        mkdir(dir, (S_IRUSR or S_IXUSR).toUInt()) // r-x------ : created without write permission
-        try {
-            val failure =
-                assertFailsWith<IllegalStateException> {
-                    DataDirLock.forDataHome(Path(dir)).tryAcquire()
-                }
-            assertContains(failure.message ?: "", "cannot open data-dir lock file")
-        } finally {
-            rmdir(dir)
+            val dir = "/tmp/lu-lock-perm-${getpid()}"
+            rmdir(dir) // defensive: clear a leftover from a previously-crashed run
+            mkdir(dir, (S_IRUSR or S_IXUSR).toUInt()) // r-x------ : created without write permission
+            try {
+                val failure =
+                    shouldThrow<IllegalStateException> {
+                        DataDirLock.forDataHome(Path(dir)).tryAcquire()
+                    }
+                (failure.message ?: "") shouldContain "cannot open data-dir lock file"
+            } finally {
+                rmdir(dir)
+            }
         }
-    }
-}
+    })

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/SqlAdminConnectionNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/SqlAdminConnectionNativeTest.kt
@@ -1,10 +1,10 @@
 package com.calypsan.listenup.server.db
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlin.random.Random
-import kotlin.test.Test
 
 /**
  * Native parity proof for the SQLite admin-connection seam ([openAdminConnection] → libsqlite3 cinterop).
@@ -12,33 +12,31 @@ import kotlin.test.Test
  * connection on a fresh file, run DDL + DML via [SqlAdminConnection.execute], read it back via the bound
  * [SqlAdminConnection.query], and assert the round-trip survives the cinterop marshalling.
  */
-class SqlAdminConnectionNativeTest {
-    @Test
-    fun executesDdlAndQueriesItBackOverTheNativeDriver() {
-        // Temp dir is unusable in the linuxX64 test runner — use a working-directory-relative file.
-        val dbName = "lu-admin-native-test-${Random.nextInt(1, Int.MAX_VALUE).toString(HEX_RADIX)}.db"
-        try {
-            openAdminConnection(dbName, readOnly = false).use { conn ->
-                conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
-                conn.execute("INSERT INTO t (id, name) VALUES (1, 'kaladin')")
-                conn.execute("INSERT INTO t (id, name) VALUES (2, 'shallan')")
-                val names =
-                    conn.query(
-                        sql = "SELECT name FROM t WHERE name = ?",
-                        bind = { bindString(1, "shallan") },
-                        map = { row -> row.getString("name") },
-                    )
-                names shouldBe listOf("shallan")
-            }
-        } finally {
-            // journal_mode=WAL (set for read-write) leaves -wal / -shm sidecars; remove all three.
-            for (suffix in listOf("", "-wal", "-shm")) {
-                SystemFileSystem.delete(Path(dbName + suffix), mustExist = false)
+class SqlAdminConnectionNativeTest :
+    FunSpec({
+        test("executes ddl and queries it back over the native driver") {
+            // A working-directory-relative file (no temp dir needed for this quick round-trip check).
+            val dbName = "lu-admin-native-test-${Random.nextInt(1, Int.MAX_VALUE).toString(HEX_RADIX)}.db"
+            try {
+                openAdminConnection(dbName, readOnly = false).use { conn ->
+                    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+                    conn.execute("INSERT INTO t (id, name) VALUES (1, 'kaladin')")
+                    conn.execute("INSERT INTO t (id, name) VALUES (2, 'shallan')")
+                    val names =
+                        conn.query(
+                            sql = "SELECT name FROM t WHERE name = ?",
+                            bind = { bindString(1, "shallan") },
+                            map = { row -> row.getString("name") },
+                        )
+                    names shouldBe listOf("shallan")
+                }
+            } finally {
+                // journal_mode=WAL (set for read-write) leaves -wal / -shm sidecars; remove all three.
+                for (suffix in listOf("", "-wal", "-shm")) {
+                    SystemFileSystem.delete(Path(dbName + suffix), mustExist = false)
+                }
             }
         }
-    }
+    })
 
-    private companion object {
-        const val HEX_RADIX = 16
-    }
-}
+private const val HEX_RADIX = 16

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/sqldelight/DriverFactoryConcurrentReadNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/sqldelight/DriverFactoryConcurrentReadNativeTest.kt
@@ -1,15 +1,17 @@
 package com.calypsan.listenup.server.db.sqldelight
 
 import app.cash.sqldelight.db.QueryResult
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlin.random.Random
-import kotlin.test.Test
+
+private const val HEX_RADIX = 16
+private const val CONCURRENT_READS = 32
 
 /**
  * Native runtime proof for [DriverFactory] on linuxX64: with the WAL reader pool (maxReaderConnections > 1)
@@ -17,10 +19,9 @@ import kotlin.test.Test
  * transient SQLITE_BUSY. Regression guard for the reader-pool sizing — if WAL or the busy-timeout were ever
  * dropped, or the pool returned to a single connection that BUSY'd under contention, this would surface it.
  */
-class DriverFactoryConcurrentReadNativeTest {
-    @Test
-    fun concurrentReadsAllSucceedUnderTheWalReaderPool(): Unit =
-        runBlocking {
+class DriverFactoryConcurrentReadNativeTest :
+    FunSpec({
+        test("concurrent reads all succeed under the wal reader pool") {
             val dbName = "lu-driver-pool-test-${Random.nextInt(1, Int.MAX_VALUE).toString(HEX_RADIX)}.db"
             val driver = DriverFactory().createDriver(dbName)
             try {
@@ -53,9 +54,4 @@ class DriverFactoryConcurrentReadNativeTest {
                 }
             }
         }
-
-    private companion object {
-        const val HEX_RADIX = 16
-        const val CONCURRENT_READS = 32
-    }
-}
+    })

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/MultipartUploadNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/MultipartUploadNativeTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.io
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO as ClientCIO
@@ -17,12 +18,13 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
-import kotlinx.coroutines.runBlocking
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.readByteArray
-import kotlin.test.Test
+
+private const val RECEIVED = "received"
+private const val EMPTY = "empty"
 
 /**
  * Proves the Kotlin/Native runtime serves multipart uploads at parity with the JVM. Ktor's CIO server
@@ -31,18 +33,11 @@ import kotlin.test.Test
  * by `MultipartFormDataTest` on the JVM runner). This drives a real `embeddedServer(CIO)` over an
  * ephemeral port and asserts the uploaded file lands on disk byte-for-byte.
  *
- * `kotlin.test.@Test` + `runBlocking` and a `Unit` body so the K/N runner discovers it; the upload
- * target is a CWD-relative path because the native test runner has no usable temp directory.
+ * The upload target is a CWD-relative path.
  */
-class MultipartUploadNativeTest {
-    private companion object {
-        const val RECEIVED = "received"
-        const val EMPTY = "empty"
-    }
-
-    @Test
-    fun nativeServerStreamsTheFirstFilePartToDisk(): Unit =
-        runBlocking {
+class MultipartUploadNativeTest :
+    FunSpec({
+        test("native server streams the first file part to disk") {
             val dest = Path("lu-native-multipart-upload-test.bin")
             val payload = ByteArray(50_000) { (it * 7).toByte() }
             val server =
@@ -88,9 +83,7 @@ class MultipartUploadNativeTest {
             }
         }
 
-    @Test
-    fun nativeServerReadsTheFirstFilePartIntoMemory(): Unit =
-        runBlocking {
+        test("native server reads the first file part into memory") {
             // The avatar route needs the first file part's bytes in memory (magic-number validation),
             // not a stream to disk. The Kotlin/Native CIO server can't use `receiveMultipart`
             // (KTOR-7361), so this exercises the raw-channel path over a real embeddedServer(CIO).
@@ -137,4 +130,4 @@ class MultipartUploadNativeTest {
                 server.stop(0, 0)
             }
         }
-}
+    })

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/SystemEnvNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/SystemEnvNativeTest.kt
@@ -1,9 +1,10 @@
 package com.calypsan.listenup.server.io
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.posix.setenv
-import kotlin.test.Test
+import platform.posix.unsetenv
 
 /**
  * Native proof for the [readEnv] / [userHomeDir] / [hostname] env seam: the
@@ -11,28 +12,35 @@ import kotlin.test.Test
  * `gethostname`. Round-trips a value set with `setenv`, confirms an unset name reads as null, and proves
  * the host-name actual returns a sane, NUL-stripped string.
  */
-class SystemEnvNativeTest {
-    @OptIn(ExperimentalForeignApi::class)
-    @Test
-    fun readEnvRoundTripsSetenvAndReturnsNullForUnset() {
-        setenv("LISTENUP_NATIVE_ENV_TEST", "native-value-42", 1)
-        readEnv("LISTENUP_NATIVE_ENV_TEST") shouldBe "native-value-42"
-        readEnv("LISTENUP_NATIVE_ENV_DEFINITELY_UNSET") shouldBe null
-    }
+@OptIn(ExperimentalForeignApi::class)
+class SystemEnvNativeTest :
+    FunSpec({
 
-    @OptIn(ExperimentalForeignApi::class)
-    @Test
-    fun userHomeDirReadsHomeEnv() {
-        setenv("HOME", "/home/listenup-native-test", 1)
-        userHomeDir() shouldBe "/home/listenup-native-test"
-    }
+        test("readEnv round-trips a setenv value and reads an unset name as null") {
+            setenv("LISTENUP_NATIVE_ENV_TEST", "native-value-42", 1)
+            readEnv("LISTENUP_NATIVE_ENV_TEST") shouldBe "native-value-42"
+            readEnv("LISTENUP_NATIVE_ENV_DEFINITELY_UNSET") shouldBe null
+        }
 
-    @Test
-    fun hostnameReturnsANonBlankHostName() {
-        // The value is host-dependent (the CI container's name), but `gethostname` always succeeds on a
-        // real host, and the actual must strip the trailing NUL padding from the fixed-size buffer.
-        val name = hostname()
-        name.isNotBlank() shouldBe true
-        name.all { it.code in 33..126 } shouldBe true
-    }
-}
+        test("userHomeDir reads HOME") {
+            // HOME is process-global and the native lane runs every spec in ONE process, so leaving it
+            // clobbered strands every later spec that resolves a writable directory from it — the boot
+            // and collection specs root their data home under $HOME, and SQLiter resolves a bare
+            // database name under $HOME too. Put it back.
+            val originalHome = readEnv("HOME")
+            try {
+                setenv("HOME", "/home/listenup-native-test", 1)
+                userHomeDir() shouldBe "/home/listenup-native-test"
+            } finally {
+                if (originalHome != null) setenv("HOME", originalHome, 1) else unsetenv("HOME")
+            }
+        }
+
+        test("hostname returns a non-blank host name") {
+            // The value is host-dependent (the CI container's name), but `gethostname` always succeeds on a
+            // real host, and the actual must strip the trailing NUL padding from the fixed-size buffer.
+            val name = hostname()
+            name.isNotBlank() shouldBe true
+            name.all { it.code in 33..126 } shouldBe true
+        }
+    })

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayerNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayerNativeTest.kt
@@ -1,7 +1,7 @@
 package com.calypsan.listenup.server.mdns
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import kotlin.test.Test
 
 /**
  * Native construction/teardown proof for the mDNS POSIX socket layer ([openMdnsSockets] → getifaddrs /
@@ -13,22 +13,20 @@ import kotlin.test.Test
  * unreliable in sandboxes. This test proves the enumeration + bind + join + teardown syscall path runs
  * cleanly and releases its file descriptors; it does not assert a datagram round-trip.
  */
-class MdnsSocketLayerNativeTest {
-    @Test
-    fun opensAndClosesMulticastSocketsWithoutCrashing() {
-        // May be empty on a runner with no usable interface — a valid outcome (advertise-disabled).
-        val sockets = openMdnsSockets()
-        try {
-            for (socket in sockets) {
-                socket.ipv4.size shouldBe IPV4_BYTES
-                socket.interfaceName.isNotBlank() shouldBe true
+class MdnsSocketLayerNativeTest :
+    FunSpec({
+        test("opens and closes multicast sockets without crashing") {
+            // May be empty on a runner with no usable interface — a valid outcome (advertise-disabled).
+            val sockets = openMdnsSockets()
+            try {
+                for (socket in sockets) {
+                    socket.ipv4.size shouldBe IPV4_BYTES
+                    socket.interfaceName.isNotBlank() shouldBe true
+                }
+            } finally {
+                sockets.forEach { it.leaveAndClose() }
             }
-        } finally {
-            sockets.forEach { it.leaveAndClose() }
         }
-    }
+    })
 
-    private companion object {
-        const val IPV4_BYTES = 4
-    }
-}
+private const val IPV4_BYTES = 4

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/metadata/MetadataHttpClientNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/metadata/MetadataHttpClientNativeTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server.metadata
 
 import com.calypsan.listenup.server.di.metadataHttpClient
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
@@ -14,11 +15,9 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlin.test.Test
 
 /**
  * Native capability proof for the metadata HTTP client seam (`metadataHttpClient`): on Kotlin/Native
@@ -27,22 +26,11 @@ import kotlin.test.Test
  * metadata client can perform a GET **and deserialize a JSON body via ContentNegotiation** — the exact
  * path the scrapers rely on. Real outbound HTTPS is verified manually via `runNative` (CI has no
  * outbound network), so this exercises the request + JSON-deserialize seam over loopback HTTP.
- *
- * `kotlin.test.@Test` + `runBlocking`, `Unit` body, real `embeddedServer(CIO)` over an ephemeral port.
  */
-class MetadataHttpClientNativeTest {
-    @Serializable
-    @SerialName("CatalogItem")
-    private data class CatalogItem(
-        val asin: String,
-        val title: String,
-    )
-
-    private val lenientJson = Json { ignoreUnknownKeys = true }
-
-    @Test
-    fun nativeCioClientGetsAndDeserializesJson(): Unit =
-        runBlocking {
+class MetadataHttpClientNativeTest :
+    FunSpec({
+        test("native CIO client gets and deserializes JSON") {
+            val lenientJson = Json { ignoreUnknownKeys = true }
             val server =
                 embeddedServer(CIO, port = 0) {
                     install(ServerContentNegotiation) { json(lenientJson) }
@@ -71,4 +59,11 @@ class MetadataHttpClientNativeTest {
                 server.stop(0, 0)
             }
         }
-}
+    })
+
+@Serializable
+@SerialName("CatalogItem")
+private data class CatalogItem(
+    val asin: String,
+    val title: String,
+)

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/plugins/NativeCallLoggingNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/plugins/NativeCallLoggingNativeTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.plugins
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO as ClientCIO
@@ -12,8 +13,6 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
-import kotlinx.coroutines.runBlocking
-import kotlin.test.Test
 
 /**
  * Native runtime proof for the linuxX64 [installCallLogging] actual: it installs on the real CIO
@@ -21,10 +20,9 @@ import kotlin.test.Test
  * interceptor's emitted line is not asserted (capturing the native logging appender's stdout is not
  * practical) — the contract under test is "installs + serves through the interceptor on native".
  */
-class NativeCallLoggingNativeTest {
-    @Test
-    fun installsAndServesARequestThroughTheLoggingInterceptor(): Unit =
-        runBlocking {
+class NativeCallLoggingNativeTest :
+    FunSpec({
+        test("installs and serves a request through the logging interceptor") {
             val server =
                 embeddedServer(
                     factory = CIO,
@@ -49,4 +47,4 @@ class NativeCallLoggingNativeTest {
                 server.stop(0, 0)
             }
         }
-}
+    })

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/rpcguard/RpcGuardNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/rpcguard/RpcGuardNativeTest.kt
@@ -7,14 +7,13 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.foundation.FoundationDeps
 import com.calypsan.listenup.server.foundation.foundationServer
 import com.calypsan.listenup.server.auth.JwtConfiguration
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO as ClientCIO
 import io.ktor.client.plugins.websocket.WebSockets as ClientWebSockets
-import kotlin.test.Test
-import kotlinx.coroutines.runBlocking
 import kotlinx.rpc.krpc.ktor.client.installKrpc
 import kotlinx.rpc.krpc.ktor.client.rpc
 import kotlinx.rpc.krpc.ktor.client.rpcConfig
@@ -30,20 +29,13 @@ import io.ktor.server.routing.routing
  * constant user-facing message (no stacktrace can ride InternalError) — running on linuxX64 over
  * the real CIO/krpc transport.
  *
- * `kotlin.test.@Test` + `runBlocking` (Kotest's FunSpec is invisible to the K/N test runner;
- * its assertions still run). Lives in `linuxX64Test` because `PingServiceGuarded` is generated
- * into `:contract`'s linuxX64 source set, not commonMain.
+ * Lives in `linuxX64Test` because `PingServiceGuarded` is generated into `:contract`'s linuxX64
+ * source set, not commonMain.
  */
-class RpcGuardNativeTest {
-    private val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client")
-
-    private class ThrowingPing : PingService {
-        override suspend fun ping(): AppResult<String> = throw RuntimeException("boom")
-    }
-
-    @Test
-    fun guardSanitizesThrownExceptionOnNative(): Unit =
-        runBlocking {
+class RpcGuardNativeTest :
+    FunSpec({
+        test("guard sanitizes thrown exception on native") {
+            val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client")
             val server =
                 foundationServer(port = 0, deps = FoundationDeps(jwt) { true }) {
                     routing {
@@ -88,4 +80,8 @@ class RpcGuardNativeTest {
                 server.stop(0, 0)
             }
         }
+    })
+
+private class ThrowingPing : PingService {
+    override suspend fun ping(): AppResult<String> = throw RuntimeException("boom")
 }

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/scanner/watcher/InotifyDirectoryWatcherNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/scanner/watcher/InotifyDirectoryWatcherNativeTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.scanner.watcher
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -9,14 +10,12 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.writeString
 import kotlin.random.Random
-import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -26,14 +25,12 @@ import kotlin.time.Duration.Companion.seconds
  * a file inside it and asserts the kernel events surface as Create / Modify / Delete (`MOVED_TO`/
  * `MOVED_FROM` map to Create/Delete the same way the JVM WatchService does).
  *
- * Scratch dir is working-directory-relative (`SystemTemporaryDirectory` is unusable in the linuxX64
- * test runner). `onSubscription` makes the collector's subscription deterministic so the first events
- * after `add()` are never raced away by the replay-less SharedFlow.
+ * Scratch dir is working-directory-relative. `onSubscription` makes the collector's subscription
+ * deterministic so the first events after `add()` are never raced away by the replay-less SharedFlow.
  */
-class InotifyDirectoryWatcherNativeTest {
-    @Test
-    fun surfacesCreateModifyDeleteForFilesInAWatchedDirectory(): Unit =
-        runBlocking {
+class InotifyDirectoryWatcherNativeTest :
+    FunSpec({
+        test("surfaces create modify delete for files in a watched directory") {
             val dir = Path("lu-inotify-test-${Random.nextInt(1, Int.MAX_VALUE).toString(HEX_RADIX)}")
             SystemFileSystem.createDirectories(dir)
             val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -45,14 +42,17 @@ class InotifyDirectoryWatcherNativeTest {
                 // Let the replay-less SharedFlow collector subscribe before the watcher emits.
                 delay(SUBSCRIBE_DELAY)
                 watcher.add(dir.toString())
-                val file = Path(dir, "book.mp3")
+                val file = Path(dir, WATCHED_FILE_NAME)
 
                 SystemFileSystem.sink(file).buffered().use { it.writeString("hello") }
-                events.await { it.kind == DirectoryWatchEventKind.Create && it.path.endsWith("book.mp3") }
-                events.await { it.kind == DirectoryWatchEventKind.Modify && it.path.endsWith("book.mp3") }
+                events.await { it.kind == DirectoryWatchEventKind.Create && it.path.endsWith(WATCHED_FILE_NAME) }
+                events.await { it.kind == DirectoryWatchEventKind.Modify && it.path.endsWith(WATCHED_FILE_NAME) }
 
                 SystemFileSystem.delete(file)
-                val delete = events.await { it.kind == DirectoryWatchEventKind.Delete && it.path.endsWith("book.mp3") }
+                val delete =
+                    events.await {
+                        it.kind == DirectoryWatchEventKind.Delete && it.path.endsWith(WATCHED_FILE_NAME)
+                    }
                 delete.targetDirectory shouldBe dir.toString()
             } finally {
                 collector.cancel()
@@ -61,19 +61,18 @@ class InotifyDirectoryWatcherNativeTest {
                 SystemFileSystem.delete(dir, mustExist = false)
             }
         }
+    })
 
-    private suspend fun Channel<DirectoryWatchEvent>.await(
-        predicate: (DirectoryWatchEvent) -> Boolean,
-    ): DirectoryWatchEvent =
-        withTimeout(AWAIT_TIMEOUT) {
-            var event = receive()
-            while (!predicate(event)) event = receive()
-            event
-        }
-
-    private companion object {
-        const val HEX_RADIX = 16
-        val SUBSCRIBE_DELAY = 300.milliseconds
-        val AWAIT_TIMEOUT = 5.seconds
+private suspend fun Channel<DirectoryWatchEvent>.await(
+    predicate: (DirectoryWatchEvent) -> Boolean,
+): DirectoryWatchEvent =
+    withTimeout(AWAIT_TIMEOUT) {
+        var event = receive()
+        while (!predicate(event)) event = receive()
+        event
     }
-}
+
+private const val HEX_RADIX = 16
+private const val WATCHED_FILE_NAME = "book.mp3"
+private val SUBSCRIBE_DELAY = 300.milliseconds
+private val AWAIT_TIMEOUT = 5.seconds

--- a/server/src/linuxX64Test/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/server/src/linuxX64Test/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,0 +1,39 @@
+package io.kotest.provided
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.names.DuplicateTestNameMode
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Kotest project configuration for the **`:server` linuxX64** test run — the native peer of the
+ * jvmTest config (`server/src/jvmTest/.../io/kotest/provided/ProjectConfig.kt`). Kotest discovers
+ * `io.kotest.provided.ProjectConfig` on native through the KSP-generated entry point, the same name
+ * it looks for on the JVM; the two never collide because each compiles into its own binary.
+ *
+ * This lane only started executing Kotest specs when the `io.kotest` Gradle plugin was applied — before
+ * that the Kotlin/Native runner collected only `kotlin.test`-annotated specs, so 54 FunSpec specs from
+ * `commonTest` sat on the classpath unexecuted while the lane reported green. These settings are the
+ * honesty guards that make a repeat of that visible:
+ *
+ *  - [failOnEmptyTestSuite] — a spec that registers zero tests is almost always a mistake (a misnamed
+ *    `test`, a `context` that never adds leaves). Fail instead of passing silently. This is the exact
+ *    shape of the bug above, one spec down.
+ *  - [duplicateTestNameMode] — two tests sharing a name inside one spec silently shadow each other's
+ *    results; make the copy-paste an error.
+ *  - [timeout] — the native lane boots real CIO servers and a real SQLite DB. A generous per-test
+ *    ceiling turns a genuine hang into a named "timed out" failure instead of stalling the whole
+ *    invocation. Far above any legitimate test's duration, so it only fires on a real hang.
+ *
+ * Deliberately NOT carrying jvmTest's `FlakyServerSpecRetryExtension`: that extension is JVM-only
+ * (`java.io.File`, `java.time.Instant`, `ConcurrentHashMap`) and its retry ledger exists for the
+ * contended 2-core CI runner's E2E specs, which have no native counterpart.
+ *
+ * The discovered-test-count floor for this lane lives in Gradle (`server/build.gradle.kts`, the
+ * `KotlinNativeTest` configuration), not here — Gradle's test task sees the run's true total.
+ */
+class ProjectConfig : AbstractProjectConfig() {
+    override val timeout: Duration = 120.seconds
+    override val failOnEmptyTestSuite: Boolean = true
+    override val duplicateTestNameMode: DuplicateTestNameMode = DuplicateTestNameMode.Error
+}

--- a/tools/detekt/baseline.xml
+++ b/tools/detekt/baseline.xml
@@ -131,7 +131,7 @@
     <ID>ThrowsCount:ZipReader.kt:ZipReader$private fun parseHeaders: List&lt;ZipEntryInfo&gt;</ID>
     <ID>ThrowsCount:ZipReader.kt:ZipReader$private fun readZip64Eocd: Zip64Eocd</ID>
     <ID>ThrowsCount:ZipReader.kt:ZipReader$public fun openEntry: RawSource</ID>
-    <ID>TooGenericExceptionThrown:RpcGuardNativeTest.kt:RpcGuardNativeTest.ThrowingPing$throw RuntimeException("boom")</ID>
+    <ID>TooGenericExceptionThrown:RpcGuardNativeTest.kt:ThrowingPing$throw RuntimeException("boom")</ID>
     <ID>TooGenericExceptionThrown:ScannerServiceGuardedBehaviorTest.kt:ScannerServiceGuardedBehaviorTest$throw RuntimeException("boom")</ID>
     <ID>TooManyFunctions:Koin.ios.kt:KoinHelper</ID>
     <ID>UnderscoresInNumericLiterals:Lz77.kt:1640531527</ID>


### PR DESCRIPTION
## The finding

Applying the Kotest 6 Gradle plugin to `:server` took the linuxX64 test count from **28 to 82**.

The other 54 were Kotest `FunSpec` specs living in `server/commonTest`. They compiled into the native test binary and sat on the classpath, but with no native Kotest runner the Kotlin/Native test infrastructure only ever collected the `kotlin.test`-annotated specs. The lane reported `BUILD SUCCESSFUL` over a third of its own suite. Several source comments even documented the workaround ("Kotest's FunSpec is invisible to the K/N test runner") — the limitation was known, the silent under-reporting was not.

## Turning the runner on exposed 6 failures, both causes pre-existing

**1. `SystemTemporaryDirectory` is the empty path on native.** kotlinx-io resolves it as `getenv("TMPDIR") ?: getenv("TMP") ?: ""`. Neither is set for a Gradle-launched native binary, so `createDirectories(Path(""))` fails with `mkdir failed: No such file or directory`. The JVM lane never saw this because it gets `java.io.tmpdir` for free — which is exactly why the older native specs root their scratch dirs under `$HOME`.

Fixed by setting `TMPDIR` under `build/` on the `KotlinNativeTest` task — the native mirror of the `java.io.tmpdir` redirect `jvmTest` already had.

**2. Environment mutation leaks; native runs the whole lane in one process.** `SystemEnvNativeTest` set `HOME=/home/listenup-native-test` to exercise the env seam and never restored it, so every later spec deriving a writable dir from `$HOME` hit `Permission denied` (`/home` is root-owned). The subtlest victim was `DriverFactoryConcurrentReadNativeTest`, which never mentions `HOME`: SQLiter's Linux `DatabaseFileContext.databaseDirPath()` resolves a bare database name via `getenv("HOME")`, so it failed with "unable to open database file" from the same poison.

This was an order-dependent landmine that predated the change — applying Kotest merely reshuffled spec order and detonated it. Fixed by save/restore in a `finally`, here and in `NativeServerBootTest`'s `LISTENUP_HOME` (which hadn't detonated yet but is read by the real boot path, and every further migration reshuffles order again).

## Guards

- **Discovered-count floor** on the native task, the counterpart of the one #1216 gave the JVM lanes. Control-probed by raising it to 200 and confirming the build genuinely fails.
- **`ProjectConfig` for linuxX64** — `failOnEmptyTestSuite`, `duplicateTestNameMode = Error`, and a timeout ceiling. Control-probed with a 1 ms timeout to prove native actually auto-discovers it rather than the file being decoration. Deliberately does not carry jvmTest's retry extension, which is JVM-only.

## Also

All 20 remaining `kotlin.test` files in `:server` migrated to FunSpec, and every stale comment asserting the old native-runner limitation corrected. One detekt baseline ID re-keyed: baseline IDs encode class nesting, and moving a helper to top level breaks the entry.

## Verification

- `:server:linuxX64Test` — 24 specs, 82 tests, 0 failures
- `:server:jvmTest` — 2,790 tests, 0 failures (unchanged; confirms the module-wide plugin didn't disturb the JVM lane)
- `spotlessCheck`, `detekt` — clean