### PR TITLE
🐛 fix(shared): stop iOS trapping on bridged enum collections in search and metadata

### DIFF
--- a/app/iosApp/ListenUp/Features/Metadata/MetadataMatchMapping.swift
+++ b/app/iosApp/ListenUp/Features/Metadata/MetadataMatchMapping.swift
@@ -51,15 +51,26 @@ enum MetadataMatchMapping {
         }
     }
 
+    /// Per-field provenance is resolved by a Kotlin accessor, never by subscripting the bridged
+    /// `Map<BookField, String>`: Swift Export force-casts the map's opaque Kotlin enum keys to this
+    /// *pure Swift* `BookField`, which has no Objective-C identity, so the cast traps as soon as the
+    /// match carries any fallback provenance. Passing a `BookField` *into* Kotlin as an argument is
+    /// the direction that bridges. Same trap that crashed search on `Set<SearchHitType>`; see
+    /// `NoBridgedEnumCollectionsInUiStateRule`.
     static func preview(from ready: PreviewLoadStateReady, match: MetadataBook) -> MetadataPreview {
+        preview(from: ready, match: match, sourceFor: { ready.fallbackSourceFor(field: $0) })
+    }
+
+    /// Provenance-injecting seam. Production passes the Kotlin accessor above; tests pass a native
+    /// closure, because a `[BookField: String]` built in Swift and handed to the Kotlin initializer
+    /// is not the map production sees — its keys are Swift-boxed, so a Kotlin-side lookup misses.
+    static func preview(
+        from ready: PreviewLoadStateReady,
+        match: MetadataBook,
+        sourceFor: (BookField) -> String?
+    ) -> MetadataPreview {
         let book = ready.preview
         let sel = ready.selections
-
-        // Read per-field provenance at the boundary. `fallbackSources` is a bridged Kotlin
-        // `Map<BookField, String>`; subscripting it here (not in a view/`ForEach`) is the same
-        // idiom as `BookEditObserver`'s per-role maps. Each closure call yields a native `String?`.
-        let fallback = ready.fallbackSources
-        let sourceFor: (BookField) -> String? = { fallback[$0] }
 
         let identity = identityFields(book: book, selections: sel, sourceFor: sourceFor)
         let details = detailFields(book: book, selections: sel, sourceFor: sourceFor)

--- a/app/iosApp/ListenUp/Features/Search/SearchModels.swift
+++ b/app/iosApp/ListenUp/Features/Search/SearchModels.swift
@@ -3,10 +3,10 @@ import Shared
 
 /// Single-select search scope, surfaced as `.searchScopes` segments above the results.
 ///
-/// The shared `SearchViewModel` models filters as an additive `Set<SearchHitType>`
-/// (multi-select). iOS's search UI is single-select, so a `SearchScope` is the iOS
-/// projection of that set: an empty set is "All", and exactly one type maps to that
-/// scope. Any unexpected multi-type set collapses to `.all` — the safe superset.
+/// The shared `SearchViewModel` models filters as a `Set<SearchHitType>` (Compose's chips
+/// are multi-select). iOS's search UI is single-select, so a `SearchScope` is the iOS
+/// projection of that set: no types is "All", and exactly one type maps to that scope.
+/// Any unexpected multi-type set collapses to `.all` — the safe superset.
 enum SearchScope: Hashable, CaseIterable {
     case all
     case books
@@ -25,24 +25,24 @@ enum SearchScope: Hashable, CaseIterable {
         }
     }
 
-    /// The set of types this scope represents in the shared VM (`.all` → empty set).
-    var selectedTypes: Set<SearchHitType> {
-        guard let hitType else { return [] }
-        return [hitType]
-    }
-
-    /// Project the VM's `selectedTypes` set onto a single-select scope. Empty → `.all`,
-    /// a single type → its scope, anything else → `.all` (the safe superset).
-    static func from(selectedTypes: Set<SearchHitType>) -> SearchScope {
-        guard selectedTypes.count == 1, let only = selectedTypes.first else { return .all }
+    /// Project the VM's `selectedTypeNames` onto a single-select scope. No types → `.all`,
+    /// exactly one → its scope, anything else → `.all` (the safe superset).
+    ///
+    /// **Why names and not the VM's `selectedTypes`:** Swift Export bridges the Kotlin
+    /// `Set<SearchHitType>` as an `NSSet` of opaque Kotlin enum-entry objects and force-casts each
+    /// element to this *pure Swift* enum, which has no Objective-C identity. The elements arrive as
+    /// `AnyHashable` and the cast traps as soon as the set is non-empty — "Could not cast value of
+    /// type 'Swift.AnyHashable' to …SearchHitType" — so every scope selection crashed the screen.
+    /// The shared VM projects the entry names instead, and Swift Export's generated
+    /// `SearchHitType(_ description:)` init parses exactly those. Passing a type back *into* Kotlin
+    /// (`setTypeFilter`) is the direction that bridges, so the write path needs no projection.
+    ///
+    /// An unrecognized name is dropped rather than trapped: a shared-enum case this build predates
+    /// narrows the filter, which is the same safe-superset stance taken on a multi-type set.
+    static func from(typeNames: [String]) -> SearchScope {
+        let types = typeNames.compactMap { SearchHitType($0) }
+        guard types.count == 1, let only = types.first else { return .all }
         return SearchScope.allCases.first { $0.hitType == only } ?? .all
-    }
-
-    /// The symmetric difference between the current VM types and this scope's target
-    /// types — i.e. exactly the `toggleTypeFilter(_:)` calls needed to move the VM
-    /// from `current` to this scope, since the VM exposes only an additive toggle.
-    func toggles(from current: Set<SearchHitType>) -> [SearchHitType] {
-        Array(current.symmetricDifference(selectedTypes))
     }
 }
 

--- a/app/iosApp/ListenUp/Features/Search/SearchObserver.swift
+++ b/app/iosApp/ListenUp/Features/Search/SearchObserver.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import Shared
 
 /// Observes `SearchViewModel` — flattens the sealed `SearchUiState` into flat
-/// `@Observable` properties and projects the additive `selectedTypes` filter onto a
-/// single-select `SearchScope`. Thin over `FlowBridge`, mirroring `LibraryObserver`.
+/// `@Observable` properties and projects the VM's type filter onto a single-select
+/// `SearchScope`. Thin over `FlowBridge`, mirroring `LibraryObserver`.
 @Observable
 @MainActor
 final class SearchObserver {
@@ -17,10 +17,6 @@ final class SearchObserver {
     /// One-shot navigation target produced by a tapped hit. The view consumes and
     /// clears it (`nil`) once the push is enqueued.
     var pendingNavigation: SearchRoute?
-
-    /// The VM's current filter set — the source of truth for translating a scope
-    /// selection into the right sequence of additive `toggleTypeFilter` calls.
-    private var selectedTypes: Set<SearchHitType> = []
 
     private let viewModel: SearchViewModel
     private let bridge = FlowBridge()
@@ -43,11 +39,15 @@ final class SearchObserver {
         viewModel.clearQuery()
     }
 
-    /// Move the VM's additive filter set to exactly this scope. The VM only exposes a
-    /// toggle, so we fire one toggle per differing type (the symmetric difference).
+    /// Move the VM's filter to exactly this scope — one call, no intermediate state.
+    ///
+    /// Passing a `SearchHitType` *into* Kotlin is the direction Swift Export bridges safely,
+    /// so the write path needs no name projection (unlike the read; see `SearchScope`).
     func selectScope(_ scope: SearchScope) {
-        for type in scope.toggles(from: selectedTypes) {
-            viewModel.toggleTypeFilter(type: type)
+        if let type = scope.hitType {
+            viewModel.setTypeFilter(type: type)
+        } else {
+            viewModel.clearTypeFilters()
         }
     }
 
@@ -62,8 +62,9 @@ final class SearchObserver {
 
     private func apply(_ state: SearchUiState) {
         query = state.query
-        selectedTypes = state.selectedTypes
-        selectedScope = SearchScope.from(selectedTypes: state.selectedTypes)
+        // Never read `state.selectedTypes`: the bridged Kotlin `Set<SearchHitType>` traps on
+        // element cast. See `SearchScope.from(typeNames:)`.
+        selectedScope = SearchScope.from(typeNames: state.selectedTypeNames)
 
         switch onEnum(of: state) {
         case .idle:

--- a/app/iosApp/ListenUpTests/MetadataMatchMappingTests.swift
+++ b/app/iosApp/ListenUpTests/MetadataMatchMappingTests.swift
@@ -149,12 +149,11 @@ struct MetadataMatchMappingTests {
             authors: [ref("Zogarth", asin: "AUTH1")],
             genres: ["Fantasy"]
         )
-        let state = ready(
-            book: book,
-            fallbackSources: [.description: "Audnexus", .authors: "iTunes", .genres: "Audnexus"],
-            contributingSources: ["Audible", "Audnexus", "iTunes"]
-        )
-        let preview = MetadataMatchMapping.preview(from: state, match: book)
+        let state = ready(book: book, contributingSources: ["Audible", "Audnexus", "iTunes"])
+        // Native provenance lookup, matching what the Kotlin `fallbackSourceFor` accessor returns in
+        // production. Reading the bridged `fallbackSources` map from Swift traps — see `ready(...)`.
+        let sources: [BookField: String] = [.description: "Audnexus", .authors: "iTunes", .genres: "Audnexus"]
+        let preview = MetadataMatchMapping.preview(from: state, match: book, sourceFor: { sources[$0] })
 
         // Per-field fallback labels flow to the matching row structs; unmapped fields stay nil.
         #expect(preview.identityFields.first { $0.field == .title }?.sourceLabel == nil)
@@ -266,10 +265,14 @@ struct MetadataMatchMappingTests {
         )
     }
 
+    /// Builds a Kotlin `Ready`. Deliberately takes **no** `fallbackSources`: a `[BookField: String]`
+    /// constructed in Swift and handed to the Kotlin initializer is not the map production sees —
+    /// Swift Export boxes the enum keys, so a Kotlin-side lookup misses them while a Swift-side
+    /// lookup succeeds. A fixture built that way passes for exactly the reason production crashes.
+    /// Provenance is injected natively instead; see `previewCarriesFieldSourceCoverAndContributingProvenance`.
     private func ready(
         book: MetadataBook,
         selections: MetadataSelections? = nil,
-        fallbackSources: [BookField: String] = [:],
         coverEntries: [CoverEntry] = [],
         coverSourceLabel: String? = nil,
         coverResolution: String? = nil,
@@ -287,7 +290,7 @@ struct MetadataMatchMappingTests {
             genreCandidates: book.genres,
             moodCandidates: book.moods,
             tagCandidates: book.tags,
-            fallbackSources: fallbackSources,
+            fallbackSources: [:],
             coverSourceLabel: coverSourceLabel,
             coverResolution: coverResolution,
             contributingSources: contributingSources

--- a/app/iosApp/ListenUpTests/SearchObserverTests.swift
+++ b/app/iosApp/ListenUpTests/SearchObserverTests.swift
@@ -3,7 +3,12 @@ import Shared
 @testable import ListenUp
 
 /// Pure-mapping coverage for the search observer's two seams: the single-select
-/// scope ↔ `Set<SearchHitType>` projection, and the de-duplicating hit grouping.
+/// scope ← `selectedTypeNames` projection, and the de-duplicating hit grouping.
+///
+/// The projection is name-based on purpose: reading the VM's `Set<SearchHitType>` across
+/// Swift Export traps on element cast. That trap is a *runtime bridge* failure, so nothing
+/// here can catch it — these tests pin the shape of the safe path, and the guarantee that
+/// the unsafe one stays unused lives in `NoBridgedEnumCollectionsInUiStateRule`.
 ///
 /// `SearchObserver.apply`'s flatten of the sealed `SearchUiState` (including the
 /// `.tooShort` phase added for the trigram-index minimum-query-length floor) can't be
@@ -13,51 +18,57 @@ import Shared
 /// green-build pass (the app target's exhaustive `switch` compiling). What *is* pure and
 /// constructible is the mirrored `minSearchQueryLength` floor, pinned below.
 struct SearchObserverTests {
-    // MARK: - Scope ↔ types projection
+    // MARK: - Name projection → scope (the bridge-safe read path)
 
-    @Test func emptyTypesMapToAll() {
-        #expect(SearchScope.from(selectedTypes: []) == .all)
+    /// The shared VM hands iOS `selectedTypeNames`, not `selectedTypes`: bridging the Kotlin
+    /// `Set<SearchHitType>` traps on element cast ("Could not cast value of type
+    /// 'Swift.AnyHashable' to …SearchHitType") the moment a scope is selected.
+    @Test func noTypesMapToAll() {
+        #expect(SearchScope.from(typeNames: []) == .all)
     }
 
-    @Test func singleTypeMapsToItsScope() {
-        #expect(SearchScope.from(selectedTypes: [.book]) == .books)
-        #expect(SearchScope.from(selectedTypes: [.contributor]) == .people)
-        #expect(SearchScope.from(selectedTypes: [.series]) == .series)
-        #expect(SearchScope.from(selectedTypes: [.tag]) == .tags)
+    @Test func singleTypeNameMapsToItsScope() {
+        #expect(SearchScope.from(typeNames: ["BOOK"]) == .books)
+        #expect(SearchScope.from(typeNames: ["CONTRIBUTOR"]) == .people)
+        #expect(SearchScope.from(typeNames: ["SERIES"]) == .series)
+        #expect(SearchScope.from(typeNames: ["TAG"]) == .tags)
     }
 
-    @Test func multipleTypesCollapseToAll() {
-        #expect(SearchScope.from(selectedTypes: [.book, .series]) == .all)
+    /// Compose's chips are multi-select, so the shared state can legitimately hold several
+    /// types that iOS's one-of-N control cannot express. `.all` is the safe superset.
+    @Test func multipleTypeNamesCollapseToAll() {
+        #expect(SearchScope.from(typeNames: ["BOOK", "SERIES"]) == .all)
+        #expect(SearchScope.from(typeNames: ["BOOK", "TAG"]) == .all)
     }
 
-    @Test func scopeRoundTripsThroughItsTypes() {
+    /// Every scope survives the write→read round trip: `hitType` is what iOS sends to
+    /// `setTypeFilter`, and its name is what comes back in `selectedTypeNames`.
+    @Test func everyScopeRoundTripsThroughTheSharedProjection() {
         for scope in SearchScope.allCases {
-            #expect(SearchScope.from(selectedTypes: scope.selectedTypes) == scope)
+            let names = scope.hitType.map { [$0.description] } ?? []
+            #expect(SearchScope.from(typeNames: names) == scope)
         }
     }
 
-    @Test func allScopeHasNoFilterTypes() {
-        #expect(SearchScope.all.selectedTypes.isEmpty)
-        #expect(SearchScope.books.selectedTypes == [.book])
+    /// Pins the exact strings the shared `selectedTypeNames` projection emits (Kotlin's
+    /// `SearchHitType.entries.map { it.name }`) against Swift Export's generated
+    /// `LosslessStringConvertible` round-trip. A rename on either side breaks this, not the app.
+    @Test func everyHitTypeRoundTripsThroughItsName() {
+        for type in SearchHitType.allCases {
+            #expect(SearchHitType(type.description) == type)
+        }
+        #expect(SearchHitType.book.description == "BOOK")
+        #expect(SearchHitType.contributor.description == "CONTRIBUTOR")
+        #expect(SearchHitType.series.description == "SERIES")
+        #expect(SearchHitType.tag.description == "TAG")
     }
 
-    // MARK: - Toggle deltas (the VM exposes only an additive toggle)
-
-    @Test func selectingBooksFromAllTogglesBookOn() {
-        #expect(SearchScope.books.toggles(from: []) == [.book])
-    }
-
-    @Test func returningToAllTogglesTheActiveTypeOff() {
-        #expect(SearchScope.all.toggles(from: [.book]) == [.book])
-    }
-
-    @Test func switchingScopesTogglesBothTypes() {
-        let toggles = Set(SearchScope.series.toggles(from: [.book]))
-        #expect(toggles == [.book, .series])
-    }
-
-    @Test func reselectingTheSameScopeIsANoOp() {
-        #expect(SearchScope.books.toggles(from: [.book]).isEmpty)
+    /// An unknown name is dropped rather than trapping — a shared enum can gain a case that
+    /// this build predates. Matching is exact, so casing is not a near-miss.
+    @Test func unknownNamesAreDropped() {
+        #expect(SearchScope.from(typeNames: ["BOOK", "PODCAST"]) == .books)
+        #expect(SearchScope.from(typeNames: ["book"]) == .all)
+        #expect(SearchScope.from(typeNames: ["PODCAST"]) == .all)
     }
 
     // MARK: - Grouping (over native SearchRow)

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
@@ -221,7 +221,23 @@ sealed interface PreviewLoadState {
         val coverSourceLabel: String? = null,
         val coverResolution: String? = null,
         val contributingSources: List<String> = emptyList(),
-    ) : PreviewLoadState
+    ) : PreviewLoadState {
+        /**
+         * Bridge-safe per-field provenance lookup: the [fallbackSources] subscript happens HERE, in
+         * Kotlin, so Swift only ever passes a [BookField] as a function argument.
+         *
+         * Swift Export bridges the `Map<BookField, String>` as an `NSDictionary` whose keys are
+         * opaque Kotlin enum-entry objects, then force-casts them to the Swift `BookField` — a *pure
+         * Swift* enum with no Objective-C identity. Reading the map from Swift traps as soon as it
+         * has an entry, i.e. exactly when a match carries fallback provenance. Passing an enum
+         * *into* Kotlin is the direction that bridges, so this accessor is safe where the subscript
+         * is not. Same idiom as `BookEditUiState.searchResultsForRole`.
+         *
+         * Compose subscripts [fallbackSources] directly — enum-keyed maps are only hazardous across
+         * the Swift Export boundary.
+         */
+        fun fallbackSourceFor(field: BookField): String? = fallbackSources[field]
+    }
 
     /** Preview fetch failed; [message] is shown in-line. */
     data class Failed(

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModel.kt
@@ -39,6 +39,26 @@ sealed interface SearchUiState {
     val query: String
     val selectedTypes: Set<SearchHitType>
 
+    /**
+     * iOS-safe projection of [selectedTypes] as [SearchHitType] entry names, in declaration order.
+     *
+     * Swift Export bridges a `Set<SearchHitType>` as an `NSSet` of opaque Kotlin enum-entry objects
+     * and force-casts each element to the Swift `SearchHitType` — a *pure Swift* enum with no
+     * Objective-C identity. The elements arrive as `AnyHashable` and the cast traps the instant the
+     * set is non-empty ("Could not cast value of type 'Swift.AnyHashable' to …SearchHitType"), which
+     * crashed the search screen on every scope selection. Reading [selectedTypes] from Swift is a
+     * bug; read this instead and rebuild the enum locally with Swift Export's generated
+     * `SearchHitType(_ description:)` init, which parses exactly these names. Passing a
+     * [SearchHitType] back *into* Kotlin as a function argument ([SearchViewModel.toggleTypeFilter])
+     * is the direction that bridges safely and needs no projection.
+     *
+     * Declaration order (not set-iteration order) so the derived iOS scope can't flicker.
+     * Compose reads [selectedTypes] directly — enum collections are only hazardous across the
+     * Swift Export boundary.
+     */
+    val selectedTypeNames: List<String>
+        get() = SearchHitType.entries.filter { it in selectedTypes }.map { it.name }
+
     /** No query entered. */
     data class Idle(
         override val query: String = "",
@@ -197,10 +217,24 @@ class SearchViewModel(
         queryFlow.value = ""
     }
 
+    /** Add or remove [type] from the filter set — the additive shape Compose's chips use. */
     fun toggleTypeFilter(type: SearchHitType) {
         typesFlow.update { current ->
             if (type in current) current - type else current + type
         }
+    }
+
+    /**
+     * Narrow the filter to exactly [type], discarding whatever was selected before.
+     *
+     * The single-select counterpart to [toggleTypeFilter], for UIs whose scope control is
+     * one-of-N rather than a set of chips (iOS's `.searchScopes`). Expressing that as a
+     * sequence of additive toggles meant switching Books → Series published an intermediate
+     * `{BOOK, SERIES}` state, which the search pipeline could pick up and run a query for a
+     * pair the user never asked for. Replacing the set outright cannot produce that state.
+     */
+    fun setTypeFilter(type: SearchHitType) {
+        typesFlow.value = setOf(type)
     }
 
     /** Reset all type filters, returning the overlay to its "All" (unfiltered) scope. */

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
@@ -1071,4 +1071,43 @@ class MetadataViewModelTest :
                 ready.contributingSources shouldBe listOf("Audible", "Audnexus", "iTunes")
             }
         }
+
+        test("fallbackSourceFor resolves per-field provenance for the bridged iOS read path") {
+            runTest {
+                val book =
+                    makeBook(asin = "B001", title = "Dune").copy(
+                        matchProvenance =
+                            MatchProvenance(
+                                contributingSources = listOf("Audible", "Audnexus"),
+                                fallbackFields =
+                                    mapOf(
+                                        BookField.DESCRIPTION to "Audnexus",
+                                        BookField.AUTHORS to "iTunes",
+                                    ),
+                                coverSource = null,
+                                coverWidth = null,
+                                coverHeight = null,
+                            ),
+                    )
+                val repo = mock<MetadataRepository>()
+                everySuspend { repo.searchBooks(any(), any(), any()) } returns AppResult.Success(MetadataSearchResults(listOf(book)))
+                everySuspend { repo.getBookMetadata(any(), any()) } returns AppResult.Success(book)
+                everySuspend { repo.getBookChapters(any(), any()) } returns AppResult.Success(MetadataChapters(emptyList()))
+                val vm = buildVm(repo)
+                vm.initForBook("b1", "Dune", "Frank Herbert")
+                vm.search()
+                advanceUntilIdle()
+                vm.selectMatch(book)
+                advanceUntilIdle()
+
+                val ready = (vm.state.value as MetadataUiState.Preview).loadState as PreviewLoadState.Ready
+
+                // The subscript must happen HERE, in Kotlin. iOS cannot subscript the bridged
+                // `Map<BookField, String>` — Swift Export force-casts the opaque Kotlin enum keys and
+                // traps. This is the accessor `MetadataMatchMapping` calls per field instead.
+                ready.fallbackSourceFor(BookField.DESCRIPTION) shouldBe "Audnexus"
+                ready.fallbackSourceFor(BookField.AUTHORS) shouldBe "iTunes"
+                ready.fallbackSourceFor(BookField.TITLE) shouldBe null
+            }
+        }
     })

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModelTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModelTest.kt
@@ -13,6 +13,7 @@ import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import dev.mokkery.verify.VerifyMode.Companion.not
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
@@ -350,6 +351,53 @@ class SearchViewModelTest :
             }
         }
 
+        test("selectedTypeNames projects the selected types as their enum names") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+                viewModel.state.value.selectedTypeNames
+                    .shouldBeEmpty()
+
+                viewModel.toggleTypeFilter(SearchHitType.SERIES)
+                advanceUntilIdle()
+
+                viewModel.state.value.selectedTypeNames shouldBe listOf("SERIES")
+            }
+        }
+
+        test("selectedTypeNames follows declaration order, not insertion order") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+
+                // Toggled tag-first; the projection must still read in SearchHitType.entries order so
+                // iOS's scope derivation can't flicker on set-iteration order.
+                viewModel.toggleTypeFilter(SearchHitType.TAG)
+                viewModel.toggleTypeFilter(SearchHitType.BOOK)
+                advanceUntilIdle()
+
+                viewModel.state.value.selectedTypeNames shouldBe listOf("BOOK", "TAG")
+            }
+        }
+
+        test("every SearchHitType survives the selectedTypeNames projection") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                SearchHitType.entries.forEach { viewModel.toggleTypeFilter(it) }
+                advanceUntilIdle()
+
+                // Pins the exact strings iOS parses back through Swift Export's generated
+                // `SearchHitType(_ description:)` init — a rename on either side must fail here.
+                viewModel.state.value.selectedTypeNames shouldBe
+                    listOf("BOOK", "CONTRIBUTOR", "SERIES", "TAG")
+            }
+        }
+
         test("toggleTypeFilter triggers re-search immediately when query present") {
             runTest {
                 val fixture = createFixture()
@@ -368,6 +416,62 @@ class SearchViewModelTest :
                     fixture.searchRepository.search(
                         query = "test",
                         types = listOf(SearchHitType.BOOK),
+                        genres = null,
+                        genrePath = null,
+                        limit = 30,
+                    )
+                }
+            }
+        }
+
+        test("setTypeFilter replaces the filter set rather than adding to it") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                viewModel.toggleTypeFilter(SearchHitType.BOOK)
+                viewModel.toggleTypeFilter(SearchHitType.TAG)
+                advanceUntilIdle()
+                viewModel.state.value.selectedTypes shouldBe setOf(SearchHitType.BOOK, SearchHitType.TAG)
+
+                viewModel.setTypeFilter(SearchHitType.SERIES)
+                advanceUntilIdle()
+
+                viewModel.state.value.selectedTypes shouldBe setOf(SearchHitType.SERIES)
+            }
+        }
+
+        test("setTypeFilter switches scope without searching the intermediate type pair") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns createSearchResult()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+
+                viewModel.onQueryChanged("test")
+                advanceTimeBy(400.milliseconds)
+                viewModel.setTypeFilter(SearchHitType.BOOK)
+                advanceUntilIdle()
+
+                viewModel.setTypeFilter(SearchHitType.SERIES)
+                advanceUntilIdle()
+
+                verifySuspend {
+                    fixture.searchRepository.search(
+                        query = "test",
+                        types = listOf(SearchHitType.SERIES),
+                        genres = null,
+                        genrePath = null,
+                        limit = 30,
+                    )
+                }
+                // iOS used to switch scopes by firing the symmetric difference as additive toggles
+                // (BOOK off, SERIES on), so the VM briefly held both and could issue a search for a
+                // pair the user never selected. One replacing call cannot produce that state.
+                verifySuspend(not) {
+                    fixture.searchRepository.search(
+                        query = "test",
+                        types = listOf(SearchHitType.BOOK, SearchHitType.SERIES),
                         genres = null,
                         genrePath = null,
                         limit = 30,

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoBridgedEnumCollectionsInUiStateRule.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoBridgedEnumCollectionsInUiStateRule.kt
@@ -16,9 +16,17 @@ import io.kotest.matchers.collections.shouldBeEmpty
  * Could not cast value of type 'KotlinRuntimeSupport._KotlinExistential<…>' to '…ContributorRole'
  * ```
  *
+ * ```
+ * Could not cast value of type 'Swift.AnyHashable' to '…SearchHitType'
+ * ```
+ *
+ * (Both messages have been observed in the wild — the first on a `List<ContributorRole>`, the second
+ * on a `Set<SearchHitType>`. The boxing differs, the trap does not.)
+ *
  * This has bitten the book-edit `ContributorRole` surface **twice** — first as map keys (#1198), then
- * as `List<ContributorRole>` elements — and there is a latent third instance in search
- * (`selectedTypes: Set<SearchHitType>`, materialized by the iOS `SearchObserver`).
+ * as `List<ContributorRole>` elements — then shipped as two live crashes: the metadata match preview
+ * (`fallbackSources`, subscripted per field) and the search screen (`selectedTypes`, materialized on
+ * every scope selection). All four are now behind String projections / argument-taking accessors.
  *
  * A `presentation` UI-state type is read by BOTH Compose (which subscripts/iterates enum collections
  * natively — no problem) AND by iOS via Swift Export (which traps). So any PUBLIC enum-typed
@@ -26,10 +34,11 @@ import io.kotest.matchers.collections.shouldBeEmpty
  * `apiValue`-`String` projection for iOS** (see `BookEditUiState.orderedVisibleRoleApiValues`) and
  * keep the enum handling in Kotlin; iOS reconstructs a Swift enum locally to pass back as an argument.
  *
- * Existing occurrences are allow-listed ([ALLOWED_ENUM_COLLECTION_MEMBERS]): the book-edit members
- * already have String projections that iOS reads. Per [NoThrowsInDataLayerRule]'s philosophy, the
- * allowlist keeps them visible while the rule fails the build on any NEW enum collection added to the
- * bridged surface. Removing a name is the signal its iOS-safe projection has shipped.
+ * Existing occurrences are allow-listed ([ALLOWED_ENUM_COLLECTION_MEMBERS]) — every one of them is
+ * there because Compose reads the enum collection natively and should keep doing so. Per
+ * [NoThrowsInDataLayerRule]'s philosophy, the allowlist keeps them visible while the rule fails the
+ * build on any NEW enum collection added to the bridged surface. The status recorded against each
+ * name — whether iOS has a safe projection yet — is the part that matters; see the companion.
  */
 class NoBridgedEnumCollectionsInUiStateRule :
     FunSpec({
@@ -75,20 +84,30 @@ class NoBridgedEnumCollectionsInUiStateRule :
          * Enum-typed collections/maps already on the bridged presentation surface, with their audit
          * status. This rule went in AFTER these existed, so the allowlist records the debt (per
          * [NoThrowsInDataLayerRule]'s philosophy) rather than forcing one giant PR; the rule still
-         * fails on any NEW enum collection. Removing a name is the signal its iOS-safe projection
-         * shipped.
+         * fails on any NEW enum collection. A name stays listed for as long as Compose needs the
+         * enum collection — what changes is whether iOS has a safe way to read the same data.
          *
          * **HANDLED** — iOS reads a String projection / argument-taking accessor, never the enum
-         * collection: the book-edit `ContributorRole` surface (`orderedVisibleRoleApiValues` +
-         * `…ForRole(role)` accessors).
-         *
-         * **LATENT — iOS materializes the enum, must migrate to an accessor/projection:**
-         * - `fallbackSources` (`Map<BookField, String>`): iOS `MetadataMatchMapping` subscripts it by
-         *   the `BookField` key (`fallback[field]`) — the #1198 map-key trap, live. Highest priority.
-         * - `selectedTypes` (`Set<SearchHitType>`): iOS `SearchObserver` iterates / `symmetricDifference`s it.
+         * collection itself:
+         * - The book-edit `ContributorRole` surface: `orderedVisibleRoleApiValues` +
+         *   `…ForRole(role)` accessors.
+         * - `fallbackSources` (`Map<BookField, String>`): iOS calls
+         *   `PreviewLoadState.Ready.fallbackSourceFor(field)`, so the map subscript happens in
+         *   Kotlin. Was the #1198 map-key trap, live in `MetadataMatchMapping` until it crashed the
+         *   match preview for any book carrying fallback provenance.
+         * - `selectedTypes` (`Set<SearchHitType>`): iOS reads `SearchUiState.selectedTypeNames` and
+         *   rebuilds the Swift enum locally. Was live in `SearchObserver` until it crashed the
+         *   search screen on every scope selection ("Could not cast value of type
+         *   'Swift.AnyHashable' to …SearchHitType" — the `Set` variant of the same trap, where the
+         *   elements arrive boxed because `Set` demands `Hashable`).
          *
          * **LATENT — not currently read by iOS (Android-only sort), but a landmine for any future
          * iOS use:** `booksCategories` / `seriesCategories` / `contributorCategories` (`List<SortCategory>`).
+         *
+         * Note what a green suite does *not* prove: these traps are runtime bridge failures, so a
+         * Swift unit test can only catch one if its fixture crosses the boundary the way production
+         * does. `MetadataMatchMappingTests` built its `[BookField: String]` in Swift — Swift-boxed
+         * keys cast back cleanly — and so stayed green for the entire life of the live crash.
          */
         val ALLOWED_ENUM_COLLECTION_MEMBERS =
             setOf(
@@ -100,7 +119,7 @@ class NoBridgedEnumCollectionsInUiStateRule :
                 "visibleRoles",
                 "availableRolesToAdd",
                 "orderedVisibleRoles",
-                // LATENT (iOS materializes): migrate to an accessor/projection
+                // HANDLED: iOS reads fallbackSourceFor(field) / selectedTypeNames instead
                 "fallbackSources",
                 "selectedTypes",
                 // LATENT (Android-only today): guard against future iOS materialization


### PR DESCRIPTION
Fixes the reported search crash, plus a second live instance of the same bug found while tracing it.

```
Could not cast value of type 'Swift.AnyHashable' to
'(extension in Shared):…client.domain.model.SearchHitType'
```

## Root cause

Swift Export bridges a Kotlin enum **collection** as an `NSSet`/`NSDictionary` of opaque Kotlin
enum-entry objects, then force-casts the elements to the Swift enum — which is a *pure Swift* value
type with no Objective-C identity. The cast traps. From the generated bridge:

```swift
// Shared.swift — before
public var selectedTypes: Swift.Set<…SearchHitType> {
    get { return com_…_selectedTypes_get(…) as! Swift.Set<…SearchHitType> }   // ← traps
}
```

An empty collection has no elements to cast, which is exactly why the "All" scope worked and every
other scope selection died on the next state emission.

`NoBridgedEnumCollectionsInUiStateRule` had already predicted this and allow-listed it as
**LATENT — iOS materializes the enum**. Both listed latent sites turned out to be live:

| Site | Surface | Trigger |
|---|---|---|
| `SearchUiState.selectedTypes` (`Set<SearchHitType>`) | Search | any scope selection |
| `PreviewLoadState.Ready.fallbackSources` (`Map<BookField, String>`) | Metadata match preview | any match carrying fallback provenance |

## Fix

The pattern already established by `BookEditUiState.orderedVisibleRoleApiValues`: enum handling stays
in Kotlin, iOS gets a `String` projection or an argument-taking accessor. Passing an enum *into*
Kotlin bridges natively, so the write path needed no projection.

- **`SearchUiState.selectedTypeNames: List<String>`** — generated getter is now
  `as! Swift.Array<Swift.String>`. Swift rebuilds the enum via Swift Export's generated
  `SearchHitType("BOOK")` init; the source patcher deliberately preserves those literals, so no
  hand-written mapping table is needed.
- **`PreviewLoadState.Ready.fallbackSourceFor(field)`** — generated call passes
  `field.__externalRCRef()` into Kotlin; the map subscript happens in Kotlin.

Compose is untouched — it reads the enum collections natively, which was never the problem.

## Also in here: the scope switch no longer publishes an intermediate state

iOS's single-select `.searchScopes` was driving the VM's additive `toggleTypeFilter` via a symmetric
difference, so switching Books → Series fired two toggles and the VM briefly held `{BOOK, SERIES}` —
reachable by the search pipeline. `SearchViewModel.setTypeFilter(type)` replaces the set in one call.
`toggleTypeFilter` / `clearTypeFilters` are unchanged for Compose's multi-select chips.

That deletes the machinery that existed only to compute the toggle sequence: `SearchScope` is now
two symmetric members — `hitType` (write) and `from(typeNames:)` (read) — and `SearchObserver`'s
private `selectedTypes` mirror is gone.

## A note on why the test suite was green through a live crash

`MetadataMatchMappingTests` built its `[BookField: String]` fixture **in Swift**. Swift-boxed enum
keys cast back cleanly, so that test passed for precisely the reason production failed — production
builds the map in Kotlin, where the keys are real Kotlin enum entries with no Swift identity.

These traps are runtime bridge failures: **a Swift unit test can only catch one if its fixture
crosses the boundary the way production does.** So the fixture helper no longer accepts
`fallbackSources` at all (it can't be rebuilt that way), provenance coverage moved to an injected
native closure plus a Kotlin test that builds a real `Ready`, and the reasoning is recorded in the
Konsist rule so a green suite isn't mistaken for evidence here again.

Verification for these fixes is structural: the regenerated
`SPMPackage/<target>/Debug/Sources/Shared/Shared.swift` shows both trapping casts replaced.

## Tests

- Kotlin: `selectedTypeNames` projection (declaration order, exact strings, full enum coverage);
  `setTypeFilter` replaces rather than adds, and `verifySuspend(not)` pins that the intermediate
  `[BOOK, SERIES]` search never issues; `fallbackSourceFor` on a real Kotlin `Ready`.
- Swift: name → scope projection, unknown-name tolerance, and a round-trip pin
  (`SearchHitType(type.description) == type`) so a rename on either side fails here rather than in
  the app.

`SearchObserverTests` goes 22 → 19 `@Test`: 4 toggle-delta tests removed with the code they covered,
5 set-based scope tests replaced by 6 name-based ones.

## Gates

`spotlessCheck` + `detekt` ✅ · full JVM test stage ✅ · `Test (iOS)` ✅ 533 tests / 0 failures.

Two pre-existing local failures are **not** from this branch and are left alone:
`MulticastMdnsResponderTest` (2/2783, multicast receive on the dev Mac — confirmed identical on a
clean tree) and `verifyLicenses` (regenerates `*-macos-arm64` over the committed Linux entries when
run on macOS).