### PR TITLE
🐛 fix(shared): make the auto-rewind setting actually rewind on resume

### DIFF
--- a/app/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.android.kt
+++ b/app/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.android.kt
@@ -49,6 +49,7 @@ val androidPlaybackModule: Module =
                 scope = get(),
                 bookSyncDomainHandler = get<SyncDomainHandler<BookSyncPayload>>(named(SyncDomains.BOOKS.name)),
                 playbackBandwidthCoordinator = get(),
+                localPreferences = get(),
                 // Android's Media3 `PlaybackService.PlayerListener` already persists
                 // book-relative transitions and records listening spans. Opt this class out
                 // of transition persistence so play/pause is not double-written to the outbox

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/AutoRewind.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/AutoRewind.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.playback
+
+private const val ONE_MINUTE_MS = 60_000L
+private const val ONE_HOUR_MS = 3_600_000L
+private const val ONE_DAY_MS = 86_400_000L
+
+private const val SHORT_BREAK_REWIND_MS = 5_000L
+private const val LONG_BREAK_REWIND_MS = 15_000L
+private const val OVERNIGHT_REWIND_MS = 30_000L
+
+/**
+ * How far to back up when resuming a book, given how long the listener was away.
+ *
+ * Coming back to a story mid-sentence is disorienting, and the longer you have been gone the more
+ * runway you need to pick the thread back up. The ladder mirrors that: a pause to answer the door
+ * costs nothing, a lunch break replays a few seconds, and returning the next day replays enough to
+ * re-establish the scene.
+ *
+ * The result is a playback *start offset*, never a new stored position — see the call site in
+ * [PlaybackPreparer]. Rewinding the persisted position would let repeated open/close cycles walk
+ * a listener backwards through a book they never un-listened to.
+ *
+ * @param elapsedAwayMs wall-clock milliseconds since the book was last played.
+ * @return milliseconds to subtract from the resume position; never negative.
+ */
+internal fun autoRewindMs(elapsedAwayMs: Long): Long =
+    when {
+        elapsedAwayMs < ONE_MINUTE_MS -> 0L
+        elapsedAwayMs < ONE_HOUR_MS -> SHORT_BREAK_REWIND_MS
+        elapsedAwayMs < ONE_DAY_MS -> LONG_BREAK_REWIND_MS
+        else -> OVERNIGHT_REWIND_MS
+    }

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.client.data.sync.SyncDomainHandler
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
 import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackPrepareRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -74,6 +75,7 @@ internal class PlaybackManagerImpl(
     private val scope: CoroutineScope,
     private val bookSyncDomainHandler: SyncDomainHandler<BookSyncPayload>,
     private val playbackBandwidthCoordinator: PlaybackBandwidthCoordinator,
+    private val localPreferences: LocalPreferences,
     /**
      * When true, this instance is the reporter-based persistence owner: [setPlaybackState]
      * routes Playing/Paused transitions through [reporter] (position + listening span), and
@@ -108,6 +110,7 @@ internal class PlaybackManagerImpl(
             channel = channel,
             scope = scope,
             bookSyncDomainHandler = bookSyncDomainHandler,
+            localPreferences = localPreferences,
         )
 
     override val currentBookId: StateFlow<BookId?>

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -24,11 +24,13 @@ import com.calypsan.listenup.client.domain.model.ContributorRole
 import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
 import com.calypsan.listenup.client.domain.playback.TimelineFileInput
 import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackPrepareRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.download.DownloadService
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Clock
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -117,6 +119,8 @@ class PlaybackPreparer internal constructor(
     private val channel: RpcChannel<BookService>,
     private val scope: CoroutineScope,
     private val bookSyncDomainHandler: SyncDomainHandler<BookSyncPayload>,
+    private val localPreferences: LocalPreferences,
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     /**
      * Prepare playback for [bookId].
@@ -232,13 +236,7 @@ class PlaybackPreparer internal constructor(
                 ?: if (timeline.isFullyDownloaded) fetchAuthoritativePosition(bookId) else null
         val resolved = resolveResumePosition(savedPosition, serverPosition)
 
-        val resumePositionMs =
-            if (resolved?.isFinished == true) {
-                logger.info { "Book is finished - starting from beginning for re-read" }
-                0L
-            } else {
-                resolved?.positionMs ?: 0L
-            }
+        val resumePositionMs = resumeStartPositionMs(resolved)
 
         val resumeSpeed =
             if (savedPosition != null && savedPosition.hasCustomSpeed) {
@@ -380,6 +378,36 @@ class PlaybackPreparer internal constructor(
                 null
             }
         }
+
+    /**
+     * The position playback should START at, given the reconciled [resolved] row.
+     *
+     * A finished book restarts at zero for a re-read. Otherwise the graduated [autoRewindMs] ladder
+     * backs the start up by however long the listener has been away, so returning to a book does
+     * not drop them mid-sentence.
+     *
+     * The rewind is a START OFFSET and never a write. The resolved row keeps the position the
+     * listener actually reached; only the value handed to the player moves. Persisting the rewound
+     * value would let repeated open/close cycles walk someone backwards through content they never
+     * un-listened to.
+     */
+    private fun resumeStartPositionMs(resolved: ResolvedResumePosition?): Long {
+        if (resolved == null) return 0L
+        if (resolved.isFinished) {
+            logger.info { "Book is finished - starting from beginning for re-read" }
+            return 0L
+        }
+        val rewindMs =
+            if (localPreferences.autoRewindEnabled.value) {
+                autoRewindMs(nowMillis() - resolved.lastPlayedAtMs)
+            } else {
+                0L
+            }
+        if (rewindMs > 0) {
+            logger.debug { "Auto-rewind: backing up ${rewindMs}ms from ${resolved.positionMs}" }
+        }
+        return (resolved.positionMs - rewindMs).coerceAtLeast(0L)
+    }
 
     /**
      * Build the [PlaybackTimeline]: resolve each file's local path, fetch signed
@@ -540,6 +568,12 @@ private data class TimelineBuildResult(
 internal data class ResolvedResumePosition(
     val positionMs: Long,
     val isFinished: Boolean,
+    /**
+     * When the WINNING side was last played. Carried out of the resolver rather than recomputed by
+     * callers: the resolver already picks by this key, so deriving it a second time at the call
+     * site would be a second copy of the conflict rule, free to drift from this one.
+     */
+    val lastPlayedAtMs: Long,
 )
 
 /**
@@ -563,11 +597,12 @@ internal fun resolveResumePosition(
 ): ResolvedResumePosition? =
     when {
         local == null && server == null -> null
-        server == null -> ResolvedResumePosition(local!!.positionMs, local.isFinished)
-        local == null -> ResolvedResumePosition(server.positionMs, server.finished)
+        server == null ->
+            ResolvedResumePosition(local!!.positionMs, local.isFinished, local.effectiveLastPlayedAtMs)
+        local == null -> ResolvedResumePosition(server.positionMs, server.finished, server.lastPlayedAt)
         server.lastPlayedAt > local.effectiveLastPlayedAtMs ->
-            ResolvedResumePosition(server.positionMs, server.finished)
-        else -> ResolvedResumePosition(local.positionMs, local.isFinished)
+            ResolvedResumePosition(server.positionMs, server.finished, server.lastPlayedAt)
+        else -> ResolvedResumePosition(local.positionMs, local.isFinished, local.effectiveLastPlayedAtMs)
     }
 
 // ========== Type Conversions ==========

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/AutoRewindTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/AutoRewindTest.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.client.playback
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The graduated auto-rewind ladder: how far playback backs up when you return to a book,
+ * as a function of how long you were away. Short breaks cost nothing; the longer the gap,
+ * the more re-orientation you need.
+ */
+class AutoRewindTest :
+    FunSpec({
+
+        test("a break under a minute rewinds nothing") {
+            autoRewindMs(0) shouldBe 0L
+            autoRewindMs(30_000) shouldBe 0L
+            autoRewindMs(59_999) shouldBe 0L
+        }
+
+        test("a break of minutes to an hour rewinds five seconds") {
+            autoRewindMs(60_000) shouldBe 5_000L
+            autoRewindMs(30 * 60_000L) shouldBe 5_000L
+            autoRewindMs(3_599_999) shouldBe 5_000L
+        }
+
+        test("a break of an hour to a day rewinds fifteen seconds") {
+            autoRewindMs(3_600_000) shouldBe 15_000L
+            autoRewindMs(12 * 3_600_000L) shouldBe 15_000L
+            autoRewindMs(86_399_999) shouldBe 15_000L
+        }
+
+        test("a break of a day or more rewinds the full thirty seconds") {
+            autoRewindMs(86_400_000) shouldBe 30_000L
+            autoRewindMs(30 * 86_400_000L) shouldBe 30_000L
+        }
+
+        test("a negative gap rewinds nothing rather than seeking forward") {
+            // Clock skew between devices can make lastPlayedAt sit in the future. Rewinding by a
+            // negative amount would jump the listener AHEAD of where they stopped — losing content
+            // is worse than replaying it, so the ladder floors at zero.
+            autoRewindMs(-1) shouldBe 0L
+            autoRewindMs(-86_400_000) shouldBe 0L
+        }
+    })

--- a/app/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/app/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -140,6 +140,7 @@ internal val iosPlaybackModule: Module =
                 channel = rpcChannel<BookService>(),
                 scope = get(qualifier = named(PLAYBACK_SCOPE)),
                 bookSyncDomainHandler = get<SyncDomainHandler<BookSyncPayload>>(named(SyncDomains.BOOKS.name)),
+                localPreferences = get(),
             )
         }
 

--- a/app/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.jvm.kt
+++ b/app/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.jvm.kt
@@ -48,6 +48,7 @@ val desktopPlaybackModule: Module =
                 scope = get(qualifier = named("playbackScope")),
                 bookSyncDomainHandler = get<SyncDomainHandler<BookSyncPayload>>(named(SyncDomains.BOOKS.name)),
                 playbackBandwidthCoordinator = get(),
+                localPreferences = get(),
             )
         }
     }

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
@@ -34,6 +35,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -73,6 +75,8 @@ class PlaybackManagerBufferingStateTest :
             val playbackPreferences: PlaybackPreferences = mock()
             everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
 
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(false)
             return PlaybackManagerImpl(
                 serverConfig = serverConfig,
                 playbackPreferences = playbackPreferences,
@@ -89,6 +93,7 @@ class PlaybackManagerBufferingStateTest :
                 channel = RpcChannel.forTest(mock<BookService>()),
                 scope = scope,
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                localPreferences = localPreferences,
                 playbackBandwidthCoordinator = bandwidthCoordinator,
             )
         }

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
@@ -12,8 +12,10 @@ import com.calypsan.listenup.client.data.remote.forTest
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
@@ -23,6 +25,7 @@ import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 
@@ -75,22 +78,27 @@ class PlaybackManagerFallbackFetchAtomicityTest :
             channel: RpcChannel<BookService>,
             handler: SyncDomainHandler<BookSyncPayload>,
         ): PlaybackPreparer =
-            PlaybackPreparer(
-                serverConfig = mock(),
-                playbackPreferences = mock(),
-                bookDao = db.bookDao(),
-                audioFileDao = db.audioFileDao(),
-                chapterDao = db.chapterDao(),
-                imageStorage = mock(),
-                progressTracker = buildProgressTracker(),
-                tokenProvider = mock(),
-                deviceContext = DeviceContext(type = DeviceType.Phone),
-                downloadService = mock(),
-                prepareRepository = testPlaybackPrepareRepository("af-1"),
-                channel = channel,
-                scope = CoroutineScope(Job()),
-                bookSyncDomainHandler = handler,
-            )
+            run {
+                val localPreferences: LocalPreferences = mock()
+                every { localPreferences.autoRewindEnabled } returns MutableStateFlow(false)
+                PlaybackPreparer(
+                    serverConfig = mock(),
+                    playbackPreferences = mock(),
+                    bookDao = db.bookDao(),
+                    audioFileDao = db.audioFileDao(),
+                    chapterDao = db.chapterDao(),
+                    imageStorage = mock(),
+                    progressTracker = buildProgressTracker(),
+                    tokenProvider = mock(),
+                    deviceContext = DeviceContext(type = DeviceType.Phone),
+                    downloadService = mock(),
+                    prepareRepository = testPlaybackPrepareRepository("af-1"),
+                    channel = channel,
+                    scope = CoroutineScope(Job()),
+                    bookSyncDomainHandler = handler,
+                    localPreferences = localPreferences,
+                )
+            }
 
         test("fetchBookFromServer delegates the write to bookSyncDomainHandler.onCatchUpItem") {
             val db = createInMemoryTestDatabase()

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -24,6 +24,7 @@ import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
@@ -36,6 +37,7 @@ import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 
@@ -147,6 +149,8 @@ class PlaybackManagerFallbackFetchTest :
                     imageStorage = stubImageStorage(),
                 ).toHandler(transactionRunner = RoomTransactionRunner(db), registry = ClientSyncDomainRegistry())
 
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(false)
             return PlaybackManagerImpl(
                 serverConfig = serverConfig,
                 playbackPreferences = playbackPreferences,
@@ -163,6 +167,7 @@ class PlaybackManagerFallbackFetchTest :
                 channel = channel,
                 scope = CoroutineScope(Job()),
                 bookSyncDomainHandler = bookSyncDomainHandler,
+                localPreferences = localPreferences,
                 playbackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
             )
         }

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPositionTransitionTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPositionTransitionTest.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
@@ -37,6 +38,7 @@ import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.TestScope
@@ -88,6 +90,8 @@ class PlaybackManagerPositionTransitionTest :
             everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
             everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
 
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(false)
             return PlaybackManagerImpl(
                 serverConfig = serverConfig,
                 playbackPreferences = defaultPlaybackPreferences(),
@@ -104,6 +108,7 @@ class PlaybackManagerPositionTransitionTest :
                 channel = RpcChannel.forTest(mock<BookService>()),
                 scope = scope,
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                localPreferences = localPreferences,
                 playbackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
                 persistTransitionsViaReporter = persistTransitionsViaReporter,
             )

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
@@ -33,6 +34,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 
@@ -103,6 +105,8 @@ class PlaybackManagerPrepareTest :
             // return null (no saved position), exercising the fresh-playback path.
             val progressTracker = buildProgressTracker()
 
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(false)
             return PlaybackManagerImpl(
                 serverConfig = serverConfig,
                 playbackPreferences = playbackPreferences,
@@ -119,6 +123,7 @@ class PlaybackManagerPrepareTest :
                 channel = RpcChannel.forTest(mock<BookService>()),
                 scope = CoroutineScope(Job()),
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                localPreferences = localPreferences,
                 playbackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
             )
         }

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -19,6 +19,7 @@ import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
@@ -89,6 +90,8 @@ class PlaybackManagerSpeedTest :
             everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
             everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
 
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(false)
             return PlaybackManagerImpl(
                 serverConfig = serverConfig,
                 playbackPreferences = playbackPreferences,
@@ -105,6 +108,7 @@ class PlaybackManagerSpeedTest :
                 channel = RpcChannel.forTest(mock<BookService>()),
                 scope = scope,
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                localPreferences = localPreferences,
                 playbackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
             )
         }

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparerTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparerTest.kt
@@ -23,6 +23,7 @@ import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
 import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackPrepareRepository
@@ -48,6 +49,7 @@ import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -132,11 +134,18 @@ class PlaybackPreparerTest :
 
         // ── fake factory builder ───────────────────────────────────────────────────────
 
+        // autoRewindEnabled defaults OFF so the resume-merge tests above assert the raw resolved
+        // position; the auto-rewind tests opt in explicitly. Production defaults it ON.
         fun buildPreparer(
             downloadService: DownloadService,
             prepareRepository: PlaybackPrepareRepository,
             progressTracker: ProgressTracker = buildProgressTracker(),
+            autoRewindEnabled: Boolean = false,
+            nowMillis: () -> Long = { 1_000_000_000_000L },
         ): PlaybackPreparer {
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(autoRewindEnabled)
+
             val tokenProvider: AudioTokenProvider = mock()
             everySuspend { tokenProvider.prepareForPlayback() } returns Unit
 
@@ -164,6 +173,8 @@ class PlaybackPreparerTest :
                 channel = RpcChannel.forTest(mock<BookService>()),
                 scope = CoroutineScope(Job()),
                 bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                localPreferences = localPreferences,
+                nowMillis = nowMillis,
             )
         }
 
@@ -319,6 +330,128 @@ class PlaybackPreparerTest :
 
                 result.shouldNotBeNull()
                 result.resumePositionMs shouldBe 0L
+            }
+        }
+
+        // ── auto-rewind on resume ──────────────────────────────────────────────────────
+
+        test("returning after a long gap rewinds the start position") {
+            runTest {
+                // Away for two days: the ladder's top rung replays 30s so the listener can
+                // re-establish the scene instead of landing mid-sentence.
+                val preparer =
+                    buildPreparer(
+                        downloadService = streamingDownloadService(),
+                        prepareRepository = preparedWith(resumePosition = null),
+                        progressTracker = trackerWithLocalPosition(localPosition(pos600, baseTime)),
+                        autoRewindEnabled = true,
+                        nowMillis = { baseTime + 2 * 86_400_000L },
+                    )
+
+                val result = preparer.prepare(bookId)
+
+                result.shouldNotBeNull()
+                result.resumePositionMs shouldBe pos600 - 30_000L
+            }
+        }
+
+        test("resuming immediately does not rewind") {
+            runTest {
+                val preparer =
+                    buildPreparer(
+                        downloadService = streamingDownloadService(),
+                        prepareRepository = preparedWith(resumePosition = null),
+                        progressTracker = trackerWithLocalPosition(localPosition(pos600, baseTime)),
+                        autoRewindEnabled = true,
+                        nowMillis = { baseTime + 5_000L },
+                    )
+
+                val result = preparer.prepare(bookId)
+
+                result.shouldNotBeNull()
+                result.resumePositionMs shouldBe pos600
+            }
+        }
+
+        test("auto-rewind disabled leaves the resume position untouched") {
+            runTest {
+                val preparer =
+                    buildPreparer(
+                        downloadService = streamingDownloadService(),
+                        prepareRepository = preparedWith(resumePosition = null),
+                        progressTracker = trackerWithLocalPosition(localPosition(pos600, baseTime)),
+                        autoRewindEnabled = false,
+                        nowMillis = { baseTime + 2 * 86_400_000L },
+                    )
+
+                val result = preparer.prepare(bookId)
+
+                result.shouldNotBeNull()
+                result.resumePositionMs shouldBe pos600
+            }
+        }
+
+        test("rewind near the start of a book clamps at zero rather than going negative") {
+            runTest {
+                val preparer =
+                    buildPreparer(
+                        downloadService = streamingDownloadService(),
+                        prepareRepository = preparedWith(resumePosition = null),
+                        progressTracker = trackerWithLocalPosition(localPosition(2_000L, baseTime)),
+                        autoRewindEnabled = true,
+                        nowMillis = { baseTime + 2 * 86_400_000L },
+                    )
+
+                val result = preparer.prepare(bookId)
+
+                result.shouldNotBeNull()
+                result.resumePositionMs shouldBe 0L
+            }
+        }
+
+        test("a finished book still restarts at zero and is not rewound below it") {
+            runTest {
+                // Finished wins the re-read branch (start at 0); auto-rewind must not turn that
+                // into a negative seek or reintroduce a position.
+                val preparer =
+                    buildPreparer(
+                        downloadService = streamingDownloadService(),
+                        prepareRepository = preparedWith(resumePosition = null),
+                        progressTracker =
+                            trackerWithLocalPosition(localPosition(pos600, baseTime, isFinished = true)),
+                        autoRewindEnabled = true,
+                        nowMillis = { baseTime + 2 * 86_400_000L },
+                    )
+
+                val result = preparer.prepare(bookId)
+
+                result.shouldNotBeNull()
+                result.resumePositionMs shouldBe 0L
+            }
+        }
+
+        test("the rewind is a start offset only — the stored position is never walked backwards") {
+            runTest {
+                // Repeated open/close must not creep. The preparer reports a rewound START, but the
+                // persisted row it read stays where the listener actually stopped, so preparing
+                // twice from the same row yields the same offset rather than compounding.
+                val tracker = trackerWithLocalPosition(localPosition(pos600, baseTime))
+                val preparer =
+                    buildPreparer(
+                        downloadService = streamingDownloadService(),
+                        prepareRepository = preparedWith(resumePosition = null),
+                        progressTracker = tracker,
+                        autoRewindEnabled = true,
+                        nowMillis = { baseTime + 2 * 86_400_000L },
+                    )
+
+                val first = preparer.prepare(bookId)
+                val second = preparer.prepare(bookId)
+
+                first.shouldNotBeNull()
+                second.shouldNotBeNull()
+                first.resumePositionMs shouldBe pos600 - 30_000L
+                second.resumePositionMs shouldBe pos600 - 30_000L
             }
         }
 


### PR DESCRIPTION
## The bug

`autoRewindEnabled` is persisted in `SettingsRepositoryImpl`, exposed through `SettingsViewModel`, and rendered as a toggle in **both** the Compose settings screen and the SwiftUI one.

Nothing read it. `PlaybackPreparer` — where the resume position is actually computed — had no settings dependency at all. The switch has been decorative since it shipped, which makes it a UI that lies.

## The behaviour

A graduated ladder keyed on how long you were away, rather than a flat offset — a pause to answer the door shouldn't cost anything, but returning the next day should replay enough to re-establish the scene:

| Time away | Rewind |
|---|---|
| under a minute | none |
| a minute to an hour | 5s |
| an hour to a day | 15s |
| a day or more | 30s |

The input was already there: `PlaybackPosition.effectiveLastPlayedAtMs` (with its legacy `updatedAt` fallback) is the same field the sync layer uses as its conflict key.

## Two design points worth review

**The rewind is a start offset, never a write.** The resolved row keeps the position the listener actually reached; only the value handed to the player moves. Had the rewound value been persisted, repeated open/close cycles would walk someone backwards through content they never un-listened to. There's a regression test for exactly that (`the rewind is a start offset only — the stored position is never walked backwards`).

**`ResolvedResumePosition` now carries `lastPlayedAtMs`.** The elapsed-away gap has to come from the *winning* side of the local-vs-server reconcile. The resolver already picks by that key, so deriving it again at the call site would have been a second copy of the conflict rule, free to drift from the first.

Negative gaps (clock skew across devices puts `lastPlayedAt` in the future) floor at zero — rewinding by a negative amount would seek the listener *ahead* of where they stopped, and losing content is worse than replaying it.

## Tests

TDD throughout; every test was watched failing first.

- `AutoRewindTest` — 5 tests covering each rung, the boundaries, and the negative-gap floor.
- `PlaybackPreparerTest` — 6 new tests: long gap rewinds, immediate resume doesn't, disabled leaves it untouched, clamps at zero near the start of a book, a finished book still restarts at zero, and the no-creep guard.

The fixture defaults the toggle **off** so the pre-existing resume-merge tests keep asserting the raw resolved position; the new tests opt in explicitly. Production defaults it on.

## Verification

`./gradlew verifyLocal :app:androidApp:assembleDebug` — BUILD SUCCESSFUL. sharedLogic 3,451 tests, contract 108, server 2,790, all 0 failures. Lint clean.

iOS DI (`PlaybackModule.ios.kt`) is wired too, but Apple targets can't build on Linux — relying on the macOS lane for that one.