### PR TITLE
🍱 chore(iosApp): declare export-compliance exemption so TestFlight builds don't stall

### DIFF
--- a/app/iosApp/ListenUp/Info.plist
+++ b/app/iosApp/ListenUp/Info.plist
@@ -4,6 +4,15 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<!-- Export compliance, declared once here so it is not asked per-build. ListenUp ships no
+	     cryptography of its own: the client speaks HTTPS over the platform networking stack and
+	     stores its tokens via the platform keychain, and the Argon2id password hashing lives
+	     server-side, never in the app. That is exactly the standard-encryption exemption, so every
+	     TestFlight and App Store build can answer "no non-exempt encryption" up front. Without this
+	     key each upload processes and then stalls awaiting a manual answer before it can reach a
+	     tester. Revisit if the app ever bundles its own crypto. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>ListenUp needs local network access to discover your audiobook server.</string>
 	<key>NSBonjourServices</key>


### PR DESCRIPTION
## Why

`Info.plist` carries no `ITSAppUsesNonExemptEncryption`. Without it, every upload processes and then **sits waiting for a manual export-compliance answer** before it can be distributed to a single tester. It's asked per-build until the key exists.

This is a first-submission trap and we're about to make our first iOS submission, so it would have blocked the very first TestFlight distribution.

## Why `false` is the right answer

ListenUp ships no cryptography of its own. I checked: no `cryptography-core` in the client, no CryptoKit, no CommonCrypto, no bundled crypto library anywhere in `:app:sharedLogic` or `iosApp`. The client speaks HTTPS over the platform networking stack and stores tokens via the platform keychain; the Argon2id password hashing lives server-side and never ships in the app.

That's precisely the standard-encryption exemption — using HTTPS and OS-provided crypto does not make an app subject to non-exempt encryption rules.

The rationale is recorded as a comment next to the key, including the condition that would invalidate it (bundling our own crypto), so the next person doesn't have to re-derive it or flip it blindly.

## Verified

`plistlib` round-trips the file: 8 keys, all pre-existing ones intact, new key reads `False`.

## Not in scope

`PrivacyInfo.xcprivacy` is still absent. It isn't a TestFlight blocker so it doesn't affect this release, but Apple requires privacy manifests at App Store submission and the app almost certainly touches required-reason APIs (`UserDefaults` at minimum). Worth doing before going past TestFlight.