### PR TITLE
✨ feat(shared): collapse one sitting with a book into one activity-feed entry

### DIFF
--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModel.kt
@@ -43,7 +43,11 @@ class ActivityFeedViewModel internal constructor(
         activityRepository
             .observeRecent(limit = MAX_ACTIVITIES)
             .map<_, ActivityFeedUiState> { activities ->
-                ActivityFeedUiState.Ready(activities = activities.map { it.toUiModel() })
+                // One sitting reads as one line: the server records an activity per closed playback
+                // span, so an interrupted evening otherwise arrives as a wall of entries.
+                ActivityFeedUiState.Ready(
+                    activities = activities.map { it.toUiModel() }.coalesceListeningSessions(),
+                )
             }.onStart { emit(ActivityFeedUiState.Loading) }
             .fallbackTo { e ->
                 logger.error(e) { "Error observing activity feed" }

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/CoalesceListeningSessions.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/CoalesceListeningSessions.kt
@@ -1,0 +1,62 @@
+package com.calypsan.listenup.client.presentation.discover
+
+import com.calypsan.listenup.api.dto.activity.ActivityType
+
+/**
+ * Longest idle stretch that still counts as the same sitting. Pausing to make coffee, take a call,
+ * or walk between rooms does not end your evening with a book — but picking it up again after lunch
+ * is a genuinely separate act worth its own line in the feed.
+ */
+private const val SAME_SITTING_GAP_MS = 60 * 60_000L
+
+/**
+ * Collapse consecutive listening sessions on the same book into one entry per sitting.
+ *
+ * The server records one activity per closed playback span, so a single evening with a book —
+ * paused for the kettle, resumed, paused again — arrives as a wall of entries, several of them
+ * seconds long. That is noise on the feed, which is the app's social surface: the interesting fact
+ * is "Simon listened to Dungeon Crawler Carl for an hour", not the shape of his interruptions.
+ *
+ * Merging happens at READ time, deliberately. The `activities` table is append-only by design
+ * (`ActivitySyncRepository` advances only revision/updatedAt on re-upsert, never domain fields), and
+ * every viewer's client runs this over whatever it displays — so the feed reads correctly for other
+ * people's sessions too, without mutating a log or touching the sync contract.
+ *
+ * Only *adjacent* rows merge, so any other activity between two sittings (finishing the book,
+ * a milestone) separates them. Input is expected most-recent-first, matching the feed's
+ * `occurred_at DESC` ordering; the surviving entry keeps the newest [ActivityUiModel.occurredAt] so
+ * it still sorts as recent, and carries the summed duration.
+ *
+ * One consequence worth knowing: merging is per-page, so a sitting split across a pagination
+ * boundary stays split. That is a cosmetic edge, not a correctness one — and it beats mutating
+ * durable rows to fix it.
+ */
+internal fun List<ActivityUiModel>.coalesceListeningSessions(): List<ActivityUiModel> =
+    fold(mutableListOf()) { merged: MutableList<ActivityUiModel>, activity ->
+        val previous = merged.lastOrNull()
+        if (previous != null && previous.continuesInto(activity)) {
+            // `activity` is the OLDER half of the sitting; keep the newer entry's identity and
+            // timestamp, and extend it backwards by the older span's duration.
+            merged[merged.lastIndex] = previous.copy(durationMs = previous.durationMs + activity.durationMs)
+        } else {
+            merged.add(activity)
+        }
+        merged
+    }
+
+/**
+ * True when [older] is the same sitting as this (newer) entry: both are listening sessions on the
+ * same book by the same person, with only a short idle stretch between them.
+ *
+ * The gap measured is END-of-older to START-of-newer. The newer entry's `occurredAt` is when its
+ * span *finished*, so its start is `occurredAt - durationMs`; comparing the raw timestamps instead
+ * would count the newer span's own length as idle time and wrongly split long sessions.
+ */
+private fun ActivityUiModel.continuesInto(older: ActivityUiModel): Boolean {
+    if (type != ActivityType.LISTENING_SESSION || older.type != ActivityType.LISTENING_SESSION) return false
+    if (bookId == null || bookId != older.bookId) return false
+    if (userId != older.userId) return false
+    val newerSpanStart = occurredAt - durationMs
+    val idleMs = newerSpanStart - older.occurredAt
+    return idleMs in 0..SAME_SITTING_GAP_MS
+}

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModelTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModelTest.kt
@@ -142,6 +142,30 @@ class ActivityFeedViewModelTest :
             }
         }
 
+        test("consecutive listening sessions on one book surface as a single feed entry") {
+            runTest {
+                // One sitting, interrupted: 10 minutes ending at T, preceded by 30s just before it.
+                // The feed should read as a single 10:30 entry, not two lines.
+                val fixture = createFixture()
+                val book = Activity.ActivityBook("book-1", "Dungeon Crawler Carl", "Matt Dinniman", null)
+                val tenMinutes = 600_000L
+                fixture.activitiesFlow.value =
+                    listOf(
+                        createActivity(id = "newer", type = "listening_session")
+                            .copy(occurredAtMs = 3_000_000L, durationMs = tenMinutes, book = book),
+                        createActivity(id = "older", type = "listening_session")
+                            .copy(occurredAtMs = 3_000_000L - tenMinutes, durationMs = 30_000L, book = book),
+                    )
+
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<ActivityFeedUiState.Ready>()
+                ready.activities.size shouldBe 1
+                ready.activities.first().durationMs shouldBe tenMinutes + 30_000L
+            }
+        }
+
         test("Ready state has isEmpty true when activities list is empty") {
             runTest {
                 // Given - repository emits an empty list (default fixture state)

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/CoalesceListeningSessionsTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/CoalesceListeningSessionsTest.kt
@@ -1,0 +1,139 @@
+package com.calypsan.listenup.client.presentation.discover
+
+import com.calypsan.listenup.api.dto.activity.ActivityType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+private const val MINUTE = 60_000L
+
+private fun session(
+    id: String,
+    occurredAt: Long,
+    durationMs: Long,
+    bookId: String? = "book-1",
+    userId: String = "user-1",
+): ActivityUiModel =
+    ActivityUiModel(
+        id = id,
+        userId = userId,
+        type = ActivityType.LISTENING_SESSION,
+        occurredAt = occurredAt,
+        userDisplayName = "Simon",
+        bookId = bookId,
+        bookTitle = "Dungeon Crawler Carl",
+        bookAuthorName = "Matt Dinniman",
+        bookCoverPath = null,
+        isReread = false,
+        durationMs = durationMs,
+        milestoneValue = 0,
+        milestoneUnit = null,
+        shelfId = null,
+        shelfName = null,
+    )
+
+/**
+ * One sitting with a book should read as one line in the feed. The raw rows are one-per-span, so a
+ * pause to make coffee otherwise fragments a single evening into a wall of entries.
+ *
+ * The list arrives most-recent-first, matching the feed's `occurred_at DESC` ordering.
+ */
+class CoalesceListeningSessionsTest :
+    FunSpec({
+
+        test("two sessions in the same sitting merge into one, summing their durations") {
+            // 30s at T-11min, then 10min ending at T. Reads as a single 10:30 sitting.
+            val tenMinutesAgo = 100 * MINUTE
+            val feed =
+                listOf(
+                    session("newer", occurredAt = tenMinutesAgo + 10 * MINUTE, durationMs = 10 * MINUTE),
+                    session("older", occurredAt = tenMinutesAgo - 30_000L + 30_000L, durationMs = 30_000L),
+                )
+
+            val merged = feed.coalesceListeningSessions()
+
+            merged shouldHaveSize 1
+            merged[0].durationMs shouldBe 10 * MINUTE + 30_000L
+            // The surviving entry is stamped with the END of the sitting, so it sorts as recent.
+            merged[0].occurredAt shouldBe tenMinutesAgo + 10 * MINUTE
+        }
+
+        test("sessions separated by more than the gap stay separate") {
+            val feed =
+                listOf(
+                    session("newer", occurredAt = 500 * MINUTE, durationMs = 5 * MINUTE),
+                    session("older", occurredAt = 100 * MINUTE, durationMs = 5 * MINUTE),
+                )
+
+            val merged = feed.coalesceListeningSessions()
+
+            merged shouldHaveSize 2
+        }
+
+        test("sessions for different books never merge") {
+            val feed =
+                listOf(
+                    session("a", occurredAt = 100 * MINUTE, durationMs = MINUTE, bookId = "book-1"),
+                    session("b", occurredAt = 99 * MINUTE, durationMs = MINUTE, bookId = "book-2"),
+                )
+
+            feed.coalesceListeningSessions() shouldHaveSize 2
+        }
+
+        test("sessions from different users never merge") {
+            val feed =
+                listOf(
+                    session("a", occurredAt = 100 * MINUTE, durationMs = MINUTE, userId = "user-1"),
+                    session("b", occurredAt = 99 * MINUTE, durationMs = MINUTE, userId = "user-2"),
+                )
+
+            feed.coalesceListeningSessions() shouldHaveSize 2
+        }
+
+        test("a run of three consecutive sessions collapses to one") {
+            val feed =
+                listOf(
+                    session("c", occurredAt = 102 * MINUTE, durationMs = MINUTE),
+                    session("b", occurredAt = 101 * MINUTE, durationMs = MINUTE),
+                    session("a", occurredAt = 100 * MINUTE, durationMs = MINUTE),
+                )
+
+            val merged = feed.coalesceListeningSessions()
+
+            merged shouldHaveSize 1
+            merged[0].durationMs shouldBe 3 * MINUTE
+            merged[0].occurredAt shouldBe 102 * MINUTE
+        }
+
+        test("non-listening activities pass through untouched and do not join a run") {
+            val finished =
+                session("finished", occurredAt = 101 * MINUTE, durationMs = 0L)
+                    .copy(type = ActivityType.FINISHED_BOOK)
+            val feed =
+                listOf(
+                    session("newer", occurredAt = 102 * MINUTE, durationMs = MINUTE),
+                    finished,
+                    session("older", occurredAt = 100 * MINUTE, durationMs = MINUTE),
+                )
+
+            val merged = feed.coalesceListeningSessions()
+
+            // The finished-book entry separates the two sittings; nothing merges across it.
+            merged shouldHaveSize 3
+            merged[1].type shouldBe ActivityType.FINISHED_BOOK
+        }
+
+        test("a listening session with no book is left alone") {
+            val feed =
+                listOf(
+                    session("a", occurredAt = 100 * MINUTE, durationMs = MINUTE, bookId = null),
+                    session("b", occurredAt = 99 * MINUTE, durationMs = MINUTE, bookId = null),
+                )
+
+            feed.coalesceListeningSessions() shouldHaveSize 2
+        }
+
+        test("an empty feed stays empty") {
+            emptyList<ActivityUiModel>().coalesceListeningSessions() shouldBe emptyList()
+        }
+    })


### PR DESCRIPTION
## The problem

The server records one `LISTENING_SESSION` activity per closed playback span. An evening with a book — paused for the kettle, resumed, paused again — arrives as a wall of feed entries, several of them seconds long.

That's noise on the app's social surface. The interesting fact is "Simon listened to Dungeon Crawler Carl for an hour", not the shape of his interruptions.

## The fix

Consecutive listening sessions on the same book by the same person collapse into one entry, summing their durations, when only a short idle stretch separates them. The "same sitting" gap is **60 minutes** — a pause for coffee or a phone call keeps it merged, picking the book up after lunch starts a new entry. One named constant, easy to tune.

Only *adjacent* rows merge, so any other activity between two sittings — finishing the book, a milestone — separates them.

## Why read-time, and why in the shared ViewModel

I started down the write-time path (coalesce in `StatsRecorder` before insert) and abandoned it on discovering that `ActivitySyncRepository` is **deliberately append-only**: `writePayload` advances only `revision`/`updatedAt`/`clientOpId` on re-upsert and never mutates domain fields. Extending a previous row would have meant breaking a documented sync invariant — not something to do days before a release.

Read-time is the better trade here anyway:

- `ActivityFeedViewModel` lives in `sharedLogic/presentation/` and is consumed by **both** the Compose feed and iOS (via `KoinHelper.getActivityFeedViewModel()`). One implementation, both platforms.
- Every viewer's client runs it over whatever it displays, so *other people's* sessions read correctly too — the thing that would otherwise argue for fixing it at the source.
- Zero server, sync, or migration risk. Fully reversible.

## Known consequence

Merging is per-page, so a sitting split across a pagination boundary stays split. Cosmetic, and it beats mutating durable rows to fix it. Documented in the KDoc.

## Subtlety worth reviewing

The gap measured is **end-of-older to start-of-newer**. The newer entry's `occurredAt` is when its span *finished*, so its start is `occurredAt - durationMs`. Comparing raw timestamps instead would count the newer span's own length as idle time and wrongly split long sessions — a 90-minute listen following a short one would never merge.

## Tests

TDD; every test watched failing first.

- `CoalesceListeningSessionsTest` — 8 tests: merging, the gap boundary, different books, different users, a three-session run, non-listening activities separating a run, null-book sessions, empty feed.
- `ActivityFeedViewModelTest` — one new wiring test proving the feed itself emits a single merged entry (it failed with `expected:<1> but was:<2>` before the wiring).

## Verification

`./gradlew verifyLocal` — BUILD SUCCESSFUL. sharedLogic 3,466 tests, 0 failures. Lint clean.