### PR TITLE
🐛 fix(server): restore FTS5 in the image SQLite — the baseline migration needs it

### DIFF
--- a/server/Dockerfile.native
+++ b/server/Dockerfile.native
@@ -11,9 +11,17 @@
 #
 # Version floor: our own SQL needs **3.35** (`ALTER TABLE ... DROP COLUMN`, in
 # V53__drop_blurhash_columns.sql). We pin far above that because the base ships nothing, so the
-# version is ours to choose and a pinned modern one beats an accidental old one. FTS5 is no longer
-# compiled in: the server's four FTS indexes and its search surface were removed (V55), leaving zero
-# FTS5 usage. Re-adding any FTS5 table means re-adding -DSQLITE_ENABLE_FTS5 here.
+# version is ours to choose and a pinned modern one beats an accidental old one.
+#
+# FTS5 IS REQUIRED, and the reason is easy to get wrong. The running server issues zero FTS5
+# queries — the four search indexes and the whole server-side search surface were removed — and the
+# linked binary exports zero fts5 symbols. Both facts are true and both are irrelevant: the SQLite
+# that has to understand `USING fts5` is THIS shared library, at migration time, and
+# `V1__baseline.sql` still creates four fts5 virtual tables because the squashed baseline
+# reproduces the historical schema. Dropping the flag on the strength of "no FTS5 usage" produced
+# an image that died on first boot with `no such module: fts5` — a release-blocking break that CI
+# could not see, because CI never builds this image and the tests run against the host's SQLite.
+# The verify step below turns that into a build failure instead of a runtime one.
 FROM debian:12-slim AS libs
 ARG SQLITE_AMALGAMATION_URL=https://www.sqlite.org/2024/sqlite-amalgamation-3450000.zip
 RUN apt-get update \
@@ -24,9 +32,28 @@ WORKDIR /build
 RUN curl -fsSL -o amalg.zip "$SQLITE_AMALGAMATION_URL" \
     && unzip -q amalg.zip \
     && cd sqlite-amalgamation-* \
-    && gcc -O2 -fPIC -shared -o /build/libsqlite3.so.0 sqlite3.c \
+    && gcc -O2 -fPIC -shared -DSQLITE_ENABLE_FTS5 -o /build/libsqlite3.so.0 sqlite3.c -lm \
+    && cp sqlite3.h /build/ \
     && cat sqlite3.h | grep -m1 '#define SQLITE_VERSION ' \
     && awk '/#define SQLITE_VERSION_NUMBER/ { if ($3 < 3035000) { print "SQLite too old: " $3; exit 1 } }' sqlite3.h
+
+# Prove the fts5 module is actually loadable rather than trusting the compile flag: link a throwaway
+# client against the .so we just built and have it run the exact statement V1__baseline.sql runs.
+# A missing module now fails the BUILD, loudly, instead of the server's first boot.
+RUN printf '%s\n' \
+        '#include <sqlite3.h>' \
+        '#include <stdio.h>' \
+        'int main(void){' \
+        '  sqlite3 *db; char *err = 0;' \
+        '  if (sqlite3_open(":memory:", &db) != SQLITE_OK) { fprintf(stderr, "open failed\n"); return 1; }' \
+        '  if (sqlite3_exec(db, "CREATE VIRTUAL TABLE t USING fts5(x);", 0, 0, &err) != SQLITE_OK) {' \
+        '    fprintf(stderr, "FTS5 MISSING: %s\n", err ? err : "(no message)"); return 1;' \
+        '  }' \
+        '  printf("fts5 module present\n"); return 0;' \
+        '}' > /build/fts5check.c \
+    && gcc -O2 -o /build/fts5check /build/fts5check.c -I/build /build/libsqlite3.so.0 -lm \
+    && /build/fts5check \
+    && rm -f /build/fts5check /build/fts5check.c /build/sqlite3.h
 # An empty /data to seed the runtime image's data dir — the distroless base has no shell, so the dir is
 # created here and COPY --chown'd into the final stage below.
 RUN mkdir -p /data


### PR DESCRIPTION
## Release blocker: the server image cannot boot

Dry-running the release path end-to-end — link the release binary, build the image, run it — the container **dies on first boot**:

```
Caused by: kotlin.IllegalStateException: Migration V1 (baseline) failed
Caused by: kotlin.IllegalStateException: sqlite exec failed: no such module: fts5
                                          :: -- V1__baseline.sql
```

Koin then fails the whole graph (`ContributorRepository` → `ListenUpDatabase` → `SqlDriver` → `DatabaseHandle`) and Ktor never starts. The image would have been built, tagged, and **pushed to GHCR** as `latest` before anyone found out.

## Cause — mine, from #1214

I removed `-DSQLITE_ENABLE_FTS5` from the builder stage on the strength of two checks that were both *true* and both *irrelevant*:

- the running server issues zero FTS5 queries (its four search indexes and the whole server-side search surface are gone), and
- `nm -D` on the linked binary showed zero fts5 symbols.

Neither is the thing that matters. The SQLite that has to understand `USING fts5` is the **shared library, at migration time** — and `V1__baseline.sql` still creates four fts5 virtual tables, because the squashed baseline reproduces the historical schema byte-for-byte. I verified the wrong artifact and wrote a confident comment on top of it.

## Why nothing caught it

- CI **never links the release binary** — `linkReleaseExecutableLinuxX64` appears only in `release.yml`. CI builds `compileKotlinLinuxX64` and runs the tests.
- CI **never builds this image**.
- The native tests run against the **host's** SQLite (Arch/Debian, FTS5 enabled), so `NativeServerBootTest` boots the full module happily and proves nothing about the shipped image.

This is the first release to ship this image at all — the previous server was Go — so the path had never executed anywhere.

## The fix

Restore the flag, and add a **functional guard** rather than trusting it: the builder now links a throwaway client against the `.so` it just produced and runs the exact statement the baseline runs.

```
#11 0.193 fts5 module present
```

A missing module now fails the **build**, loudly, instead of a user's first boot. Trusting the compile flag is what got us here; this checks the artifact.

Also linked `-lm` into the library itself. FTS5's BM25 ranking references `log`, which left an undefined symbol in the `.so` — it happened to resolve only because the host binary pulls in libm. That's a latent trap, so the library is now self-contained.

The comment block is rewritten to explain *why* the flag is required and exactly which reasoning is seductive and wrong, so this isn't re-derived and re-removed.

## Verified end to end, locally

- `:server:linkReleaseExecutableLinuxX64` → 25 MB stripped `server.kexe` ✅ (first time ever built)
- `docker build -f server/Dockerfile.native` → SQLite 3.45.0, `fts5 module present` ✅
- `docker run` → migrations apply, Koin graph builds, `GET /healthz` → **HTTP 200 `{"status":"ok"}`**, mDNS advertises ✅

Before this change the same three steps produced a container that exited on boot.

## Worth doing separately

CI should build this image on PRs that touch `server/Dockerfile.native` or the migrations, and boot it against `/healthz`. The whole class of bug here is "the release path is the only thing that exercises the release path."